### PR TITLE
Semantic tests for Wasm code generated with `wasm-smith`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1103,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1463,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flagset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
 
 [[package]]
 name = "flurry"
@@ -2709,6 +2735,7 @@ name = "miden-integration-tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "blake3",
  "cargo-util",
  "cargo_metadata",
@@ -2735,6 +2762,7 @@ dependencies = [
  "rustc-demangle",
  "sha2",
  "walkdir",
+ "wasm-smith",
  "wasmprinter",
 ]
 
@@ -5295,6 +5323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.211.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7d931a1120ef357f32b74547646b6fa68ea25e377772b72874b131a9ed70d4"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5308,6 +5345,20 @@ dependencies = [
  "spdx",
  "wasm-encoder 0.39.0",
  "wasmparser 0.119.0",
+]
+
+[[package]]
+name = "wasm-smith"
+version = "0.211.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ae0d1bd7d17e7ae175f9e3cf646d9b39b7115240ed8d40141c4670bab49f96"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "flagset",
+ "indexmap 2.1.0",
+ "leb128",
+ "wasm-encoder 0.211.1",
 ]
 
 [[package]]

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -36,6 +36,8 @@ filetime = "0.2.23"
 glob = "0.3.1"
 walkdir = "2.5.0"
 proptest.workspace = true
+wasm-smith = "0.211"
+arbitrary = "1.3"
 
 [dev-dependencies]
 miden-core.workspace = true

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -15,3 +15,6 @@ pub use exec_vm::execute_vm;
 
 #[cfg(test)]
 mod rust_masm_tests;
+
+#[cfg(test)]
+mod wasm_smith_tests;

--- a/tests/integration/src/wasm_smith_tests/mod.rs
+++ b/tests/integration/src/wasm_smith_tests/mod.rs
@@ -1,0 +1,59 @@
+use arbitrary::Unstructured;
+use prop::collection::vec;
+use proptest::{prelude::*, test_runner::TestRunner};
+use wasm_smith::{Config, InstructionKind, InstructionKinds};
+
+use crate::{compiler_test::wasm_to_wat, CompilerTest};
+
+fn wasm_smith_default_config() -> Config {
+    Config {
+        allow_start_export: false,
+        allowed_instructions: InstructionKinds::new(&[InstructionKind::Control]),
+        bulk_memory_enabled: false,
+        exceptions_enabled: false,
+        gc_enabled: false,
+        max_aliases: 0,
+        max_data_segments: 0,
+        max_element_segments: 0,
+        max_elements: 0,
+        max_exports: 0,
+        max_funcs: 1,
+        max_imports: 0,
+        max_table_elements: 0,
+        max_tables: 0,
+        max_tags: 0,
+        memory64_enabled: false,
+        min_funcs: 1,
+        multi_value_enabled: false,
+        reference_types_enabled: false,
+        relaxed_simd_enabled: false,
+        saturating_float_to_int_enabled: false,
+        sign_extension_ops_enabled: false,
+        simd_enabled: false,
+        tail_call_enabled: false,
+        ..Config::default()
+    }
+}
+
+#[test]
+fn simple_ctrl() {
+    TestRunner::default()
+        .run(&vec(0..=255u8, 100), move |bytes| {
+            let config = wasm_smith_default_config();
+            let mut wasm_module =
+                wasm_smith::Module::new(config, &mut Unstructured::new(&bytes)).unwrap();
+            wasm_module.ensure_termination(100).unwrap();
+            let wasm_module_bytes = wasm_module.to_bytes();
+            let wat = wasm_to_wat(&wasm_module_bytes);
+            eprintln!("wat:\n{}", wat);
+            let mut test = CompilerTest::wasm_module(wasm_module_bytes);
+            let vm_program = &test.masm_program();
+            eprintln!("vm_program: {}", vm_program);
+            // let rust_out = miden_integration_tests_rust_fib::fib(a);
+            // let args = [Felt::from(a)];
+            // let vm_out: u32 = (*execute_vm(vm_program, &args).first().unwrap()).into();
+            // prop_assert_eq!(rust_out, vm_out);
+            Ok(())
+        })
+        .unwrap();
+}


### PR DESCRIPTION
Ref #214 

Plan:
- Generate a one-function module with `wasm-smith`;
- Compile it to MASM;
- Execute them Wasmtime vs. Miden VM and check the runtime state (stack, memory);