### PR TITLE
Add IR printing functionality to the PassManager

### DIFF
--- a/dialects/hir/src/transforms/spill.rs
+++ b/dialects/hir/src/transforms/spill.rs
@@ -74,7 +74,7 @@ impl Pass for TransformSpills {
 
         state.set_post_pass_status(transform_result);
 
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/dialects/hir/src/transforms/spill.rs
+++ b/dialects/hir/src/transforms/spill.rs
@@ -3,7 +3,7 @@ use alloc::rc::Rc;
 use midenc_hir::{
     adt::SmallDenseMap,
     dialects::builtin::{Function, FunctionRef, LocalVariable},
-    pass::{Pass, PassExecutionState, PassIdentifier, PostPassStatus},
+    pass::{Pass, PassExecutionState, PostPassStatus},
     BlockRef, BuilderExt, EntityMut, Op, OpBuilder, OperationName, OperationRef, Report, Rewriter,
     SourceSpan, Spanned, Symbol, ValueRef,
 };
@@ -17,10 +17,6 @@ impl Pass for TransformSpills {
 
     fn name(&self) -> &'static str {
         "transform-spills"
-    }
-
-    fn pass_id(&self) -> Option<PassIdentifier> {
-        Some(PassIdentifier::TransformSpills)
     }
 
     fn argument(&self) -> &'static str {

--- a/dialects/hir/src/transforms/spill.rs
+++ b/dialects/hir/src/transforms/spill.rs
@@ -42,7 +42,7 @@ impl Pass for TransformSpills {
         if function.is_declaration() {
             log::debug!(target: "insert-spills", "function has no body, no spills needed!");
             state.preserved_analyses_mut().preserve_all();
-            state.set_post_pass_status(PostPassStatus::IRUnchanged);
+            state.set_post_pass_status(PostPassStatus::Unchanged);
             return Ok(());
         }
         let mut analysis =
@@ -51,7 +51,7 @@ impl Pass for TransformSpills {
         if !analysis.has_spills() {
             log::debug!(target: "insert-spills", "no spills needed!");
             state.preserved_analyses_mut().preserve_all();
-            state.set_post_pass_status(PostPassStatus::IRUnchanged);
+            state.set_post_pass_status(PostPassStatus::Unchanged);
             return Ok(());
         }
 

--- a/dialects/scf/src/transforms/cfg_to_scf.rs
+++ b/dialects/scf/src/transforms/cfg_to_scf.rs
@@ -134,7 +134,7 @@ impl Pass for LiftControlFlowToSCF {
         });
 
         if result.was_interrupted() {
-            state.set_post_pass_status(PostPassStatus::IRUnchanged);
+            state.set_post_pass_status(PostPassStatus::Unchanged);
             return result.into_result();
         }
 

--- a/dialects/scf/src/transforms/cfg_to_scf.rs
+++ b/dialects/scf/src/transforms/cfg_to_scf.rs
@@ -7,7 +7,7 @@ use midenc_hir::{
     diagnostics::Severity,
     dialects::builtin,
     dominance::DominanceInfo,
-    pass::{Pass, PassExecutionState, PassIdentifier, PostPassStatus},
+    pass::{Pass, PassExecutionState, PostPassStatus},
     Builder, EntityMut, Forward, Op, Operation, OperationName, OperationRef, RawWalk, Report,
     SmallVec, Spanned, Type, ValueRange, ValueRef, WalkResult,
 };
@@ -33,10 +33,6 @@ impl Pass for LiftControlFlowToSCF {
 
     fn name(&self) -> &'static str {
         "lift-control-flow"
-    }
-
-    fn pass_id(&self) -> Option<PassIdentifier> {
-        Some(PassIdentifier::LiftControlFlowToSCF)
     }
 
     fn argument(&self) -> &'static str {

--- a/dialects/scf/src/transforms/cfg_to_scf.rs
+++ b/dialects/scf/src/transforms/cfg_to_scf.rs
@@ -55,7 +55,7 @@ impl Pass for LiftControlFlowToSCF {
         &mut self,
         op: EntityMut<'_, Self::Target>,
         state: &mut PassExecutionState,
-    ) -> Result<PostPassStatus, Report> {
+    ) -> Result<(), Report> {
         let mut transformation = ControlFlowToSCFTransformation;
         let mut changed = false;
 
@@ -134,7 +134,8 @@ impl Pass for LiftControlFlowToSCF {
         });
 
         if result.was_interrupted() {
-            return result.into_result().map(|_| PostPassStatus::IRUnchanged);
+            state.set_post_pass_status(PostPassStatus::IRUnchanged);
+            return result.into_result();
         }
 
         log::debug!(
@@ -145,7 +146,9 @@ impl Pass for LiftControlFlowToSCF {
             state.preserved_analyses_mut().preserve_all();
         }
 
-        Ok(changed.into())
+        state.set_post_pass_status(changed.into());
+
+        Ok(())
     }
 }
 

--- a/hir-transform/src/canonicalization.rs
+++ b/hir-transform/src/canonicalization.rs
@@ -100,7 +100,7 @@ impl Pass for Canonicalizer {
     ) -> Result<(), Report> {
         let Some(rewrites) = self.rewrites.as_ref() else {
             log::debug!("skipping canonicalization as there are no rewrite patterns to apply");
-            state.set_post_pass_status(PostPassStatus::IRUnchanged);
+            state.set_post_pass_status(PostPassStatus::Unchanged);
             return Ok(());
         };
         let op = {

--- a/hir-transform/src/canonicalization.rs
+++ b/hir-transform/src/canonicalization.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, format, rc::Rc};
 
 use midenc_hir::{
-    pass::{OperationPass, Pass, PassExecutionState, PassIdentifier, PostPassStatus},
+    pass::{OperationPass, Pass, PassExecutionState, PostPassStatus},
     patterns::{self, FrozenRewritePatternSet, GreedyRewriteConfig, RewritePatternSet},
     Context, EntityMut, Operation, OperationName, Report, Spanned,
 };
@@ -60,10 +60,6 @@ impl Pass for Canonicalizer {
 
     fn name(&self) -> &'static str {
         "canonicalizer"
-    }
-
-    fn pass_id(&self) -> Option<PassIdentifier> {
-        Some(PassIdentifier::Canonicalizer)
     }
 
     fn argument(&self) -> &'static str {

--- a/hir-transform/src/canonicalization.rs
+++ b/hir-transform/src/canonicalization.rs
@@ -97,10 +97,11 @@ impl Pass for Canonicalizer {
         &mut self,
         op: EntityMut<'_, Self::Target>,
         state: &mut PassExecutionState,
-    ) -> Result<PostPassStatus, Report> {
+    ) -> Result<(), Report> {
         let Some(rewrites) = self.rewrites.as_ref() else {
             log::debug!("skipping canonicalization as there are no rewrite patterns to apply");
-            return Ok(PostPassStatus::IRUnchanged);
+            state.set_post_pass_status(PostPassStatus::IRUnchanged);
+            return Ok(());
         };
         let op = {
             let ptr = op.as_operation_ref();
@@ -146,7 +147,9 @@ impl Pass for Canonicalizer {
                 changed
             }
         };
+        let ir_changed = changed.into();
+        state.set_post_pass_status(ir_changed);
 
-        Ok(changed.into())
+        Ok(())
     }
 }

--- a/hir-transform/src/sccp.rs
+++ b/hir-transform/src/sccp.rs
@@ -1,5 +1,5 @@
 use midenc_hir::{
-    pass::{Pass, PassExecutionState, PassIdentifier},
+    pass::{Pass, PassExecutionState},
     patterns::NoopRewriterListener,
     BlockRef, Builder, EntityMut, OpBuilder, Operation, OperationFolder, OperationName, RegionList,
     Report, SmallVec, ValueRef,
@@ -24,10 +24,6 @@ impl Pass for SparseConditionalConstantPropagation {
 
     fn name(&self) -> &'static str {
         "sparse-conditional-constant-propagation"
-    }
-
-    fn pass_id(&self) -> Option<PassIdentifier> {
-        Some(PassIdentifier::SparseConditionalConstantPropagation)
     }
 
     fn argument(&self) -> &'static str {

--- a/hir-transform/src/sink.rs
+++ b/hir-transform/src/sink.rs
@@ -100,7 +100,7 @@ impl Pass for ControlFlowSink {
         &mut self,
         op: EntityMut<'_, Self::Target>,
         state: &mut PassExecutionState,
-    ) -> Result<PostPassStatus, Report> {
+    ) -> Result<(), Report> {
         let op = op.into_entity_ref();
         log::debug!(target: "control-flow-sink", "sinking operations in {op}");
 
@@ -137,7 +137,9 @@ impl Pass for ControlFlowSink {
             );
         });
 
-        Ok(sunk)
+        state.set_post_pass_status(sunk);
+
+        Ok(())
     }
 }
 
@@ -180,8 +182,8 @@ impl Pass for SinkOperandDefs {
     fn run_on_operation(
         &mut self,
         op: EntityMut<'_, Self::Target>,
-        _state: &mut PassExecutionState,
-    ) -> Result<PostPassStatus, Report> {
+        state: &mut PassExecutionState,
+    ) -> Result<(), Report> {
         let operation = op.as_operation_ref();
         drop(op);
 
@@ -409,7 +411,8 @@ impl Pass for SinkOperandDefs {
             }
         }
 
-        Ok(changed)
+        state.set_post_pass_status(changed);
+        Ok(())
     }
 }
 

--- a/hir-transform/src/sink.rs
+++ b/hir-transform/src/sink.rs
@@ -4,7 +4,7 @@ use midenc_hir::{
     adt::SmallDenseMap,
     dominance::DominanceInfo,
     matchers::{self, Matcher},
-    pass::{Pass, PassExecutionState, PassIdentifier, PostPassStatus},
+    pass::{Pass, PassExecutionState, PostPassStatus},
     traits::{ConstantLike, Terminator},
     Backward, Builder, EntityMut, Forward, FxHashSet, OpBuilder, Operation, OperationName,
     OperationRef, ProgramPoint, RawWalk, Region, RegionBranchOpInterface,
@@ -84,10 +84,6 @@ impl Pass for ControlFlowSink {
         "control-flow-sink"
     }
 
-    fn pass_id(&self) -> Option<PassIdentifier> {
-        Some(PassIdentifier::ControlFlowSink)
-    }
-
     fn argument(&self) -> &'static str {
         "control-flow-sink"
     }
@@ -165,10 +161,6 @@ impl Pass for SinkOperandDefs {
 
     fn name(&self) -> &'static str {
         "sink-operand-defs"
-    }
-
-    fn pass_id(&self) -> Option<PassIdentifier> {
-        Some(PassIdentifier::SinkOperandDefs)
     }
 
     fn argument(&self) -> &'static str {

--- a/hir-transform/src/sink.rs
+++ b/hir-transform/src/sink.rs
@@ -109,7 +109,7 @@ impl Pass for ControlFlowSink {
 
         let dominfo = state.analysis_manager().get_analysis::<DominanceInfo>()?;
 
-        let mut sunk = PostPassStatus::IRUnchanged;
+        let mut sunk = PostPassStatus::Unchanged;
         operation.raw_prewalk_all::<Forward, _>(|op: OperationRef| {
             let regions_to_sink = {
                 let op = op.borrow();
@@ -195,7 +195,7 @@ impl Pass for SinkOperandDefs {
         // then process the worklist, moving everything into position.
         let mut worklist = alloc::collections::VecDeque::default();
 
-        let mut changed = PostPassStatus::IRUnchanged;
+        let mut changed = PostPassStatus::Unchanged;
         // Visit ops in "true" post-order (i.e. block bodies are visited bottom-up).
         operation.raw_postwalk_all::<Backward, _>(|operation: OperationRef| {
             // Determine if any of this operation's operands represent one of the following:
@@ -320,7 +320,7 @@ impl Pass for SinkOperandDefs {
                         log::trace!(target: "sink-operand-defs", "    rewriting operand {operand_value} as {replacement}");
                         operand.borrow_mut().set(replacement);
 
-                        changed = PostPassStatus::IRChanged;
+                        changed = PostPassStatus::Changed;
                         // If no other uses of this value remain, then remove the original
                         // operation, as it is now dead.
                         if !operand_value.borrow().is_used() {
@@ -367,7 +367,7 @@ impl Pass for SinkOperandDefs {
                         log::trace!(target: "sink-operand-defs", "    rewriting operand {operand_value} as {replacement}");
                         sink_state.replacements.insert(operand_value, replacement);
                         operand.borrow_mut().set(replacement);
-                        changed = PostPassStatus::IRChanged;
+                        changed = PostPassStatus::Changed;
                     } else {
                         log::trace!(target: "sink-operand-defs", "    defining op is a constant with no other uses, moving into place");
                         // The original op can be moved

--- a/hir-transform/src/spill.rs
+++ b/hir-transform/src/spill.rs
@@ -4,7 +4,7 @@ use midenc_hir::{
     adt::{SmallDenseMap, SmallSet},
     cfg::Graph,
     dominance::{DomTreeNode, DominanceFrontier, DominanceInfo},
-    pass::AnalysisManager,
+    pass::{AnalysisManager, PostPassStatus},
     traits::SingleRegion,
     BlockRef, Builder, Context, FxHashMap, OpBuilder, OpOperand, Operation, OperationRef,
     ProgramPoint, Region, RegionBranchOpInterface, RegionBranchPoint, RegionRef, Report, Rewriter,
@@ -113,7 +113,7 @@ pub fn transform_spills(
     analysis: &mut SpillAnalysis,
     interface: &mut dyn TransformSpillsInterface,
     analysis_manager: AnalysisManager,
-) -> Result<(), Report> {
+) -> Result<PostPassStatus, Report> {
     assert!(
         op.borrow().implements::<dyn SingleRegion>(),
         "the spills transformation is not supported when the root op is multi-region"
@@ -252,7 +252,7 @@ pub fn transform_spills(
         )?;
     }
 
-    Ok(())
+    Ok(PostPassStatus::IRChanged)
 }
 
 fn rewrite_single_block_spills(

--- a/hir-transform/src/spill.rs
+++ b/hir-transform/src/spill.rs
@@ -252,7 +252,7 @@ pub fn transform_spills(
         )?;
     }
 
-    Ok(PostPassStatus::IRChanged)
+    Ok(PostPassStatus::Changed)
 }
 
 fn rewrite_single_block_spills(

--- a/hir/src/ir/print.rs
+++ b/hir/src/ir/print.rs
@@ -9,6 +9,7 @@ use crate::{
     AttributeValue, EntityWithId, SuccessorOperands, Value,
 };
 
+#[derive(Debug)]
 pub struct OpPrintingFlags {
     pub print_entry_block_headers: bool,
     pub print_intrinsic_attributes: bool,

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -199,7 +199,7 @@ impl Print {
 
         // Always print, unless "only_when_modified" has been set and there have not been changes.
         let modification_filter =
-            !matches!((self.only_when_modified, ir_changed), (true, PostPassStatus::IRUnchanged));
+            !matches!((self.only_when_modified, ir_changed), (true, PostPassStatus::Unchanged));
 
         pass_filter && modification_filter
     }

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -192,7 +192,7 @@ impl Print {
 
         // Always print, unless "only_when_modified" has been set and there have not been changes.
         let modification_filter =
-            !matches!((self.only_when_modified, ir_changed), (true, PostPassStatus::Unchanged));
+            !matches!(ir_changed, PostPassStatus::IRUnchanged if self.only_when_modified);
 
         pass_filter && modification_filter
     }

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -10,21 +10,55 @@ pub mod statistics;
 pub use self::{
     analysis::{Analysis, AnalysisManager, OperationAnalysis, PreservedAnalyses},
     instrumentation::{PassInstrumentation, PassInstrumentor, PipelineParentInfo},
-    manager::{Nesting, OpPassManager, PassDisplayMode, PassManager},
-    pass::{OperationPass, Pass, PassExecutionState},
+    manager::{IRPrintingConfig, Nesting, OpPassManager, PassDisplayMode, PassManager},
+    pass::{OperationPass, Pass, PassExecutionState, PassIdentifier, PostPassStatus},
     registry::{PassInfo, PassPipelineInfo},
     specialization::PassTarget,
     statistics::{PassStatistic, Statistic, StatisticValue},
 };
+use crate::{
+    alloc::{string::String, vec::Vec},
+    EntityRef, Operation, OperationName, OperationRef,
+};
 
-/// A `Pass` which prints IR it is run on, based on provided configuration.
+/// Handles IR printing, based on the [`IRPrintingConfig`] passed in
+/// [Print::new]. Currently, this struct is managed by the [`PassManager`]'s [`PassInstrumentor`],
+/// which calls the Print struct via its [`PassInstrumentation`] trait implementation.
+///
+/// The configuration passed by [`IRPrintingConfig`] controls *when* the IR gets displayed, rather
+/// than *how*. The display format itself depends on the `Display` implementation done by each
+/// [`Operation`].
+///
+/// [`Print::selected_passes`] controls which passes are selected to be printable. This means that
+/// those selected passes will run all the configured filters; which will determine whether
+/// the pass displays the IR or not. The available options are [`SelectedPasses::All`] to enable all
+/// the passes and [`SelectedPasses::Just`] to enable a select set of passes.
+///
+/// The filters that run on the selected passes are:
+/// - [`Print::only_when_modified`] will only print the IR if said pass modified the IR.
+///
+/// - [`Print::op_filter`] will only display a specific subset of operations.
 #[derive(Default)]
 pub struct Print {
-    filter: OpFilter,
+    selected_passes: Option<SelectedPasses>,
+
+    only_when_modified: bool,
+    op_filter: Option<OpFilter>,
+
     target: Option<compact_str::CompactString>,
 }
 
-#[derive(Default)]
+/// Which passes are enabled for IR printing.
+#[derive(Debug)]
+enum SelectedPasses {
+    /// Enable all passes for IR Printing.
+    All,
+    /// Just select a subset of passes for IR printing.
+    Just(Vec<PassIdentifier>),
+}
+
+#[allow(dead_code)]
+#[derive(Default, Debug)]
 enum OpFilter {
     /// Print all operations
     #[default]
@@ -40,30 +74,66 @@ enum OpFilter {
 }
 
 impl Print {
-    /// Create a printer that prints any operation
-    pub fn any() -> Self {
-        Self {
-            filter: OpFilter::All,
-            target: None,
-        }
+    pub fn new(config: &IRPrintingConfig) -> Option<Self> {
+        let print = if config.print_ir_after_all
+            || !config.print_ir_after_pass.is_empty()
+            || config.print_ir_after_modified
+        {
+            Some(Self::default())
+        } else {
+            None
+        };
+        print.map(|p| p.with_pass_filter(config)).map(|p| p.with_symbol_filter(config))
     }
 
-    /// Create a printer that only prints operations of type `T`
-    pub fn only<T: crate::OpRegistration>() -> Self {
+    pub fn with_type_filter<T: crate::OpRegistration>(mut self) -> Self {
         let dialect = <T as crate::OpRegistration>::dialect_name();
         let op = <T as crate::OpRegistration>::name();
-        Self {
-            filter: OpFilter::Type { dialect, op },
-            target: None,
-        }
+        self.op_filter = Some(OpFilter::Type { dialect, op });
+        self
     }
 
+    #[allow(dead_code)]
     /// Create a printer that only prints `Symbol` operations containing `name`
-    pub fn symbol_matching(name: &'static str) -> Self {
-        Self {
-            filter: OpFilter::Symbol(Some(name)),
-            target: None,
-        }
+    fn with_symbol_matching(mut self, name: &'static str) -> Self {
+        self.op_filter = Some(OpFilter::Symbol(Some(name)));
+        self
+    }
+
+    #[allow(unused_mut)]
+    fn with_symbol_filter(mut self, _config: &IRPrintingConfig) -> Self {
+        // NOTE: At the moment, symbol filtering is not processed by the CLI. However, were it to be
+        // added, it could be done inside this function
+        self.with_all_symbols()
+    }
+
+    fn with_all_symbols(mut self) -> Self {
+        self.op_filter = Some(OpFilter::All);
+        self
+    }
+
+    fn with_pass_filter(mut self, config: &IRPrintingConfig) -> Self {
+        let is_ir_filter_set = if config.print_ir_after_all {
+            self.selected_passes = Some(SelectedPasses::All);
+            true
+        } else if !config.print_ir_after_pass.is_empty() {
+            self.selected_passes = Some(SelectedPasses::Just(config.print_ir_after_pass.clone()));
+            true
+        } else {
+            false
+        };
+
+        if config.print_ir_after_modified {
+            self.only_when_modified = true;
+            // NOTE: If the user specified the "print after modification" flag, but didn't specify
+            // any IR pass filter flag; then we assume that the desired behavior is to set the "all
+            // pass" filter.
+            if !is_ir_filter_set {
+                self.selected_passes = Some(SelectedPasses::All);
+            }
+        };
+
+        self
     }
 
     /// Specify the `log` target to write the IR output to.
@@ -75,55 +145,103 @@ impl Print {
         self.target = Some(target);
         self
     }
-}
 
-impl Pass for Print {
-    type Target = crate::Operation;
-
-    fn name(&self) -> &'static str {
-        "print"
-    }
-
-    fn can_schedule_on(&self, _name: &crate::OperationName) -> bool {
-        true
-    }
-
-    fn run_on_operation(
-        &mut self,
-        op: crate::EntityMut<'_, Self::Target>,
-        _state: &mut PassExecutionState,
-    ) -> Result<(), crate::Report> {
-        let op = op.into_entity_ref();
-        match self.filter {
-            OpFilter::All => {
+    fn print_ir(&self, op: EntityRef<'_, Operation>) {
+        match self.op_filter {
+            Some(OpFilter::All) => {
                 let target = self.target.as_deref().unwrap_or("printer");
                 log::trace!(target: target, "{op}");
             }
-            OpFilter::Type {
+            Some(OpFilter::Type {
                 dialect,
                 op: op_name,
-            } => {
+            }) => {
                 let name = op.name();
                 if name.dialect() == dialect && name.name() == op_name {
                     let target = self.target.as_deref().unwrap_or("printer");
                     log::trace!(target: target, "{op}");
                 }
             }
-            OpFilter::Symbol(None) => {
+            Some(OpFilter::Symbol(None)) => {
                 if let Some(sym) = op.as_symbol() {
                     let name = sym.name().as_str();
                     let target = self.target.as_deref().unwrap_or(name);
                     log::trace!(target: target, "{}", sym.as_symbol_operation());
                 }
             }
-            OpFilter::Symbol(Some(filter)) => {
+            Some(OpFilter::Symbol(Some(filter))) => {
                 if let Some(sym) = op.as_symbol().filter(|sym| sym.name().as_str().contains(filter))
                 {
                     let target = self.target.as_deref().unwrap_or(filter);
                     log::trace!(target: target, "{}", sym.as_symbol_operation());
                 }
             }
+            None => (),
         }
-        Ok(())
+    }
+
+    fn pass_filter(&self, pass: &dyn OperationPass) -> bool {
+        match &self.selected_passes {
+            Some(SelectedPasses::All) => true,
+            Some(SelectedPasses::Just(passes)) => passes.iter().any(|p| {
+                if let Some(p_type) = pass.pass_id() {
+                    *p == p_type
+                } else {
+                    false
+                }
+            }),
+            None => false,
+        }
+    }
+
+    fn should_print(&self, pass: &dyn OperationPass, ir_changed: PostPassStatus) -> bool {
+        let pass_filter = self.pass_filter(pass);
+
+        // Always print, unless "only_when_modified" has been set and there have not been changes.
+        let modification_filter =
+            !matches!((self.only_when_modified, ir_changed), (true, PostPassStatus::IRUnchanged));
+
+        pass_filter && modification_filter
+    }
+}
+
+impl PassInstrumentation for Print {
+    fn run_before_pipeline(
+        &mut self,
+        _name: Option<&OperationName>,
+        _parent_info: &PipelineParentInfo,
+        op: OperationRef,
+    ) {
+        if !self.only_when_modified {
+            return;
+        }
+
+        log::trace!("IR before the pass pipeline");
+        let op = op.borrow();
+        self.print_ir(op);
+    }
+
+    fn run_before_pass(&mut self, pass: &dyn OperationPass, op: &OperationRef) {
+        if self.only_when_modified {
+            return;
+        }
+        if self.pass_filter(pass) {
+            log::trace!("Before the {} pass", pass.name());
+            let op = op.borrow();
+            self.print_ir(op);
+        }
+    }
+
+    fn run_after_pass(
+        &mut self,
+        pass: &dyn OperationPass,
+        op: &OperationRef,
+        changed: PostPassStatus,
+    ) {
+        if self.should_print(pass, changed) {
+            log::trace!("After the {} pass", pass.name());
+            let op = op.borrow();
+            self.print_ir(op);
+        }
     }
 }

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -194,7 +194,7 @@ impl Print {
         }
     }
 
-    fn should_print(&self, pass: &dyn OperationPass, ir_changed: PostPassStatus) -> bool {
+    fn should_print(&self, pass: &dyn OperationPass, ir_changed: &PostPassStatus) -> bool {
         let pass_filter = self.pass_filter(pass);
 
         // Always print, unless "only_when_modified" has been set and there have not been changes.
@@ -236,8 +236,10 @@ impl PassInstrumentation for Print {
         &mut self,
         pass: &dyn OperationPass,
         op: &OperationRef,
-        changed: PostPassStatus,
+        post_execution_state: &PassExecutionState,
     ) {
+        let changed = post_execution_state.post_pass_status();
+
         if self.should_print(pass, changed) {
             log::trace!("After the {} pass", pass.name());
             let op = op.borrow();

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -56,7 +56,6 @@ enum SelectedPasses {
     Just(SmallVec<[String; 1]>),
 }
 
-#[allow(dead_code)]
 #[derive(Default, Debug)]
 enum OpFilter {
     /// Print all operations
@@ -64,8 +63,14 @@ enum OpFilter {
     All,
     /// Print any `Symbol` operation, optionally filtering by symbols whose name contains a given
     /// string.
+    /// NOTE: Currently marked as `dead_code` since it is not configured via the CLI. See
+    /// [`Print::with_symbol_filter`] for more details.
+    #[allow(dead_code)]
     Symbol(Option<&'static str>),
     /// Print only operations of the given type
+    /// NOTE: Currently marked as `dead_code` since it is not configured via the CLI. See
+    /// [`Print::with_symbol_filter`] for more details.
+    #[allow(dead_code)]
     Type {
         dialect: crate::interner::Symbol,
         op: crate::interner::Symbol,
@@ -99,10 +104,12 @@ impl Print {
         self
     }
 
-    #[allow(unused_mut)]
-    fn with_symbol_filter(mut self, _config: &IRPrintingConfig) -> Self {
-        // NOTE: At the moment, symbol filtering is not processed by the CLI. However, were it to be
-        // added, it could be done inside this function
+    /// Configure which operations are printed. This is set via the different variants present in
+    /// [`OpFilter`].
+    ///
+    /// NOTE: At the moment, all operations are shown because symbol filtering is not processed by
+    /// the CLI. If added, this function could be expanded to process it.
+    fn with_symbol_filter(self, _config: &IRPrintingConfig) -> Self {
         self.with_all_symbols()
     }
 

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -7,19 +7,18 @@ pub mod registry;
 mod specialization;
 pub mod statistics;
 
+use alloc::string::String;
+
 pub use self::{
     analysis::{Analysis, AnalysisManager, OperationAnalysis, PreservedAnalyses},
     instrumentation::{PassInstrumentation, PassInstrumentor, PipelineParentInfo},
     manager::{IRPrintingConfig, Nesting, OpPassManager, PassDisplayMode, PassManager},
-    pass::{OperationPass, Pass, PassExecutionState, PassIdentifier, PostPassStatus},
+    pass::{OperationPass, Pass, PassExecutionState, PostPassStatus},
     registry::{PassInfo, PassPipelineInfo},
     specialization::PassTarget,
     statistics::{PassStatistic, Statistic, StatisticValue},
 };
-use crate::{
-    alloc::{string::String, vec::Vec},
-    EntityRef, Operation, OperationName, OperationRef,
-};
+use crate::{EntityRef, Operation, OperationName, OperationRef, SmallVec};
 
 /// Handles IR printing, based on the [`IRPrintingConfig`] passed in
 /// [Print::new]. Currently, this struct is managed by the [`PassManager`]'s [`PassInstrumentor`],
@@ -54,7 +53,7 @@ enum SelectedPasses {
     /// Enable all passes for IR Printing.
     All,
     /// Just select a subset of passes for IR printing.
-    Just(Vec<PassIdentifier>),
+    Just(SmallVec<[String; 1]>),
 }
 
 #[allow(dead_code)]
@@ -183,13 +182,7 @@ impl Print {
     fn pass_filter(&self, pass: &dyn OperationPass) -> bool {
         match &self.selected_passes {
             Some(SelectedPasses::All) => true,
-            Some(SelectedPasses::Just(passes)) => passes.iter().any(|p| {
-                if let Some(p_type) = pass.pass_id() {
-                    *p == p_type
-                } else {
-                    false
-                }
-            }),
+            Some(SelectedPasses::Just(passes)) => passes.iter().any(|p| pass.name() == *p),
             None => false,
         }
     }

--- a/hir/src/pass.rs
+++ b/hir/src/pass.rs
@@ -192,7 +192,7 @@ impl Print {
 
         // Always print, unless "only_when_modified" has been set and there have not been changes.
         let modification_filter =
-            !matches!(ir_changed, PostPassStatus::IRUnchanged if self.only_when_modified);
+            !matches!(ir_changed, PostPassStatus::Unchanged if self.only_when_modified);
 
         pass_filter && modification_filter
     }

--- a/hir/src/pass/instrumentation.rs
+++ b/hir/src/pass/instrumentation.rs
@@ -5,7 +5,7 @@ use compact_str::CompactString;
 use smallvec::SmallVec;
 
 use super::OperationPass;
-use crate::{pass::PostPassStatus, OperationName, OperationRef};
+use crate::{pass::PassExecutionState, OperationName, OperationRef};
 
 #[allow(unused_variables)]
 pub trait PassInstrumentation {
@@ -27,7 +27,7 @@ pub trait PassInstrumentation {
         &mut self,
         pass: &dyn OperationPass,
         op: &OperationRef,
-        changed: PostPassStatus,
+        post_execution_state: &PassExecutionState,
     ) {
     }
     fn run_after_pass_failed(&mut self, pass: &dyn OperationPass, op: &OperationRef) {}
@@ -66,9 +66,9 @@ impl<P: ?Sized + PassInstrumentation> PassInstrumentation for Box<P> {
         &mut self,
         pass: &dyn OperationPass,
         op: &OperationRef,
-        changed: PostPassStatus,
+        post_execution_state: &PassExecutionState,
     ) {
-        (**self).run_after_pass(pass, op, changed);
+        (**self).run_after_pass(pass, op, post_execution_state);
     }
 
     fn run_after_pass_failed(&mut self, pass: &dyn OperationPass, op: &OperationRef) {
@@ -115,9 +115,9 @@ impl PassInstrumentor {
         &self,
         pass: &dyn OperationPass,
         op: &OperationRef,
-        changed: PostPassStatus,
+        post_execution_state: &PassExecutionState,
     ) {
-        self.instrument(|pi| pi.run_after_pass(pass, op, changed));
+        self.instrument(|pi| pi.run_after_pass(pass, op, post_execution_state));
     }
 
     pub fn run_after_pass_failed(&self, pass: &dyn OperationPass, op: &OperationRef) {

--- a/hir/src/pass/manager.rs
+++ b/hir/src/pass/manager.rs
@@ -1048,7 +1048,7 @@ impl OpToOpPassAdaptor {
                 }
             }
         }
-        state.set_post_pass_status(PostPassStatus::IRUnchanged);
+        state.set_post_pass_status(PostPassStatus::Unchanged);
         Ok(())
     }
 }

--- a/hir/src/pass/manager.rs
+++ b/hir/src/pass/manager.rs
@@ -4,7 +4,6 @@ use alloc::{
     format,
     rc::Rc,
     string::{String, ToString},
-    vec::Vec,
 };
 
 use compact_str::{CompactString, ToCompactString};
@@ -53,27 +52,7 @@ impl TryFrom<&Options> for IRPrintingConfig {
     type Error = Report;
 
     fn try_from(options: &Options) -> Result<Self, Self::Error> {
-        let available_passes = [
-            "canonicalizer",
-            "control-flow-sink",
-            "lift-control-flow",
-            "sink-operand-defs",
-            "sparse-conditional-constant-propagation",
-            "transform-spills",
-        ];
-
-        let pass_filters: Vec<_> = {
-            let invalid_pass = options
-                .print_ir_after_pass
-                .iter()
-                .find(|pass| !available_passes.contains(&pass.as_str()));
-
-            if let Some(invalid_pass) = invalid_pass {
-                Err(Report::msg(format!("'{invalid_pass}' unrecognized pass.")))
-            } else {
-                Ok(options.print_ir_after_pass.clone())
-            }
-        }?;
+        let pass_filters = options.print_ir_after_pass.clone();
 
         if options.print_ir_after_all && !pass_filters.is_empty() {
             return Err(Report::msg(

--- a/hir/src/pass/manager.rs
+++ b/hir/src/pass/manager.rs
@@ -4,6 +4,7 @@ use alloc::{
     format,
     rc::Rc,
     string::{String, ToString},
+    vec::Vec,
 };
 
 use compact_str::{CompactString, ToCompactString};
@@ -52,7 +53,27 @@ impl TryFrom<&Options> for IRPrintingConfig {
     type Error = Report;
 
     fn try_from(options: &Options) -> Result<Self, Self::Error> {
-        let pass_filters = options.print_ir_after_pass.clone();
+        let available_passes = [
+            "canonicalizer",
+            "control-flow-sink",
+            "lift-control-flow",
+            "sink-operand-defs",
+            "sparse-conditional-constant-propagation",
+            "transform-spills",
+        ];
+
+        let pass_filters: Vec<_> = {
+            let invalid_pass = options
+                .print_ir_after_pass
+                .iter()
+                .find(|pass| !available_passes.contains(&pass.as_str()));
+
+            if let Some(invalid_pass) = invalid_pass {
+                Err(Report::msg(format!("'{invalid_pass}' unrecognized pass.")))
+            } else {
+                Ok(options.print_ir_after_pass.clone())
+            }
+        }?;
 
         if options.print_ir_after_all && !pass_filters.is_empty() {
             return Err(Report::msg(

--- a/hir/src/pass/manager.rs
+++ b/hir/src/pass/manager.rs
@@ -992,8 +992,7 @@ impl OpToOpPassAdaptor {
             if result.is_err() {
                 instrumentor.run_after_pass_failed(pass, &op);
             } else {
-                let in_result = result.as_ref().unwrap_or(&PostPassStatus::IRUnchanged);
-                instrumentor.run_after_pass(pass, &op, *in_result);
+                instrumentor.run_after_pass(pass, &op, &execution_state);
             }
         }
 
@@ -1015,7 +1014,7 @@ impl OpToOpPassAdaptor {
         op: OperationRef,
         state: &mut PassExecutionState,
         verify: bool,
-    ) -> Result<PostPassStatus, Report> {
+    ) -> Result<(), Report> {
         let analysis_manager = state.analysis_manager();
         let instrumentor = analysis_manager.pass_instrumentor();
         let parent_info = PipelineParentInfo {
@@ -1049,8 +1048,8 @@ impl OpToOpPassAdaptor {
                 }
             }
         }
-
-        Ok(PostPassStatus::IRUnchanged)
+        state.set_post_pass_status(PostPassStatus::IRUnchanged);
+        Ok(())
     }
 }
 
@@ -1091,7 +1090,7 @@ impl Pass for OpToOpPassAdaptor {
         &mut self,
         _op: EntityMut<'_, Operation>,
         _state: &mut PassExecutionState,
-    ) -> Result<PostPassStatus, Report> {
+    ) -> Result<(), Report> {
         unreachable!("unexpected call to `Pass::run_on_operation` for OpToOpPassAdaptor")
     }
 }

--- a/hir/src/pass/pass.rs
+++ b/hir/src/pass/pass.rs
@@ -174,16 +174,16 @@ impl TryFrom<&String> for PassIdentifier {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum PostPassStatus {
-    IRUnchanged,
-    IRChanged,
+    Unchanged,
+    Changed,
 }
 
 impl From<bool> for PostPassStatus {
     fn from(ir_was_changed: bool) -> Self {
         if ir_was_changed {
-            PostPassStatus::IRChanged
+            PostPassStatus::Changed
         } else {
-            PostPassStatus::IRUnchanged
+            PostPassStatus::Unchanged
         }
     }
 }
@@ -434,7 +434,7 @@ impl PassExecutionState {
             analysis_manager,
             preserved_analyses: Default::default(),
             pipeline_executor,
-            post_pass_status: PostPassStatus::IRUnchanged,
+            post_pass_status: PostPassStatus::Unchanged,
         }
     }
 

--- a/midenc-compile/src/compiler.rs
+++ b/midenc-compile/src/compiler.rs
@@ -339,6 +339,13 @@ pub struct UnstableOptions {
         )
     )]
     pub print_ir_after_pass: Vec<String>,
+    /// Only print the IR if the pass modified the IR structure. If this flag is set, and no IR
+    /// filter flag is; then the default behavior is to print the IR after every pass.
+    #[cfg_attr(
+        feature = "std",
+        arg(long, default_value_t = false, help_heading = "Passes")
+    )]
+    pub print_ir_after_modified: bool,
 }
 
 impl CodegenOptions {
@@ -505,6 +512,7 @@ impl Compiler {
         options.print_cfg_after_pass = unstable.print_cfg_after_pass;
         options.print_ir_after_all = unstable.print_ir_after_all;
         options.print_ir_after_pass = unstable.print_ir_after_pass;
+        options.print_ir_after_modified = unstable.print_ir_after_modified;
 
         // Establish --target-dir
         let target_dir = if self.target_dir.is_absolute() {

--- a/midenc-compile/src/stages/rewrite.rs
+++ b/midenc-compile/src/stages/rewrite.rs
@@ -3,7 +3,7 @@ use alloc::boxed::Box;
 use midenc_dialect_hir::transforms::TransformSpills;
 use midenc_dialect_scf::transforms::LiftControlFlowToSCF;
 use midenc_hir::{
-    pass::{Nesting, PassManager},
+    pass::{IRPrintingConfig, Nesting, PassManager},
     patterns::{GreedyRewriteConfig, RegionSimplificationLevel},
     Op,
 };
@@ -22,6 +22,7 @@ impl Stage for ApplyRewritesStage {
     }
 
     fn run(&mut self, input: Self::Input, context: Rc<Context>) -> CompilerResult<Self::Output> {
+        let ir_print_config: IRPrintingConfig = (&context.as_ref().session().options).try_into()?;
         log::debug!(target: "driver", "applying rewrite passes");
         // TODO(pauls): Set up pass registration for new pass infra
         /*
@@ -48,7 +49,8 @@ impl Stage for ApplyRewritesStage {
         */
 
         // Construct a pass manager with the default pass pipeline
-        let mut pm = PassManager::on::<builtin::World>(context.clone(), Nesting::Implicit);
+        let mut pm = PassManager::on::<builtin::World>(context.clone(), Nesting::Implicit)
+            .enable_ir_printing(ir_print_config);
 
         let mut rewrite_config = GreedyRewriteConfig::default();
         rewrite_config.with_region_simplification_level(RegionSimplificationLevel::Normal);

--- a/midenc-session/src/options/mod.rs
+++ b/midenc-session/src/options/mod.rs
@@ -52,6 +52,8 @@ pub struct Options {
     pub print_ir_after_all: bool,
     /// Print IR to stdout each time the named passes are applied
     pub print_ir_after_pass: Vec<String>,
+    /// Only print the IR if the pass modified the IR structure.
+    pub print_ir_after_modified: bool,
     /// Save intermediate artifacts in memory during compilation
     pub save_temps: bool,
     /// We store any leftover argument matches in the session options for use
@@ -126,6 +128,7 @@ impl Options {
             print_cfg_after_pass: vec![],
             print_ir_after_all: false,
             print_ir_after_pass: vec![],
+            print_ir_after_modified: false,
             flags: CompileFlags::default(),
         }
     }


### PR DESCRIPTION
# Usage
This PR implements the IR printing functionality, which can enabled via the use of flags passed to the compiler. The flags it introduces are:
`-Z print-ir-after-all`, `-Z print-ir-after-pass` and `-Z print-ir-after-modified`.

- `print-ir-after-all`: This enables IR printing for every pass.
- `print-ir-after-pass`: This enables IR printing for a selected number passes.
  - Those passes have to be passed as a comma separated string after an equal sign, like so:
  - `-Z print-ir-after-pass=canonicalizer,lift-control-flow`
- `print-if-after-modified`: This will only allow a pass to print the IR *if* it modifies the IR it received as input.

Here's an example output of the usage of these flags, these CLI examples are using the `fib.rs` available in the [Miden book](https://0xpolygonmiden.github.io/miden-docs/imported/miden-compiler/src/guides/rust_to_wasm.html). Do note that the output here is excluding all the non-Print output, in reality the compiler is way more verbose.

## Print after every pass

`print-ir-after-all` will enable IR printing after every compiler pass. 

<details>

<summary>Click here to see the CLI command </summary>


```shell
midenc compile  --emit masm=wasm_fib.masm,masp fib.wasm -Z print-ir-after-all


[TRACE midenc_hir::pass] Before the Pipeline Collection: [builtin.component] pass
[TRACE printer] builtin.world  {
      builtin.component root_ns:root@1.0.0 {
          builtin.module public @wasm_fib {
              public builtin.function @fib(v0: i32) -> i32 {
              ^block4(v0: i32):
                  v2 = arith.constant 0 : i32;
                  v3 = arith.constant 0 : i32;
                  v4 = arith.constant 1 : i32;
                  cf.br ^block6(v4, v0, v3);
              ^block5(v1: i32):
  
              ^block6(v6: i32, v7: i32, v10: i32):
                  v8 = arith.constant 0 : i32;
                  v9 = arith.neq v7, v8 : i1;
                  cf.cond_br v9 ^block8, ^block9;
              ^block7(v5: i32):
  
              ^block8:
                  v11 = arith.constant -1 : i32;
                  v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                  v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                  cf.br ^block6(v13, v12, v6);
              ^block9:
                  builtin.ret v10;
              };
  
              builtin.global_variable private @#__stack_pointer : i32 {
                  builtin.ret_imm 1048576;
              };
          };
      };
  };
[TRACE midenc_hir::pass] Before the Pipeline Collection: [builtin.module] pass
[TRACE printer] builtin.component root_ns:root@1.0.0 {
      builtin.module public @wasm_fib {
          public builtin.function @fib(v0: i32) -> i32 {
          ^block4(v0: i32):
              v2 = arith.constant 0 : i32;
              v3 = arith.constant 0 : i32;
              v4 = arith.constant 1 : i32;
              cf.br ^block6(v4, v0, v3);
          ^block5(v1: i32):
  
          ^block6(v6: i32, v7: i32, v10: i32):
              v8 = arith.constant 0 : i32;
              v9 = arith.neq v7, v8 : i1;
              cf.cond_br v9 ^block8, ^block9;
          ^block7(v5: i32):
  
          ^block8:
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              cf.br ^block6(v13, v12, v6);
          ^block9:
              builtin.ret v10;
          };
  
          builtin.global_variable private @#__stack_pointer : i32 {
              builtin.ret_imm 1048576;
          };
      };
  };
[TRACE midenc_hir::pass] Before the Pipeline Collection: [builtin.function] pass
[TRACE printer] builtin.module public @wasm_fib {
      public builtin.function @fib(v0: i32) -> i32 {
      ^block4(v0: i32):
          v2 = arith.constant 0 : i32;
          v3 = arith.constant 0 : i32;
          v4 = arith.constant 1 : i32;
          cf.br ^block6(v4, v0, v3);
      ^block5(v1: i32):
  
      ^block6(v6: i32, v7: i32, v10: i32):
          v8 = arith.constant 0 : i32;
          v9 = arith.neq v7, v8 : i1;
          cf.cond_br v9 ^block8, ^block9;
      ^block7(v5: i32):
  
      ^block8:
          v11 = arith.constant -1 : i32;
          v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
          v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
          cf.br ^block6(v13, v12, v6);
      ^block9:
          builtin.ret v10;
      };
  
      builtin.global_variable private @#__stack_pointer : i32 {
          builtin.ret_imm 1048576;
      };
  };
[TRACE midenc_hir::pass] Before the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v2 = arith.constant 0 : i32;
      v3 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v3);
  ^block5(v1: i32):
  
  ^block6(v6: i32, v7: i32, v10: i32):
      v8 = arith.constant 0 : i32;
      v9 = arith.neq v7, v8 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block7(v5: i32):
  
  ^block8:
      v11 = arith.constant -1 : i32;
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v2);
  ^block6(v6: i32, v7: i32, v10: i32):
      v9 = arith.neq v7, v2 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block8:
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] Before the lift-control-flow pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v2);
  ^block6(v6: i32, v7: i32, v10: i32):
      v9 = arith.neq v7, v2 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block8:
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the lift-control-flow pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] Before the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] Before the sink-operand-defs pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the sink-operand-defs pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] Before the control-flow-sink pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the control-flow-sink pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] Before the transform-spills pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the transform-spills pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the Pipeline Collection: [builtin.function] pass
[TRACE printer] builtin.module public @wasm_fib {
      public builtin.function @fib(v0: i32) -> i32 {
      ^block4(v0: i32):
          v22 = ub.poison i32 : i32;
          v2 = arith.constant 0 : i32;
          v4 = arith.constant 1 : i32;
          v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
          ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
              v53 = arith.constant 0 : i32;
              v9 = arith.neq v7, v53 : i1;
              v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
              ^block8:
                  v21 = arith.constant 1 : u32;
                  v15 = arith.constant 0 : u32;
                  v11 = arith.constant -1 : i32;
                  v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                  v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                  scf.yield v13, v12, v6, v15, v21;
              } else {
              ^block16:
                  v50 = arith.constant 0 : u32;
                  v51 = arith.constant 1 : u32;
                  v52 = ub.poison i32 : i32;
                  scf.yield v52, v52, v52, v51, v50;
              };
              v44 = arith.trunc v49 : i1;
              scf.condition v44, v45, v46, v47, v10;
          } do {
          ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
              scf.yield v40, v41, v42, v43;
          };
          builtin.ret v35;
      };
  
      builtin.global_variable private @#__stack_pointer : i32 {
          builtin.ret_imm 1048576;
      };
  };
[TRACE midenc_hir::pass] After the Pipeline Collection: [builtin.module] pass
[TRACE printer] builtin.component root_ns:root@1.0.0 {
      builtin.module public @wasm_fib {
          public builtin.function @fib(v0: i32) -> i32 {
          ^block4(v0: i32):
              v22 = ub.poison i32 : i32;
              v2 = arith.constant 0 : i32;
              v4 = arith.constant 1 : i32;
              v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
              ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
                  v53 = arith.constant 0 : i32;
                  v9 = arith.neq v7, v53 : i1;
                  v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
                  ^block8:
                      v21 = arith.constant 1 : u32;
                      v15 = arith.constant 0 : u32;
                      v11 = arith.constant -1 : i32;
                      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                      scf.yield v13, v12, v6, v15, v21;
                  } else {
                  ^block16:
                      v50 = arith.constant 0 : u32;
                      v51 = arith.constant 1 : u32;
                      v52 = ub.poison i32 : i32;
                      scf.yield v52, v52, v52, v51, v50;
                  };
                  v44 = arith.trunc v49 : i1;
                  scf.condition v44, v45, v46, v47, v10;
              } do {
              ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
                  scf.yield v40, v41, v42, v43;
              };
              builtin.ret v35;
          };
  
          builtin.global_variable private @#__stack_pointer : i32 {
              builtin.ret_imm 1048576;
          };
      };
  };
[TRACE midenc_hir::pass] Before the Pipeline Collection: [builtin.function] pass
[TRACE printer] builtin.component root_ns:root@1.0.0 {
      builtin.module public @wasm_fib {
          public builtin.function @fib(v0: i32) -> i32 {
          ^block4(v0: i32):
              v22 = ub.poison i32 : i32;
              v2 = arith.constant 0 : i32;
              v4 = arith.constant 1 : i32;
              v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
              ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
                  v53 = arith.constant 0 : i32;
                  v9 = arith.neq v7, v53 : i1;
                  v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
                  ^block8:
                      v21 = arith.constant 1 : u32;
                      v15 = arith.constant 0 : u32;
                      v11 = arith.constant -1 : i32;
                      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                      scf.yield v13, v12, v6, v15, v21;
                  } else {
                  ^block16:
                      v50 = arith.constant 0 : u32;
                      v51 = arith.constant 1 : u32;
                      v52 = ub.poison i32 : i32;
                      scf.yield v52, v52, v52, v51, v50;
                  };
                  v44 = arith.trunc v49 : i1;
                  scf.condition v44, v45, v46, v47, v10;
              } do {
              ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
                  scf.yield v40, v41, v42, v43;
              };
              builtin.ret v35;
          };
  
          builtin.global_variable private @#__stack_pointer : i32 {
              builtin.ret_imm 1048576;
          };
      };
  };
[TRACE midenc_hir::pass] After the Pipeline Collection: [builtin.function] pass
[TRACE printer] builtin.component root_ns:root@1.0.0 {
      builtin.module public @wasm_fib {
          public builtin.function @fib(v0: i32) -> i32 {
          ^block4(v0: i32):
              v22 = ub.poison i32 : i32;
              v2 = arith.constant 0 : i32;
              v4 = arith.constant 1 : i32;
              v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
              ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
                  v53 = arith.constant 0 : i32;
                  v9 = arith.neq v7, v53 : i1;
                  v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
                  ^block8:
                      v21 = arith.constant 1 : u32;
                      v15 = arith.constant 0 : u32;
                      v11 = arith.constant -1 : i32;
                      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                      scf.yield v13, v12, v6, v15, v21;
                  } else {
                  ^block16:
                      v50 = arith.constant 0 : u32;
                      v51 = arith.constant 1 : u32;
                      v52 = ub.poison i32 : i32;
                      scf.yield v52, v52, v52, v51, v50;
                  };
                  v44 = arith.trunc v49 : i1;
                  scf.condition v44, v45, v46, v47, v10;
              } do {
              ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
                  scf.yield v40, v41, v42, v43;
              };
              builtin.ret v35;
          };
  
          builtin.global_variable private @#__stack_pointer : i32 {
              builtin.ret_imm 1048576;
          };
      };
  };
[TRACE midenc_hir::pass] After the Pipeline Collection: [builtin.component] pass
[TRACE printer] builtin.world  {
      builtin.component root_ns:root@1.0.0 {
          builtin.module public @wasm_fib {
              public builtin.function @fib(v0: i32) -> i32 {
              ^block4(v0: i32):
                  v22 = ub.poison i32 : i32;
                  v2 = arith.constant 0 : i32;
                  v4 = arith.constant 1 : i32;
                  v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
                  ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
                      v53 = arith.constant 0 : i32;
                      v9 = arith.neq v7, v53 : i1;
                      v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
                      ^block8:
                          v21 = arith.constant 1 : u32;
                          v15 = arith.constant 0 : u32;
                          v11 = arith.constant -1 : i32;
                          v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                          v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                          scf.yield v13, v12, v6, v15, v21;
                      } else {
                      ^block16:
                          v50 = arith.constant 0 : u32;
                          v51 = arith.constant 1 : u32;
                          v52 = ub.poison i32 : i32;
                          scf.yield v52, v52, v52, v51, v50;
                      };
                      v44 = arith.trunc v49 : i1;
                      scf.condition v44, v45, v46, v47, v10;
                  } do {
                  ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
                      scf.yield v40, v41, v42, v43;
                  };
                  builtin.ret v35;
              };
  
              builtin.global_variable private @#__stack_pointer : i32 {
                  builtin.ret_imm 1048576;
              };
          };
      };
  };

```

</details>
This output, by itself, can be *quite* verbose, since every pass will print the IR *even if* no modification has been made.

In order to reduce noise, the `-Z print-ir-after-modified` can be used:

<details>

<summary>Click here to see the CLI command </summary>

```shell
midenc compile  --emit masm=wasm_fib.masm,masp fib.wasm -Z print-ir-after-all -Z print-ir-after-modified

[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] builtin.world  {
      builtin.component root_ns:root@1.0.0 {
          builtin.module public @wasm_fib {
              public builtin.function @fib(v0: i32) -> i32 {
              ^block4(v0: i32):
                  v2 = arith.constant 0 : i32;
                  v3 = arith.constant 0 : i32;
                  v4 = arith.constant 1 : i32;
                  cf.br ^block6(v4, v0, v3);
              ^block5(v1: i32):
  
              ^block6(v6: i32, v7: i32, v10: i32):
                  v8 = arith.constant 0 : i32;
                  v9 = arith.neq v7, v8 : i1;
                  cf.cond_br v9 ^block8, ^block9;
              ^block7(v5: i32):
  
              ^block8:
                  v11 = arith.constant -1 : i32;
                  v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                  v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                  cf.br ^block6(v13, v12, v6);
              ^block9:
                  builtin.ret v10;
              };
  
              builtin.global_variable private @#__stack_pointer : i32 {
                  builtin.ret_imm 1048576;
              };
          };
      };
  };
[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] builtin.component root_ns:root@1.0.0 {
      builtin.module public @wasm_fib {
          public builtin.function @fib(v0: i32) -> i32 {
          ^block4(v0: i32):
              v2 = arith.constant 0 : i32;
              v3 = arith.constant 0 : i32;
              v4 = arith.constant 1 : i32;
              cf.br ^block6(v4, v0, v3);
          ^block5(v1: i32):
  
          ^block6(v6: i32, v7: i32, v10: i32):
              v8 = arith.constant 0 : i32;
              v9 = arith.neq v7, v8 : i1;
              cf.cond_br v9 ^block8, ^block9;
          ^block7(v5: i32):
  
          ^block8:
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              cf.br ^block6(v13, v12, v6);
          ^block9:
              builtin.ret v10;
          };
  
          builtin.global_variable private @#__stack_pointer : i32 {
              builtin.ret_imm 1048576;
          };
      };
  };
[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] builtin.module public @wasm_fib {
      public builtin.function @fib(v0: i32) -> i32 {
      ^block4(v0: i32):
          v2 = arith.constant 0 : i32;
          v3 = arith.constant 0 : i32;
          v4 = arith.constant 1 : i32;
          cf.br ^block6(v4, v0, v3);
      ^block5(v1: i32):
  
      ^block6(v6: i32, v7: i32, v10: i32):
          v8 = arith.constant 0 : i32;
          v9 = arith.neq v7, v8 : i1;
          cf.cond_br v9 ^block8, ^block9;
      ^block7(v5: i32):
  
      ^block8:
          v11 = arith.constant -1 : i32;
          v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
          v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
          cf.br ^block6(v13, v12, v6);
      ^block9:
          builtin.ret v10;
      };
  
      builtin.global_variable private @#__stack_pointer : i32 {
          builtin.ret_imm 1048576;
      };
  };
[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v2 = arith.constant 0 : i32;
      v3 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v3);
  ^block5(v1: i32):
  
  ^block6(v6: i32, v7: i32, v10: i32):
      v8 = arith.constant 0 : i32;
      v9 = arith.neq v7, v8 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block7(v5: i32):
  
  ^block8:
      v11 = arith.constant -1 : i32;
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v2);
  ^block6(v6: i32, v7: i32, v10: i32):
      v9 = arith.neq v7, v2 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block8:
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the lift-control-flow pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the sink-operand-defs pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };

```
</details>

Now, only passes that modify the IR will actually print. In the case of `fib.rs` those pases are:  `canonicalizer`, `lift-control-flow` and `sink-operand-defs`.

## Print after a subset of passes
And let's say that one is only interested in a subset of passes. For this, the `print-ir-after-pass` is added.
The following will only print the IR after passes: `control-flow-sink`, `canonicalizer` and `lift-control-flow-pass`.

<details>

<summary>Click here to see the CLI command </summary>

```shell
midenc compile  --emit masm=wasm_fib.masm,masp fib.wasm -Z print-ir-after-pass=canonicalizer, lift-control-flow-pass, control-flow-sink

[TRACE midenc_hir::pass] Before the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v2 = arith.constant 0 : i32;
      v3 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v3);
  ^block5(v1: i32):
  
  ^block6(v6: i32, v7: i32, v10: i32):
      v8 = arith.constant 0 : i32;
      v9 = arith.neq v7, v8 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block7(v5: i32):
  
  ^block8:
      v11 = arith.constant -1 : i32;
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v2);
  ^block6(v6: i32, v7: i32, v10: i32):
      v9 = arith.neq v7, v2 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block8:
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] Before the lift-control-flow pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v2);
  ^block6(v6: i32, v7: i32, v10: i32):
      v9 = arith.neq v7, v2 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block8:
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the lift-control-flow pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] Before the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] Before the control-flow-sink pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
[TRACE midenc_hir::pass] After the control-flow-sink pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v53 = arith.constant 0 : i32;
          v9 = arith.neq v7, v53 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v21 = arith.constant 1 : u32;
              v15 = arith.constant 0 : u32;
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              v50 = arith.constant 0 : u32;
              v51 = arith.constant 1 : u32;
              v52 = ub.poison i32 : i32;
              scf.yield v52, v52, v52, v51, v50;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
```
</details>

Furthermore, this last flag can also be combined with the `print-ir-after-modified` flag. This combination will only print IR if *one of the selected passes* modifies the IR.

<details>

<summary>Click here to see the CLI command </summary>



```shell
midenc compile  --emit masm=wasm_fib.masm,masp fib.wasm -Z print-ir-after-pass=canonicalizer,lift-control-flow,control-flow-sink -Z print-ir-after-modified

[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] builtin.world  {
      builtin.component root_ns:root@1.0.0 {
          builtin.module public @wasm_fib {
              public builtin.function @fib(v0: i32) -> i32 {
              ^block4(v0: i32):
                  v2 = arith.constant 0 : i32;
                  v3 = arith.constant 0 : i32;
                  v4 = arith.constant 1 : i32;
                  cf.br ^block6(v4, v0, v3);
              ^block5(v1: i32):
  
              ^block6(v6: i32, v7: i32, v10: i32):
                  v8 = arith.constant 0 : i32;
                  v9 = arith.neq v7, v8 : i1;
                  cf.cond_br v9 ^block8, ^block9;
              ^block7(v5: i32):
  
              ^block8:
                  v11 = arith.constant -1 : i32;
                  v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
                  v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
                  cf.br ^block6(v13, v12, v6);
              ^block9:
                  builtin.ret v10;
              };
  
              builtin.global_variable private @#__stack_pointer : i32 {
                  builtin.ret_imm 1048576;
              };
          };
      };
  };
[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] builtin.component root_ns:root@1.0.0 {
      builtin.module public @wasm_fib {
          public builtin.function @fib(v0: i32) -> i32 {
          ^block4(v0: i32):
              v2 = arith.constant 0 : i32;
              v3 = arith.constant 0 : i32;
              v4 = arith.constant 1 : i32;
              cf.br ^block6(v4, v0, v3);
          ^block5(v1: i32):
  
          ^block6(v6: i32, v7: i32, v10: i32):
              v8 = arith.constant 0 : i32;
              v9 = arith.neq v7, v8 : i1;
              cf.cond_br v9 ^block8, ^block9;
          ^block7(v5: i32):
  
          ^block8:
              v11 = arith.constant -1 : i32;
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              cf.br ^block6(v13, v12, v6);
          ^block9:
              builtin.ret v10;
          };
  
          builtin.global_variable private @#__stack_pointer : i32 {
              builtin.ret_imm 1048576;
          };
      };
  };
[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] builtin.module public @wasm_fib {
      public builtin.function @fib(v0: i32) -> i32 {
      ^block4(v0: i32):
          v2 = arith.constant 0 : i32;
          v3 = arith.constant 0 : i32;
          v4 = arith.constant 1 : i32;
          cf.br ^block6(v4, v0, v3);
      ^block5(v1: i32):
  
      ^block6(v6: i32, v7: i32, v10: i32):
          v8 = arith.constant 0 : i32;
          v9 = arith.neq v7, v8 : i1;
          cf.cond_br v9 ^block8, ^block9;
      ^block7(v5: i32):
  
      ^block8:
          v11 = arith.constant -1 : i32;
          v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
          v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
          cf.br ^block6(v13, v12, v6);
      ^block9:
          builtin.ret v10;
      };
  
      builtin.global_variable private @#__stack_pointer : i32 {
          builtin.ret_imm 1048576;
      };
  };
[TRACE midenc_hir::pass] IR before the pass pipeline
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v2 = arith.constant 0 : i32;
      v3 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v3);
  ^block5(v1: i32):
  
  ^block6(v6: i32, v7: i32, v10: i32):
      v8 = arith.constant 0 : i32;
      v9 = arith.neq v7, v8 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block7(v5: i32):
  
  ^block8:
      v11 = arith.constant -1 : i32;
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the canonicalizer pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      cf.br ^block6(v4, v0, v2);
  ^block6(v6: i32, v7: i32, v10: i32):
      v9 = arith.neq v7, v2 : i1;
      cf.cond_br v9 ^block8, ^block9;
  ^block8:
      v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
      v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
      cf.br ^block6(v13, v12, v6);
  ^block9:
      builtin.ret v10;
  };
[TRACE midenc_hir::pass] After the lift-control-flow pass
[TRACE printer] public builtin.function @fib(v0: i32) -> i32 {
  ^block4(v0: i32):
      v22 = ub.poison i32 : i32;
      v21 = arith.constant 1 : u32;
      v15 = arith.constant 0 : u32;
      v11 = arith.constant -1 : i32;
      v2 = arith.constant 0 : i32;
      v4 = arith.constant 1 : i32;
      v32, v33, v34, v35 = scf.while v4, v0, v2, v22 : i32, i32, i32, i32 {
      ^block6(v6: i32, v7: i32, v10: i32, v27: i32):
          v9 = arith.neq v7, v2 : i1;
          v45, v46, v47, v48, v49 = scf.if v9 : i32, i32, i32, u32, u32 {
          ^block8:
              v12 = arith.add v7, v11 : i32 #[overflow = wrapping];
              v13 = arith.add v10, v6 : i32 #[overflow = wrapping];
              scf.yield v13, v12, v6, v15, v21;
          } else {
          ^block16:
              scf.yield v22, v22, v22, v21, v15;
          };
          v44 = arith.trunc v49 : i1;
          scf.condition v44, v45, v46, v47, v10;
      } do {
      ^block15(v40: i32, v41: i32, v42: i32, v43: i32):
          scf.yield v40, v41, v42, v43;
      };
      builtin.ret v35;
  };
```
</details>



Like we saw in the second example, `control-flow-sink` didn't modify the IR. So even though it is enabled, since `-Z print-ir-after-modifed` was passed, it does not print IR.

# Implementation
For this PR, I used the already existing `Print` struct. Originally, it implemented the `Pass` trait, which enabled `Print` to be added after each `Pass`, just as if it were any other compiler pass. Whilst this approach was straightforward to use for debugging a specific pass, it was not usable via the CLI and also required modifying the code manually. 

So, `Print` got its functionality moved from `Pass` to `PassInstrumentation`. `PassInstrumentation` was an already present trait that allowed arbitray functions to be run before and/or after any pass. However, it was not implemented by any struct *yet* (If I'm not mistaken). The `Pass` trait was actually *removed* from `Print`, since if left implemented, it could lead to cases where IR printing was triggered twice: Once for `PassInstrumentation` and another time for `Pass`.

With this trait now in place, `Print`'s methods could be invoked arbitrarily after every passed. The one thing that the `PassInstrumentation` trait was missing was an `OperationRef`, which actually holds the `Display` trait implementation for each operation.

Another thing that the issue required was the option to only print the IR after passes which modified its structure. That logic came in the form of the [PostPassStatus enum](https://github.com/0xMiden/compiler/pull/494/files#diff-fc753986f4b1d08a320f9ccebf22c13c39e0d2d5dc2da2fdf90f66a6cdddac6eR140-R144), which was added to `PassExecutionState`. Now, every `Pass::run_on_operation` updates said value via the `PassExecutionState::set_post_pass_status` function to indicate whether the Pass modified the IR or not.

To actually enable IR printing, one has to pass one of the flags described in the [#Usage] section. These will get stored in the `UnstableOptions` struct and will later get mapped to a `Print` struct [in the new() method](https://github.com/0xMiden/compiler/pull/494/files#diff-5a568dbaff5328fcab8864fa9ee021f289be89b5cb90595f3750cced2704d71cR81-R90). If no Print struct is created, no print is enabled.
