### PR TITLE
fix: note script compilation

### DIFF
--- a/codegen/masm/intrinsics/mem.masm
+++ b/codegen/masm/intrinsics/mem.masm
@@ -385,7 +385,7 @@ export.store_sw # [addr, offset, value]
         mem_store     # []
     else
         # convert offset to bits
-        swap.1 push.8 u32wrapping_mul swap.1   # [addr, bit_offset]
+        swap.1 push.8 u32wrapping_mul swap.1   # [addr, bit_offset, value]
 
         # the store is across an element boundary
         #
@@ -403,6 +403,8 @@ export.store_sw # [addr, offset, value]
         # manipulate the bits of the two target elements, such that the 32-bit word we're storing
         # is placed at the correct offset from the start of the memory cell when viewing the cell
         # as a set of 4 32-bit chunks
+        #
+        # First, mask out the bits we're going to overwrite in the two elements we loaded
         movup.4 u32and         # [e1_masked, mask_hi, rshift, e0, addr, bit_offset, value]
         movup.3 movup.2 u32and # [e0_masked, e1_masked, rshift, addr, bit_offset, value]
 
@@ -410,14 +412,15 @@ export.store_sw # [addr, offset, value]
         # combine them with the preserved bits of the original contents of the cell
         #
         # first, the contents of e0
-        dup.7 movup.7    # [bit_offset, value, e0_masked, e1_masked, rshift, addr, value]
-        u32shr           # [value >> bit_offset, e0_masked, e1_masked, rshift, addr, value]
+        dup.5 movup.5    # [bit_offset, value, e0_masked, e1_masked, rshift, addr, value]
+        u32shl           # [value << bit_offset, e0_masked, e1_masked, rshift, addr, value]
         u32or            # [e0', e1_masked, rshift, addr, value]
+
         # then the contents of w1
         swap.1           # [e1_masked, e0', rshift, addr, value]
         movup.4          # [value, e1_masked, e0', rshift, addr]
         movup.3          # [rshift, value, e1_masked, e0', addr]
-        u32shl           # [value << rshift, e1_masked, e0', addr]
+        u32shr           # [value >> rshift, e1_masked, e0', addr]
         u32or            # [e1', e0', addr]
 
         # finally, write back the updated elements

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -202,12 +202,14 @@ impl MasmComponent {
 
         // Assemble library
         let mut modules: Vec<Arc<masm::Module>> = self.modules.clone();
-        // Sort modules to ensure intrinsics are first since the target compiled module imports them
-        modules.sort_by_key(|m| {
-            let name = m.path().path().into_owned();
-            let is_intrinsic = crate::intrinsics::INTRINSICS_MODULE_NAMES.contains(&name.as_str());
-            (!is_intrinsic, name)
-        });
+
+        // We need to add modules according to their dependencies (add the dependency before the dependent)
+        // Workaround until https://github.com/0xPolygonMiden/miden-vm/issues/1669 is implemented
+        modules.reverse();
+
+        log::debug!(target: "assembly", "start adding the following modules with assembler: {}",
+            modules.iter().map(|m| m.path().to_string()).collect::<Vec<_>>().join(", "));
+
         for module in modules.iter().cloned() {
             if lib_modules.contains(module.path()) {
                 log::warn!(

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -120,6 +120,7 @@ pub fn register_dialect_hooks(context: &midenc_hir::Context) {
         info.register_operation_trait::<hir::Bitcast, dyn HirLowering>();
         //info.register_operation_trait::<hir::ConstantBytes, dyn HirLowering>();
         info.register_operation_trait::<hir::Exec, dyn HirLowering>();
+        info.register_operation_trait::<hir::Call, dyn HirLowering>();
         info.register_operation_trait::<hir::Store, dyn HirLowering>();
         info.register_operation_trait::<hir::StoreLocal, dyn HirLowering>();
         info.register_operation_trait::<hir::Load, dyn HirLowering>();

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -1,7 +1,9 @@
 use alloc::{collections::BTreeSet, sync::Arc};
 
+use miden_assembly::LibraryPath;
 use midenc_hir::{
-    dialects::builtin, pass::AnalysisManager, FunctionIdent, Op, SourceSpan, Span, Symbol, ValueRef,
+    diagnostics::IntoDiagnostic, dialects::builtin, pass::AnalysisManager, FunctionIdent, Op,
+    SourceSpan, Span, Symbol, ValueRef,
 };
 use midenc_hir_analysis::analyses::LivenessAnalysis;
 use midenc_session::diagnostics::{Report, Spanned};
@@ -43,7 +45,7 @@ impl ToMasmComponent for builtin::Component {
                 let name = masm::ProcedureName::from_raw_parts(masm::Ident::from_raw_parts(
                     Span::new(entry_id.function.span, entry_id.function.as_str().into()),
                 ));
-                let path = component_path.clone().append_unchecked(entry_id.module);
+                let path = LibraryPath::new(entry_id.module).into_diagnostic()?;
                 Some(masm::InvocationTarget::AbsoluteProcedurePath { name, path })
             }
             None => None,

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -46,11 +46,16 @@ impl ToMasmComponent for builtin::Component {
                     Span::new(entry_id.function.span, entry_id.function.as_str().into()),
                 ));
 
-                let path = if component_path.to_string() == "root_ns:root@1.0.0" {
-                    // We're inside the synthethic "wrapping" component for pure Rust program
-                    // compilation. Since the user does not know about it their entrypoint does not
-                    // include the synthetic component id. Append the user-provided entrypoint
-                    // module
+                // Check if we're inside the synthetic "wrapper" component used for pure Rust
+                // compilation. Since the user does not know about it, their entrypoint does not
+                // include the synthetic component path. We append the user-provided path to the
+                // root component path here if needed.
+                //
+                // TODO(pauls): Narrow this to only be true if the target env is not 'rollup', we
+                // cannot currently do so because we do not have sufficient Cargo metadata yet in
+                // 'cargo miden build' to detect the target env, and we default it to 'rollup'
+                let is_wrapper = component_path.path() == "root_ns:root@1.0.0";
+                let path = if is_wrapper {
                     component_path.clone().append_unchecked(entry_id.module)
                 } else {
                     // We're compiling a Wasm component and the component id is included

--- a/frontend/wasm/src/component/translator.rs
+++ b/frontend/wasm/src/component/translator.rs
@@ -397,9 +397,10 @@ impl<'a> ComponentTranslator<'a> {
                     }
 
                     let module_path = SymbolPath {
-                        path: smallvec![SymbolNameComponent::Component(Symbol::intern(
-                            *arg_module_name
-                        ))],
+                        path: smallvec![
+                            SymbolNameComponent::Root,
+                            SymbolNameComponent::Component(Symbol::intern(*arg_module_name))
+                        ],
                     };
                     let arg_module = &frame.module_instances[*module_arg.1];
                     match arg_module {

--- a/frontend/wasm/src/module/module_translation_state.rs
+++ b/frontend/wasm/src/module/module_translation_state.rs
@@ -125,7 +125,7 @@ fn process_import(
             };
             let module_arg = module_args
                 .get(&import_path)
-                .unwrap_or_else(|| panic!("unexpected import '{import_path}'"));
+                .unwrap_or_else(|| panic!("unexpected import '{import_path:?}'"));
             process_module_arg(
                 module_builder,
                 world_builder,

--- a/midenc-session/src/lib.rs
+++ b/midenc-session/src/lib.rs
@@ -428,7 +428,7 @@ impl Session {
 }
 
 /// This enum describes the different target environments targetable by the compiler
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(ValueEnum))]
 pub enum TargetEnv {
     /// The emulator environment, which has a more restrictive instruction set

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.masm
@@ -102,15 +102,14 @@ proc.__rustc::__rust_realloc
                 swap.1
                 u32divmod.4
                 swap.1
-                dup.2
-                dup.2
-                dup.2
+                dup.1
+                dup.1
                 exec.::intrinsics::mem::load_sw
                 push.4294967040
                 u32and
-                movup.5
+                movup.3
                 u32or
-                movdn.4
+                movdn.2
                 exec.::intrinsics::mem::store_sw
                 u32wrapping_add.1
                 dup.0
@@ -225,15 +224,14 @@ proc.wit_bindgen_rt::run_ctors_once
         u32assert
         u32divmod.4
         swap.1
-        dup.2
-        dup.2
-        dup.2
+        dup.1
+        dup.1
         exec.::intrinsics::mem::load_sw
         push.4294967040
         u32and
-        movup.5
+        movup.3
         u32or
-        movdn.4
+        movdn.2
         exec.::intrinsics::mem::store_sw
     end
 end

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.hir
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.hir
@@ -1,242 +1,319 @@
 builtin.component miden:base/note-script@1.0.0 {
     builtin.module public @cross_ctx_note {
-        public builtin.function @cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1(v0: felt) -> felt {
+        private builtin.function @cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1(v0: felt) -> felt {
         ^block3(v0: felt):
-            v1 = hir.call v0 : felt #[callee = miden:cross-ctx-account/foo@1.0.0/process-felt] #[signature = (param felt) (result felt)];
+            v1 = hir.call v0 : felt #[callee = miden:cross-ctx-account/foo@1.0.0@1.0.0/process-felt] #[signature = (param felt) (result felt)];
             builtin.ret v1;
         };
 
-        public builtin.function @__wasm_call_ctors() {
-        ^block8:
+        private builtin.function @__wasm_call_ctors() {
+        ^block9:
             builtin.ret ;
         };
 
-        public builtin.function @cross_ctx_note::bindings::__link_custom_section_describing_imports() {
-        ^block10:
+        private builtin.function @cross_ctx_note::bindings::__link_custom_section_describing_imports() {
+        ^block11:
             builtin.ret ;
         };
 
-        public builtin.function @__rust_alloc(v2: i32, v3: i32) -> i32 {
-        ^block12(v2: i32, v3: i32):
+        private builtin.function @__rustc::__rust_alloc(v2: i32, v3: i32) -> i32 {
+        ^block13(v2: i32, v3: i32):
             v5 = arith.constant 1048616 : i32;
             v6 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v5, v3, v2) : i32
             builtin.ret v6;
         };
 
-        public builtin.function @__rust_realloc(v7: i32, v8: i32, v9: i32, v10: i32) -> i32 {
-        ^block14(v7: i32, v8: i32, v9: i32, v10: i32):
+        private builtin.function @__rustc::__rust_realloc(v7: i32, v8: i32, v9: i32, v10: i32) -> i32 {
+        ^block15(v7: i32, v8: i32, v9: i32, v10: i32):
             v12 = arith.constant 1048616 : i32;
             v13 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v12, v9, v10) : i32
-            v192 = arith.constant 0 : i32;
+            v200 = arith.constant 0 : i32;
             v14 = arith.constant 0 : i32;
             v15 = arith.eq v13, v14 : i1;
             v16 = arith.zext v15 : u32;
             v17 = hir.bitcast v16 : i32;
-            v19 = arith.neq v17, v192 : i1;
-            v191 = scf.if v19 : i32 {
-            ^block16:
-                scf.yield v13;
-            } else {
+            v19 = arith.neq v17, v200 : i1;
+            v195 = scf.if v19 : i32 {
             ^block17:
                 scf.yield v13;
+            } else {
+            ^block18:
+                v199 = arith.constant 0 : i32;
+                v21 = hir.bitcast v8 : u32;
+                v20 = hir.bitcast v10 : u32;
+                v22 = arith.lt v20, v21 : i1;
+                v23 = arith.zext v22 : u32;
+                v24 = hir.bitcast v23 : i32;
+                v26 = arith.neq v24, v199 : i1;
+                v27 = cf.select v26, v10, v8 : i32;
+                v197 = arith.constant 0 : i32;
+                v198 = arith.constant 0 : i32;
+                v29 = arith.eq v27, v198 : i1;
+                v30 = arith.zext v29 : u32;
+                v31 = hir.bitcast v30 : i32;
+                v33 = arith.neq v31, v197 : i1;
+                v196 = scf.if v33 : i32 {
+                ^block51:
+                    scf.yield v13;
+                } else {
+                ^block19:
+                    v34 = hir.bitcast v27 : u32;
+                    v35 = hir.bitcast v13 : u32;
+                    v36 = hir.int_to_ptr v35 : ptr<byte, u8>;
+                    v37 = hir.bitcast v7 : u32;
+                    v38 = hir.int_to_ptr v37 : ptr<byte, u8>;
+                    hir.mem_cpy v38, v36, v34;
+                    scf.yield v13;
+                };
+                scf.yield v196;
             };
-            builtin.ret v191;
+            builtin.ret v195;
         };
 
         public builtin.function @miden:base/note-script@1.0.0#note-script() {
-        ^block18:
+        ^block20:
+            hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/wit_bindgen_rt::run_ctors_once()
+            v202 = arith.constant 7 : felt;
+            v42 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1(v202) : felt
+            v201 = arith.constant 10 : felt;
+            hir.assert_eq v42, v201;
             builtin.ret ;
         };
 
-        public builtin.function @cabi_realloc_wit_bindgen_0_28_0(v39: i32, v40: i32, v41: i32, v42: i32) -> i32 {
-        ^block20(v39: i32, v40: i32, v41: i32, v42: i32):
-            v44 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/wit_bindgen_rt::cabi_realloc(v39, v40, v41, v42) : i32
-            builtin.ret v44;
+        public builtin.function @cabi_realloc_wit_bindgen_0_28_0(v45: i32, v46: i32, v47: i32, v48: i32) -> i32 {
+        ^block22(v45: i32, v46: i32, v47: i32, v48: i32):
+            v50 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/wit_bindgen_rt::cabi_realloc(v45, v46, v47, v48) : i32
+            builtin.ret v50;
         };
 
-        public builtin.function @wit_bindgen_rt::cabi_realloc(v45: i32, v46: i32, v47: i32, v48: i32) -> i32 {
-        ^block22(v45: i32, v46: i32, v47: i32, v48: i32):
-            v50 = arith.constant 0 : i32;
-            v51 = arith.neq v46, v50 : i1;
-            v203, v204, v205 = scf.if v51 : i32, i32, u32 {
-            ^block26:
-                v66 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/__rust_realloc(v45, v46, v47, v48) : i32
-                v194 = arith.constant 0 : u32;
-                v198 = ub.poison i32 : i32;
-                scf.yield v66, v198, v194;
+        private builtin.function @wit_bindgen_rt::cabi_realloc(v51: i32, v52: i32, v53: i32, v54: i32) -> i32 {
+        ^block24(v51: i32, v52: i32, v53: i32, v54: i32):
+            v56 = arith.constant 0 : i32;
+            v57 = arith.neq v52, v56 : i1;
+            v213, v214, v215 = scf.if v57 : i32, i32, u32 {
+            ^block28:
+                v72 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/__rustc::__rust_realloc(v51, v52, v53, v54) : i32
+                v204 = arith.constant 0 : u32;
+                v208 = ub.poison i32 : i32;
+                scf.yield v72, v208, v204;
             } else {
-            ^block27:
-                v228 = arith.constant 0 : i32;
-                v229 = arith.constant 0 : i32;
-                v53 = arith.eq v48, v229 : i1;
-                v54 = arith.zext v53 : u32;
-                v55 = hir.bitcast v54 : i32;
-                v57 = arith.neq v55, v228 : i1;
-                v214, v215, v216 = scf.if v57 : i32, i32, u32 {
-                ^block50:
-                    v199 = arith.constant 1 : u32;
-                    v227 = ub.poison i32 : i32;
-                    scf.yield v227, v47, v199;
+            ^block29:
+                v238 = arith.constant 0 : i32;
+                v239 = arith.constant 0 : i32;
+                v59 = arith.eq v54, v239 : i1;
+                v60 = arith.zext v59 : u32;
+                v61 = hir.bitcast v60 : i32;
+                v63 = arith.neq v61, v238 : i1;
+                v224, v225, v226 = scf.if v63 : i32, i32, u32 {
+                ^block54:
+                    v209 = arith.constant 1 : u32;
+                    v237 = ub.poison i32 : i32;
+                    scf.yield v237, v53, v209;
                 } else {
-                ^block28:
-                    v65 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/__rust_alloc(v48, v47) : i32
-                    v225 = arith.constant 0 : u32;
-                    v226 = ub.poison i32 : i32;
-                    scf.yield v65, v226, v225;
+                ^block30:
+                    v71 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/__rustc::__rust_alloc(v54, v53) : i32
+                    v235 = arith.constant 0 : u32;
+                    v236 = ub.poison i32 : i32;
+                    scf.yield v71, v236, v235;
                 };
-                scf.yield v214, v215, v216;
+                scf.yield v224, v225, v226;
             };
-            v210, v211 = scf.index_switch v205 : i32, u32 
+            v220, v221 = scf.index_switch v215 : i32, u32 
             case 0 {
-            ^block25:
-                v223 = arith.constant 0 : i32;
-                v69 = arith.neq v203, v223 : i1;
-                v212, v213 = scf.if v69 : i32, u32 {
-                ^block51:
-                    v222 = arith.constant 0 : u32;
-                    scf.yield v203, v222;
+            ^block27:
+                v233 = arith.constant 0 : i32;
+                v75 = arith.neq v213, v233 : i1;
+                v222, v223 = scf.if v75 : i32, u32 {
+                ^block55:
+                    v232 = arith.constant 0 : u32;
+                    scf.yield v213, v232;
                 } else {
-                ^block29:
-                    v220 = arith.constant 1 : u32;
-                    v221 = ub.poison i32 : i32;
-                    scf.yield v221, v220;
+                ^block31:
+                    v230 = arith.constant 1 : u32;
+                    v231 = ub.poison i32 : i32;
+                    scf.yield v231, v230;
                 };
-                scf.yield v212, v213;
+                scf.yield v222, v223;
             }
             default {
-            ^block57:
-                v224 = arith.constant 0 : u32;
-                scf.yield v204, v224;
+            ^block61:
+                v234 = arith.constant 0 : u32;
+                scf.yield v214, v234;
             };
-            v219 = arith.constant 0 : u32;
-            v218 = arith.eq v211, v219 : i1;
-            cf.cond_br v218 ^block52, ^block53;
-        ^block52:
-            builtin.ret v210;
-        ^block53:
+            v229 = arith.constant 0 : u32;
+            v228 = arith.eq v221, v229 : i1;
+            cf.cond_br v228 ^block56, ^block57;
+        ^block56:
+            builtin.ret v220;
+        ^block57:
             ub.unreachable ;
         };
 
-        public builtin.function @wit_bindgen_rt::run_ctors_once() {
-        ^block30:
+        private builtin.function @wit_bindgen_rt::run_ctors_once() {
+        ^block32:
+            v79 = arith.constant 1048621 : u32;
+            v243 = arith.constant 0 : u32;
+            v80 = arith.add v243, v79 : u32 #[overflow = checked];
+            v81 = hir.int_to_ptr v80 : ptr<byte, u8>;
+            v82 = hir.load v81 : u8;
+            v77 = arith.constant 0 : i32;
+            v83 = arith.zext v82 : u32;
+            v84 = hir.bitcast v83 : i32;
+            v86 = arith.neq v84, v77 : i1;
+            scf.if v86{
+            ^block34:
+                scf.yield ;
+            } else {
+            ^block35:
+                hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/__wasm_call_ctors()
+                v241 = arith.constant 1 : u8;
+                v245 = arith.constant 1048621 : u32;
+                v246 = arith.constant 0 : u32;
+                v93 = arith.add v246, v245 : u32 #[overflow = checked];
+                v94 = hir.int_to_ptr v93 : ptr<byte, u8>;
+                hir.store v94, v241;
+                scf.yield ;
+            };
             builtin.ret ;
         };
 
-        public builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v89: i32, v90: i32, v91: i32) -> i32 {
-        ^block34(v89: i32, v90: i32, v91: i32):
-            v94 = arith.constant 32 : i32;
-            v93 = arith.constant 0 : i32;
-            v232 = arith.constant 32 : u32;
-            v96 = hir.bitcast v90 : u32;
-            v98 = arith.gt v96, v232 : i1;
-            v99 = arith.zext v98 : u32;
-            v100 = hir.bitcast v99 : i32;
-            v102 = arith.neq v100, v93 : i1;
-            v103 = cf.select v102, v90, v94 : i32;
-            v265 = arith.constant 0 : i32;
-            v106 = arith.constant 1 : i32;
-            v104 = arith.popcnt v103 : u32;
-            v105 = hir.bitcast v104 : i32;
-            v107 = arith.neq v105, v106 : i1;
-            v108 = arith.zext v107 : u32;
-            v109 = hir.bitcast v108 : i32;
-            v111 = arith.neq v109, v265 : i1;
-            v241, v242 = scf.if v111 : i32, u32 {
-            ^block62:
-                v233 = arith.constant 0 : u32;
-                v237 = ub.poison i32 : i32;
-                scf.yield v237, v233;
+        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v95: i32, v96: i32, v97: i32) -> i32 {
+        ^block36(v95: i32, v96: i32, v97: i32):
+            v100 = arith.constant 32 : i32;
+            v99 = arith.constant 0 : i32;
+            v248 = arith.constant 32 : u32;
+            v102 = hir.bitcast v96 : u32;
+            v104 = arith.gt v102, v248 : i1;
+            v105 = arith.zext v104 : u32;
+            v106 = hir.bitcast v105 : i32;
+            v108 = arith.neq v106, v99 : i1;
+            v109 = cf.select v108, v96, v100 : i32;
+            v285 = arith.constant 0 : i32;
+            v110 = arith.constant -1 : i32;
+            v111 = arith.add v109, v110 : i32 #[overflow = wrapping];
+            v112 = arith.band v109, v111 : i32;
+            v114 = arith.neq v112, v285 : i1;
+            v257, v258 = scf.if v114 : i32, u32 {
+            ^block66:
+                v249 = arith.constant 0 : u32;
+                v253 = ub.poison i32 : i32;
+                scf.yield v253, v249;
             } else {
-            ^block37:
-                v113 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/core::ptr::alignment::Alignment::max(v90, v103) : i32
-                v264 = arith.constant 0 : i32;
-                v116 = hir.bitcast v91 : u32;
-                v112 = arith.constant -2147483648 : i32;
-                v114 = arith.sub v112, v113 : i32 #[overflow = wrapping];
-                v115 = hir.bitcast v114 : u32;
-                v117 = arith.lt v115, v116 : i1;
-                v118 = arith.zext v117 : u32;
-                v119 = hir.bitcast v118 : i32;
-                v121 = arith.neq v119, v264 : i1;
-                v245, v246 = scf.if v121 : i32, u32 {
-                ^block61:
-                    v262 = arith.constant 0 : u32;
-                    v263 = ub.poison i32 : i32;
-                    scf.yield v263, v262;
+            ^block39:
+                v116 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/core::ptr::alignment::Alignment::max(v96, v109) : i32
+                v284 = arith.constant 0 : i32;
+                v115 = arith.constant -2147483648 : i32;
+                v117 = arith.sub v115, v116 : i32 #[overflow = wrapping];
+                v119 = hir.bitcast v117 : u32;
+                v118 = hir.bitcast v97 : u32;
+                v120 = arith.gt v118, v119 : i1;
+                v121 = arith.zext v120 : u32;
+                v122 = hir.bitcast v121 : i32;
+                v124 = arith.neq v122, v284 : i1;
+                v261, v262 = scf.if v124 : i32, u32 {
+                ^block65:
+                    v282 = arith.constant 0 : u32;
+                    v283 = ub.poison i32 : i32;
+                    scf.yield v283, v282;
                 } else {
-                ^block38:
-                    v261 = arith.constant 0 : i32;
-                    v127 = arith.sub v261, v113 : i32 #[overflow = wrapping];
-                    v124 = arith.constant -1 : i32;
-                    v123 = arith.add v91, v113 : i32 #[overflow = wrapping];
-                    v125 = arith.add v123, v124 : i32 #[overflow = wrapping];
-                    v128 = arith.band v125, v127 : i32;
-                    v129 = hir.bitcast v89 : u32;
-                    v132 = hir.int_to_ptr v129 : (ptr i32);
-                    v133 = hir.load v132 : i32;
-                    v260 = arith.constant 0 : i32;
-                    v135 = arith.neq v133, v260 : i1;
-                    v247, v248, v249, v250 = scf.if v135 : i32, i32, i32, i32 {
-                    ^block60:
-                        v259 = arith.constant 0 : i32;
-                        scf.yield v89, v128, v113, v259;
-                    } else {
-                    ^block40:
-                        v258 = arith.constant 0 : i32;
-                        scf.yield v89, v128, v113, v258;
-                    };
-                    v149 = hir.bitcast v247 : u32;
-                    v152 = hir.int_to_ptr v149 : (ptr i32);
-                    v153 = hir.load v152 : i32;
-                    v257 = arith.constant 0 : i32;
-                    v157 = hir.bitcast v248 : u32;
-                    v147 = arith.constant 268435456 : i32;
-                    v154 = arith.sub v147, v153 : i32 #[overflow = wrapping];
-                    v156 = hir.bitcast v154 : u32;
-                    v158 = arith.lt v156, v157 : i1;
-                    v159 = arith.zext v158 : u32;
-                    v160 = hir.bitcast v159 : i32;
-                    v162 = arith.neq v160, v257 : i1;
-                    v251, v252 = scf.if v162 : i32, u32 {
-                    ^block41:
-                        v238 = arith.constant 1 : u32;
-                        scf.yield v250, v238;
+                ^block40:
+                    v280 = arith.constant 0 : i32;
+                    v130 = arith.sub v280, v116 : i32 #[overflow = wrapping];
+                    v281 = arith.constant -1 : i32;
+                    v126 = arith.add v97, v116 : i32 #[overflow = wrapping];
+                    v128 = arith.add v126, v281 : i32 #[overflow = wrapping];
+                    v131 = arith.band v128, v130 : i32;
+                    v132 = hir.bitcast v95 : u32;
+                    v133 = arith.constant 4 : u32;
+                    v134 = arith.mod v132, v133 : u32;
+                    hir.assertz v134 #[code = 250];
+                    v135 = hir.int_to_ptr v132 : ptr<byte, i32>;
+                    v136 = hir.load v135 : i32;
+                    v279 = arith.constant 0 : i32;
+                    v138 = arith.neq v136, v279 : i1;
+                    v263, v264, v265, v266 = scf.if v138 : i32, i32, i32, i32 {
+                    ^block64:
+                        v278 = arith.constant 0 : i32;
+                        scf.yield v95, v131, v116, v278;
                     } else {
                     ^block42:
-                        v256 = arith.constant 1 : u32;
-                        v169 = arith.add v153, v249 : i32 #[overflow = wrapping];
-                        scf.yield v169, v256;
+                        v139 = hir.exec @intrinsics/mem/heap_base() : i32
+                        v140 = hir.mem_size  : u32;
+                        v146 = hir.bitcast v95 : u32;
+                        v277 = arith.constant 4 : u32;
+                        v148 = arith.mod v146, v277 : u32;
+                        hir.assertz v148 #[code = 250];
+                        v247 = arith.constant 16 : u32;
+                        v143 = arith.shl v140, v247 : u32;
+                        v144 = hir.bitcast v143 : i32;
+                        v145 = arith.add v139, v144 : i32 #[overflow = wrapping];
+                        v149 = hir.int_to_ptr v146 : ptr<byte, i32>;
+                        hir.store v149, v145;
+                        v276 = arith.constant 0 : i32;
+                        scf.yield v95, v131, v116, v276;
                     };
-                    scf.yield v251, v252;
+                    v152 = hir.bitcast v263 : u32;
+                    v275 = arith.constant 4 : u32;
+                    v154 = arith.mod v152, v275 : u32;
+                    hir.assertz v154 #[code = 250];
+                    v155 = hir.int_to_ptr v152 : ptr<byte, i32>;
+                    v156 = hir.load v155 : i32;
+                    v274 = arith.constant 0 : i32;
+                    v160 = hir.bitcast v264 : u32;
+                    v150 = arith.constant 268435456 : i32;
+                    v157 = arith.sub v150, v156 : i32 #[overflow = wrapping];
+                    v159 = hir.bitcast v157 : u32;
+                    v161 = arith.lt v159, v160 : i1;
+                    v162 = arith.zext v161 : u32;
+                    v163 = hir.bitcast v162 : i32;
+                    v165 = arith.neq v163, v274 : i1;
+                    v267, v268 = scf.if v165 : i32, u32 {
+                    ^block43:
+                        v254 = arith.constant 1 : u32;
+                        scf.yield v266, v254;
+                    } else {
+                    ^block44:
+                        v167 = hir.bitcast v263 : u32;
+                        v273 = arith.constant 4 : u32;
+                        v169 = arith.mod v167, v273 : u32;
+                        hir.assertz v169 #[code = 250];
+                        v166 = arith.add v156, v264 : i32 #[overflow = wrapping];
+                        v170 = hir.int_to_ptr v167 : ptr<byte, i32>;
+                        hir.store v170, v166;
+                        v272 = arith.constant 1 : u32;
+                        v172 = arith.add v156, v265 : i32 #[overflow = wrapping];
+                        scf.yield v172, v272;
+                    };
+                    scf.yield v267, v268;
                 };
-                scf.yield v245, v246;
+                scf.yield v261, v262;
             };
-            v255 = arith.constant 0 : u32;
-            v254 = arith.eq v242, v255 : i1;
-            cf.cond_br v254 ^block36, ^block64(v241);
-        ^block36:
+            v271 = arith.constant 0 : u32;
+            v270 = arith.eq v258, v271 : i1;
+            cf.cond_br v270 ^block38, ^block68(v257);
+        ^block38:
             ub.unreachable ;
-        ^block64(v234: i32):
-            builtin.ret v234;
+        ^block68(v250: i32):
+            builtin.ret v250;
         };
 
-        public builtin.function @core::ptr::alignment::Alignment::max(v172: i32, v173: i32) -> i32 {
-        ^block43(v172: i32, v173: i32):
-            v180 = arith.constant 0 : i32;
-            v176 = hir.bitcast v173 : u32;
-            v175 = hir.bitcast v172 : u32;
-            v177 = arith.gt v175, v176 : i1;
-            v178 = arith.zext v177 : u32;
-            v179 = hir.bitcast v178 : i32;
-            v181 = arith.neq v179, v180 : i1;
-            v182 = cf.select v181, v172, v173 : i32;
-            builtin.ret v182;
+        private builtin.function @core::ptr::alignment::Alignment::max(v175: i32, v176: i32) -> i32 {
+        ^block45(v175: i32, v176: i32):
+            v183 = arith.constant 0 : i32;
+            v179 = hir.bitcast v176 : u32;
+            v178 = hir.bitcast v175 : u32;
+            v180 = arith.gt v178, v179 : i1;
+            v181 = arith.zext v180 : u32;
+            v182 = hir.bitcast v181 : i32;
+            v184 = arith.neq v182, v183 : i1;
+            v185 = cf.select v184, v175, v176 : i32;
+            builtin.ret v185;
         };
 
-        public builtin.function @cabi_realloc(v183: i32, v184: i32, v185: i32, v186: i32) -> i32 {
-        ^block45(v183: i32, v184: i32, v185: i32, v186: i32):
-            v188 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/cabi_realloc_wit_bindgen_0_28_0(v183, v184, v185, v186) : i32
-            builtin.ret v188;
+        public builtin.function @cabi_realloc(v186: i32, v187: i32, v188: i32, v189: i32) -> i32 {
+        ^block47(v186: i32, v187: i32, v188: i32, v189: i32):
+            v191 = hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/cabi_realloc_wit_bindgen_0_28_0(v186, v187, v188, v189) : i32
+            builtin.ret v191;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {
@@ -247,7 +324,8 @@ builtin.component miden:base/note-script@1.0.0 {
     };
 
     public builtin.function @note-script() {
-    ^block47:
+    ^block49:
+        hir.exec @miden:base/note-script@1.0.0/cross_ctx_note/miden:base/note-script@1.0.0#note-script()
         builtin.ret ;
     };
 };

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.hir
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.hir
@@ -2,7 +2,7 @@ builtin.component miden:base/note-script@1.0.0 {
     builtin.module public @cross_ctx_note {
         private builtin.function @cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1(v0: felt) -> felt {
         ^block3(v0: felt):
-            v1 = hir.call v0 : felt #[callee = miden:cross-ctx-account/foo@1.0.0@1.0.0/process-felt] #[signature = (param felt) (result felt)];
+            v1 = hir.call v0 : felt #[callee = miden:cross-ctx-account/foo@1.0.0/process-felt] #[signature = (param felt) (result felt)];
             builtin.ret v1;
         };
 

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.masm
@@ -1,92 +1,236 @@
-# mod #anon::lower-imports-miden:cross-ctx-account/foo@1.0.0
+# mod miden:base/note-script@1.0.0
 
-use.miden:cross-ctx-account/foo@1.0.0
+export.note-script
+    exec.::miden:base/note-script@1.0.0::cross_ctx_note::miden:base/note-script@1.0.0#note-script
+end
 
-export.process-felt
+export.init
+    push.2162688
+    exec.::intrinsics::mem::heap_init
+    push.9021226855565145792
+    push.4948740029366688057
+    push.7925211860580638461
+    push.9045569689096742779
+    adv.push_mapval
+    push.262144
+    push.3
+    exec.::std::mem::pipe_preimage_to_memory
+    drop
+    push.1048576
+    u32assert
+    mem_store.262144
+end
+
+# mod miden:base/note-script@1.0.0::cross_ctx_note
+
+proc.cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1
     call.::miden:cross-ctx-account/foo@1.0.0::process-felt
 end
 
-
-# mod cross_ctx_note
-
-use.intrinsics::mem
-use.lower-imports-miden:cross-ctx-account/foo@1.0.0
-use.miden:cross-ctx-account/foo@1.0.0
-
-proc."cross_ctx_note::bindings::__link_custom_section_describing_imports"
-
+proc.__wasm_call_ctors
+    nop
 end
 
+proc.cross_ctx_note::bindings::__link_custom_section_describing_imports
+    nop
+end
 
-proc."wit_bindgen_rt::cabi_realloc"
-    dup.1
-    neq.0
+proc.__rustc::__rust_alloc
+    push.1048616
+    movup.2
+    swap.1
+    exec.::miden:base/note-script@1.0.0::cross_ctx_note::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+end
+
+proc.__rustc::__rust_realloc
+    push.1048616
+    dup.4
+    swap.2
+    swap.4
+    swap.1
+    exec.::miden:base/note-script@1.0.0::cross_ctx_note::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    push.0
+    push.0
+    dup.2
+    swap.1
+    eq
+    neq
     if.true
-        exec."__rust_realloc"
-        dup.0
-        neq.0
-        if.true
-
-        else
-            push.0 assert
-        end
+        movdn.3
+        drop
+        drop
+        drop
     else
-        drop
-        drop
-        dup.1
-        eq.0
-        neq.0
+        push.0
+        dup.2
+        dup.5
+        swap.1
+        u32lt
+        neq
+        swap.1
+        swap.4
+        swap.1
+        cdrop
+        push.0
+        push.0
+        dup.2
+        swap.1
+        eq
+        neq
         if.true
-            swap.1 drop
+            drop
+            drop
         else
-            swap.1
-            exec."__rust_alloc"
-            dup.0
-            neq.0
-            if.true
-
-            else
-                push.0 assert
+            dup.2
+            movup.2
+            push.0
+            dup.3
+            push.0
+            gte
+            while.true
+                dup.2
+                dup.1
+                push.1
+                u32overflowing_madd
+                assertz
+                dup.2
+                dup.2
+                push.1
+                u32overflowing_madd
+                assertz
+                u32divmod.4
+                swap.1
+                exec.::intrinsics::mem::load_sw
+                push.128
+                u32and
+                swap.1
+                u32divmod.4
+                swap.1
+                dup.2
+                dup.2
+                dup.2
+                exec.::intrinsics::mem::load_sw
+                push.4294967040
+                u32and
+                movup.5
+                u32or
+                movdn.4
+                exec.::intrinsics::mem::store_sw
+                u32wrapping_add.1
+                dup.0
+                dup.4
+                u32gte
             end
+            dropw
         end
     end
 end
 
+export.miden:base/note-script@1.0.0#note-script
+    exec.::miden:base/note-script@1.0.0::cross_ctx_note::wit_bindgen_rt::run_ctors_once
+    push.7
+    exec.::miden:base/note-script@1.0.0::cross_ctx_note::cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1
+    push.10
+    assert_eq
+end
 
-proc."wit_bindgen_rt::run_ctors_once"
+export.cabi_realloc_wit_bindgen_0_28_0
+    exec.::miden:base/note-script@1.0.0::cross_ctx_note::wit_bindgen_rt::cabi_realloc
+end
+
+proc.wit_bindgen_rt::cabi_realloc
     push.0
-    add.1048621
-    u32assert
-    dup.0
-    u32mod.16
-    dup.0
-    u32mod.4
+    dup.2
     swap.1
-    u32div.4
+    neq
+    if.true
+        exec.::miden:base/note-script@1.0.0::cross_ctx_note::__rustc::__rust_realloc
+        push.0
+        push.3735929054
+        movup.2
+    else
+        drop
+        drop
+        push.0
+        push.0
+        dup.3
+        swap.1
+        eq
+        neq
+        if.true
+            swap.1
+            drop
+            push.1
+            push.3735929054
+            movup.2
+            swap.1
+        else
+            swap.1
+            exec.::miden:base/note-script@1.0.0::cross_ctx_note::__rustc::__rust_alloc
+            push.0
+            push.3735929054
+            movup.2
+        end
+    end
     movup.2
-    u32div.16
+    eq.0
+    if.true
+        swap.1
+        drop
+        push.0
+        dup.1
+        swap.1
+        neq
+        if.true
+            push.0
+            swap.1
+        else
+            drop
+            push.1
+            push.3735929054
+        end
+    else
+        drop
+        push.0
+        swap.1
+    end
+    push.0
+    movup.2
+    swap.1
+    eq
+    if.true
+        nop
+    else
+        drop
+        push.0
+        assert
+    end
+end
+
+proc.wit_bindgen_rt::run_ctors_once
+    push.1048621
+    push.0
+    add
+    u32assert
+    u32divmod.4
+    swap.1
     exec.::intrinsics::mem::load_sw
     push.128
     u32and
-    neq.0
+    push.0
+    swap.1
+    neq
     if.true
-
+        nop
     else
-        exec."__wasm_call_ctors"
+        exec.::miden:base/note-script@1.0.0::cross_ctx_note::__wasm_call_ctors
         push.1
-        push.128
-        u32and
+        push.1048621
         push.0
-        add.1048621
+        add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         dup.2
         dup.2
         dup.2
@@ -100,352 +244,167 @@ proc."wit_bindgen_rt::run_ctors_once"
     end
 end
 
-
-proc."core::ptr::alignment::Alignment::max"
-    dup.0
-    dup.2
-    u32gt
-    push.0
-    push.0
-    push.4294967294
-    movup.2
-    cdrop
-    u32or
-    neq.0
-    cdrop
-end
-
-
-proc."<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc"
+proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
     push.32
-    dup.2
+    push.0
     push.32
+    dup.4
+    swap.1
     u32gt
-    push.0
-    push.0
-    push.4294967294
-    movup.2
-    cdrop
-    u32or
-    neq.0
+    neq
     dup.3
     swap.1
     cdrop
-    dup.0
-    u32popcnt
-    push.1
+    push.0
+    push.4294967295
+    dup.2
+    swap.1
+    u32wrapping_add
+    dup.2
+    swap.1
+    u32and
     neq
-    neq.0
     if.true
-        push.0 assert
+        dropw
+        push.0
+        push.3735929054
     else
-        push.2147483648
-        swap.3
-        exec."core::ptr::alignment::Alignment::max"
-        dup.0
-        swap.1
-        swap.3
-        swap.1
-        u32wrapping_sub
-        dup.3
-        u32lt
-        push.0
-        push.0
-        push.4294967294
         movup.2
-        cdrop
-        u32or
-        neq.0
+        exec.::miden:base/note-script@1.0.0::cross_ctx_note::core::ptr::alignment::Alignment::max
+        push.0
+        push.2147483648
+        dup.2
+        u32wrapping_sub
+        dup.4
+        swap.1
+        u32gt
+        neq
         if.true
-            push.0 assert
+            drop
+            drop
+            drop
+            push.0
+            push.3735929054
         else
-            dup.0
-            dup.0
-            u32mod.4
-            assertz.err=250
-            dup.2
-            swap.1
-            swap.4
-            swap.1
-            u32wrapping_add
-            push.4294967295
-            u32wrapping_add
             push.0
-            dup.3
+            dup.1
+            swap.1
             u32wrapping_sub
-            u32and
-            push.0
+            push.4294967295
             movup.4
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
+            dup.3
+            u32wrapping_add
+            u32wrapping_add
+            u32and
+            dup.2
+            push.4
+            dup.1
             swap.1
-            u32div.4
-            movup.2
-            u32div.16
+            u32mod
+            u32assert
+            assertz.err=250
+            u32divmod.4
+            swap.1
             exec.::intrinsics::mem::load_sw
-            neq.0
+            push.0
+            neq
             if.true
-                dup.2
-                dup.0
-                u32mod.4
-                assertz.err=250
-                push.268435456
-                swap.1
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                dup.0
-                swap.1
-                swap.2
-                swap.1
-                u32wrapping_sub
-                dup.3
-                u32lt
                 push.0
-                push.0
-                push.4294967294
-                movup.2
-                cdrop
-                u32or
-                neq.0
-                if.true
-                    drop
-                    movdn.3
-                    drop
-                    drop
-                    drop
-                else
-                    swap.1
-                    drop
-                    movup.2
-                    dup.1
-                    swap.1
-                    swap.3
-                    u32wrapping_add
-                    dup.2
-                    dup.0
-                    u32mod.16
-                    dup.0
-                    u32mod.4
-                    swap.1
-                    u32div.4
-                    movup.2
-                    u32div.16
-                    exec.::intrinsics::mem::store_sw
-                    swap.1
-                    u32mod.4
-                    assertz.err=250
-                    swap.1
-                    u32wrapping_add
-                end
+                swap.3
             else
-                dup.2
                 exec.::intrinsics::mem::heap_base
-                dup.4
                 exec.::intrinsics::mem::memory_size
+                dup.4
+                push.4
+                dup.1
+                swap.1
+                u32mod
+                u32assert
+                assertz.err=250
                 push.16
+                movup.2
+                swap.1
                 u32shl
                 movup.2
                 swap.1
                 u32wrapping_add
-                dup.2
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
                 swap.1
-                u32div.4
-                movup.2
-                u32div.16
+                u32divmod.4
+                swap.1
                 exec.::intrinsics::mem::store_sw
-                dup.0
-                u32mod.4
-                assertz.err=250
-                swap.1
-                u32mod.4
-                assertz.err=250
-                push.268435456
-                swap.1
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                dup.0
-                swap.1
-                swap.2
-                swap.1
-                u32wrapping_sub
-                dup.3
-                u32lt
                 push.0
-                push.0
-                push.4294967294
+                swap.3
+            end
+            dup.0
+            push.4
+            dup.1
+            swap.1
+            u32mod
+            u32assert
+            assertz.err=250
+            u32divmod.4
+            swap.1
+            exec.::intrinsics::mem::load_sw
+            push.0
+            dup.3
+            push.268435456
+            dup.3
+            u32wrapping_sub
+            swap.1
+            u32lt
+            neq
+            if.true
+                dropw
+                push.1
+                swap.1
+            else
+                movup.4
+                drop
+                swap.1
+                push.4
+                dup.1
+                swap.1
+                u32mod
+                u32assert
+                assertz.err=250
+                dup.1
+                movup.3
+                u32wrapping_add
+                swap.1
+                u32divmod.4
+                swap.1
+                exec.::intrinsics::mem::store_sw
+                push.1
+                swap.1
                 movup.2
-                cdrop
-                u32or
-                neq.0
-                if.true
-                    drop
-                    movdn.3
-                    drop
-                    drop
-                    drop
-                else
-                    swap.1
-                    drop
-                    movup.2
-                    dup.1
-                    swap.1
-                    swap.3
-                    u32wrapping_add
-                    dup.2
-                    dup.0
-                    u32mod.16
-                    dup.0
-                    u32mod.4
-                    swap.1
-                    u32div.4
-                    movup.2
-                    u32div.16
-                    exec.::intrinsics::mem::store_sw
-                    swap.1
-                    u32mod.4
-                    assertz.err=250
-                    swap.1
-                    u32wrapping_add
-                end
+                u32wrapping_add
             end
         end
     end
-end
-
-
-proc."__rust_alloc"
-    push.1048616
+    push.0
     movup.2
     swap.1
-    exec."<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc"
-end
-
-
-proc."__rust_realloc"
-    push.1048616
-    dup.4
-    swap.2
-    swap.4
-    swap.1
-    exec."<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc"
-    dup.0
-    eq.0
-    neq.0
+    eq
     if.true
-        movdn.3 drop drop drop
+        drop
+        push.0
+        assert
     else
-        dup.1
-        dup.4
-        u32lt
-        push.0
-        push.0
-        push.4294967294
-        movup.2
-        cdrop
-        u32or
-        neq.0
-        swap.1
-        swap.4
-        swap.2
-        swap.1
-        cdrop
-        dup.2
-        movup.2
-        push.0
-        dup.3
-        gte.0
-        while.true
-            dup.2
-            dup.1
-            push.1
-            u32overflowing_madd
-            assertz
-            dup.2
-            dup.2
-            push.1
-            u32overflowing_madd
-            assertz
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            exec.::intrinsics::mem::load_sw
-            push.128
-            u32and
-            swap.1
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            dup.2
-            dup.2
-            dup.2
-            exec.::intrinsics::mem::load_sw
-            push.4294967040
-            u32and
-            movup.5
-            u32or
-            movdn.4
-            exec.::intrinsics::mem::store_sw
-            u32wrapping_add.1
-            dup.0
-            dup.4
-            u32gte
-        end
-        dropw
+        nop
     end
 end
 
-
-proc."__wasm_call_ctors"
-
+proc.core::ptr::alignment::Alignment::max
+    push.0
+    dup.2
+    dup.2
+    swap.1
+    u32gt
+    neq
+    cdrop
 end
-
 
 export.cabi_realloc
-    exec.cabi_realloc_wit_bindgen_0_28_0
+    exec.::miden:base/note-script@1.0.0::cross_ctx_note::cabi_realloc_wit_bindgen_0_28_0
 end
-
-
-export.cabi_realloc_wit_bindgen_0_28_0
-    exec."wit_bindgen_rt::cabi_realloc"
-end
-
-
-export."miden:base/note-script@1.0.0#note-script"
-    exec."wit_bindgen_rt::run_ctors_once"
-    push.7
-    exec.::lower-imports-miden:cross-ctx-account/foo@1.0.0::process-felt
-    push.10
-    assert_eq
-end
-
 

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.masm
@@ -106,15 +106,14 @@ proc.__rustc::__rust_realloc
                 swap.1
                 u32divmod.4
                 swap.1
-                dup.2
-                dup.2
-                dup.2
+                dup.1
+                dup.1
                 exec.::intrinsics::mem::load_sw
                 push.4294967040
                 u32and
-                movup.5
+                movup.3
                 u32or
-                movdn.4
+                movdn.2
                 exec.::intrinsics::mem::store_sw
                 u32wrapping_add.1
                 dup.0
@@ -231,15 +230,14 @@ proc.wit_bindgen_rt::run_ctors_once
         u32assert
         u32divmod.4
         swap.1
-        dup.2
-        dup.2
-        dup.2
+        dup.1
+        dup.1
         exec.::intrinsics::mem::load_sw
         push.4294967040
         u32and
-        movup.5
+        movup.3
         u32or
-        movdn.4
+        movdn.2
         exec.::intrinsics::mem::store_sw
     end
 end

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.wat
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.wat
@@ -1,7 +1,7 @@
-(component
+(component $cross-ctx-note
   (type (;0;)
     (instance
-      (type (;0;) (record (field "inner" float32)))
+      (type (;0;) (record (field "inner" f32)))
       (export (;1;) "felt" (type (eq 0)))
     )
   )
@@ -9,7 +9,7 @@
   (alias export 0 "felt" (type (;1;)))
   (type (;2;)
     (instance
-      (alias outer 1 1 (type (;0;)))
+      (alias outer $cross-ctx-note 1 (type (;0;)))
       (export (;1;) "felt" (type (eq 0)))
       (type (;2;) (func (param "input" 1) (result 1)))
       (export (;0;) "process-felt" (func (type 2)))
@@ -25,9 +25,9 @@
   (import "miden:core-import/intrinsics-mem@1.0.0" (instance (;2;) (type 3)))
   (type (;4;)
     (instance
-      (type (;0;) (func (param "a" u32) (result float32)))
+      (type (;0;) (func (param "a" u32) (result f32)))
       (export (;0;) "from-u32" (func (type 0)))
-      (type (;1;) (func (param "a" float32) (param "b" float32)))
+      (type (;1;) (func (param "a" f32) (param "b" f32)))
       (export (;1;) "assert-eq" (func (type 1)))
     )
   )
@@ -45,15 +45,23 @@
     (import "miden:cross-ctx-account/foo@1.0.0" "process-felt" (func $cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1 (;1;) (type 1)))
     (import "miden:core-import/intrinsics-felt@1.0.0" "assert-eq" (func $miden_stdlib_sys::intrinsics::felt::extern_assert_eq (;2;) (type 2)))
     (import "miden:core-import/intrinsics-mem@1.0.0" "heap-base" (func $miden_sdk_alloc::heap_base (;3;) (type 3)))
+    (table (;0;) 3 3 funcref)
+    (memory (;0;) 17)
+    (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
+    (export "memory" (memory 0))
+    (export "miden:base/note-script@1.0.0#note-script" (func $miden:base/note-script@1.0.0#note-script))
+    (export "cabi_realloc_wit_bindgen_0_28_0" (func $cabi_realloc_wit_bindgen_0_28_0))
+    (export "cabi_realloc" (func $cabi_realloc))
+    (elem (;0;) (i32.const 1) func $cross_ctx_note::bindings::__link_custom_section_describing_imports $cabi_realloc)
     (func $__wasm_call_ctors (;4;) (type 4))
     (func $cross_ctx_note::bindings::__link_custom_section_describing_imports (;5;) (type 4))
-    (func $__rust_alloc (;6;) (type 5) (param i32 i32) (result i32)
+    (func $__rustc::__rust_alloc (;6;) (type 5) (param i32 i32) (result i32)
       i32.const 1048616
       local.get 1
       local.get 0
       call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
     )
-    (func $__rust_realloc (;7;) (type 6) (param i32 i32 i32 i32) (result i32)
+    (func $__rustc::__rust_realloc (;7;) (type 6) (param i32 i32 i32 i32) (result i32)
       block ;; label = @1
         i32.const 1048616
         local.get 2
@@ -62,14 +70,18 @@
         local.tee 2
         i32.eqz
         br_if 0 (;@1;)
-        local.get 2
-        local.get 0
-        local.get 1
         local.get 3
         local.get 1
         local.get 3
+        local.get 1
         i32.lt_u
         select
+        local.tee 3
+        i32.eqz
+        br_if 0 (;@1;)
+        local.get 2
+        local.get 0
+        local.get 3
         memory.copy
       end
       local.get 2
@@ -104,7 +116,7 @@
             drop
             local.get 3
             local.get 2
-            call $__rust_alloc
+            call $__rustc::__rust_alloc
             local.set 2
             br 1 (;@2;)
           end
@@ -112,7 +124,7 @@
           local.get 1
           local.get 2
           local.get 3
-          call $__rust_realloc
+          call $__rustc::__rust_realloc
           local.set 2
         end
         local.get 2
@@ -142,18 +154,19 @@
         i32.gt_u
         select
         local.tee 3
-        i32.popcnt
-        i32.const 1
-        i32.ne
+        local.get 3
+        i32.const -1
+        i32.add
+        i32.and
         br_if 0 (;@1;)
+        local.get 2
         i32.const -2147483648
         local.get 1
         local.get 3
         call $core::ptr::alignment::Alignment::max
         local.tee 1
         i32.sub
-        local.get 2
-        i32.lt_u
+        i32.gt_u
         br_if 0 (;@1;)
         i32.const 0
         local.set 3
@@ -218,14 +231,6 @@
       local.get 3
       call $cabi_realloc_wit_bindgen_0_28_0
     )
-    (table (;0;) 3 3 funcref)
-    (memory (;0;) 17)
-    (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
-    (export "memory" (memory 0))
-    (export "miden:base/note-script@1.0.0#note-script" (func $miden:base/note-script@1.0.0#note-script))
-    (export "cabi_realloc_wit_bindgen_0_28_0" (func $cabi_realloc_wit_bindgen_0_28_0))
-    (export "cabi_realloc" (func $cabi_realloc))
-    (elem (;0;) (i32.const 1) func $cross_ctx_note::bindings::__link_custom_section_describing_imports $cabi_realloc)
     (data $.rodata (;0;) (i32.const 1048576) "\01\00\00\00\01\00\00\00\01\00\00\00\01\00\00\00\01\00\00\00\01\00\00\00\01\00\00\00\01\00\00\00\01\00\00\00\02\00\00\00")
   )
   (alias export 3 "from-u32" (func (;0;)))
@@ -268,4 +273,5 @@
     )
   )
   (export (;5;) "miden:base/note-script@1.0.0" (instance 4))
+  (@custom "version" "0.1.0")
 )

--- a/tests/integration/expected/types/static_mut.masm
+++ b/tests/integration/expected/types/static_mut.masm
@@ -46,15 +46,14 @@ export.global_var_update
     u32assert
     u32divmod.4
     swap.1
-    dup.2
-    dup.2
-    dup.2
+    dup.1
+    dup.1
     exec.::intrinsics::mem::load_sw
     push.4294967040
     u32and
-    movup.5
+    movup.3
     u32or
-    movdn.4
+    movdn.2
     exec.::intrinsics::mem::store_sw
 end
 

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -162,7 +162,6 @@ fn rust_sdk_cross_ctx_account() {
 }
 
 #[test]
-#[ignore = "until https://github.com/0xMiden/compiler/issues/476 is resolved"]
 fn rust_sdk_cross_ctx_note() {
     // Build cross-ctx-account package
     let args: Vec<String> = [
@@ -206,13 +205,8 @@ fn rust_sdk_cross_ctx_note() {
         ],
     );
     builder.with_entrypoint(FunctionIdent {
-        // module: Ident::new(Symbol::intern("miden:base/note-script@1.0.0"), SourceSpan::default()),
-        module: Ident::new(Symbol::intern("cross_ctx_note"), SourceSpan::default()),
-        // function: Ident::new(Symbol::intern("note-script"), SourceSpan::default()),
-        function: Ident::new(
-            Symbol::intern("miden:base/note-script@1.0.0#note-script"),
-            SourceSpan::default(),
-        ),
+        module: Ident::new(Symbol::intern("miden:base/note-script@1.0.0"), SourceSpan::default()),
+        function: Ident::new(Symbol::intern("note-script"), SourceSpan::default()),
     });
     let mut test = builder.build();
     let artifact_name = test.artifact_name().to_string();

--- a/tests/integration/src/testing/setup.rs
+++ b/tests/integration/src/testing/setup.rs
@@ -88,8 +88,9 @@ pub fn build_empty_component_for_test(context: Rc<Context>) -> LinkOutput {
     };
     let mut world_builder = WorldBuilder::new(world);
     let name = Ident::with_empty_span("root".into());
+    let ns_name = Ident::with_empty_span("root_ns".into());
     let component = world_builder
-        .define_component(name, name, Version::new(1, 0, 0))
+        .define_component(ns_name, name, Version::new(1, 0, 0))
         .unwrap_or_else(|err| panic!("failed to define component:\n{}", format_report(err)));
 
     let mut link_output = LinkOutput {


### PR DESCRIPTION
Close #476

TODO:

- [x] fix: prefix module path with `SymbolNameComponent::Root` for core Wasm module
- [x] fix `hir.call` missing lowering
- [x] order modules by dependency when passing to the Assembler;
- [x] treat the entrypoint as an absolute path
- [x] parse version in `ComponentId` parsing
- [ ] assertion failed on execution at cycle 389 on `u32lt`