### PR TITLE
feat(PassManager): handle IR printing in `PassManager`

### DIFF
--- a/hir/src/ir/print.rs
+++ b/hir/src/ir/print.rs
@@ -9,6 +9,7 @@ use crate::{
     AttributeValue, EntityWithId, SuccessorOperands, Value,
 };
 
+#[derive(Clone, Copy)]
 pub struct OpPrintingFlags {
     pub print_entry_block_headers: bool,
     pub print_intrinsic_attributes: bool,

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -24,8 +24,8 @@ pub struct Print {
     target: Option<compact_str::CompactString>,
 }
 
-#[derive(Default)]
-enum OpFilter {
+#[derive(Default, Clone, Copy)]
+pub enum OpFilter {
     /// Print all operations
     #[default]
     All,


### PR DESCRIPTION
Addresses #455.

Wires up `IRPrintingConfig` with `PassManager` to implement IR printing functionality via `PassManager`. Currently still a draft. It would be great to get some initial feedback whether the approach here makes sense.

Should the `Print` pass stay or be removed once `PassManager` takes care of IR printing?