### PR TITLE
docs: update README link to correct repository path

### DIFF
--- a/docs/src/design/frontends.md
+++ b/docs/src/design/frontends.md
@@ -5,4 +5,4 @@
 TODO
 
 For the list of the unsupported Wasm core types, instructions and features, see the
-[README](https://github.com/0xPolygonMiden/compiler/frontend-wasm/README.md).
+[README](https://github.com/0xMiden/compiler/blob/next/frontend/wasm/README.md).


### PR DESCRIPTION
This PR updates the documentation reference link to point to the correct repository path.

Changes made:
- Updated the broken link from `https://github.com/0xPolygonMiden/compiler/frontend-wasm/README.md`
- To the correct path: `https://github.com/0xMiden/compiler/blob/next/frontend/wasm/README.md`

This ensures users can properly access the documentation about unsupported Wasm core types, instructions and features.