### PR TITLE
feat: fix verify_loop

### DIFF
--- a/hir/src/ir/loops.rs
+++ b/hir/src/ir/loops.rs
@@ -1285,7 +1285,7 @@ impl Loop {
         loops.insert(self.clone());
 
         // Verify this loop.
-        self.verify_loop()?;
+        let _ = self.verify_loop();
 
         // Verify the subloops.
         for l in self.nested.borrow().iter().cloned() {


### PR DESCRIPTION
**Issue:** Installing `cargo miden` on the `next` branch fails due to a compile error.

**Steps to Reproduce:**

1. Check out the `next` branch.
2. Run the following command to install `cargo miden`:
   ```bash
   cargo install --path tools/cargo-miden --locked
   ```
3. The installation fails with the following error:
   ```
       --> hir/src/ir/loops.rs:1288:9
        |
   1288 |         self.verify_loop()?;
        |         ^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `()`
   ```

**Fix:**  
This PR addresses the issue by correcting the use of the `?` operator in `hir/src/ir/loops.rs`, making it possible to install `cargo miden` on the `next` branch.

**Verification:**  
After applying this fix, you can install `cargo miden` using the command:
```bash
cargo install --path tools/cargo-miden --locked
```

**Note:**  
If you have a previous installation of `cargo miden`, please uninstall it before reinstalling:
```bash
cargo uninstall cargo-miden
```