### PR TITLE
docs: fix invalid URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ emit Miden Assembly for.
 to compile Wasm or HIR modules/programs to Miden Assembly and test them.
 
 > [!TIP] 
-> We've published initial [documentation](https://0xpolygonmiden.github.io/compiler) 
+> We've published initial [documentation](https://0xmiden.github.io/compiler) 
 > in mdBook format for easier reading, also accessible in the `docs` directory. This documentation 
 > covers how to get started with the compiler, provides a couple guides for currently supported
 > use cases, and contains appendices that go into detail about various design aspects of the 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Miden Compiler Docs
 
-This directory contains the sources for the [Miden Compiler Documentation](https://0xpolygonmiden.github.io/compiler/).
+This directory contains the sources for the [Miden Compiler Documentation](https://0xmiden.github.io/compiler/).
 
 All doc files are written in Markdown, and are converted into an online book using the [mdBook](https://github.com/rust-lang/mdBook) utility.
 

--- a/docs/src/design/frontends.md
+++ b/docs/src/design/frontends.md
@@ -5,4 +5,4 @@
 TODO
 
 For the list of the unsupported Wasm core types, instructions and features, see the
-[README](https://github.com/0xPolygonMiden/compiler/frontend-wasm/README.md).
+[README](https://github.com/0xMiden/compiler/blob/next/frontend/wasm/README.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,5 +2,5 @@
 
 These examples are built using `cargo-miden`.
 
-`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
+`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.

--- a/examples/collatz/README.md
+++ b/examples/collatz/README.md
@@ -4,7 +4,7 @@
 
 `collatz` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).
 
-`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
+`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.
 
 ## Compile

--- a/examples/fibonacci/README.md
+++ b/examples/fibonacci/README.md
@@ -4,7 +4,7 @@
 
 `fibonacci` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).
 
-`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
+`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.
 
 ## Compile

--- a/sdk/stdlib-sys/README.md
+++ b/sdk/stdlib-sys/README.md
@@ -4,7 +4,7 @@ The `miden-stdlib-sys` crate provides a `Felt` type that represents field elemen
 
 ## Miden VM instructions
 
-See the full instruction list in the [Miden VM book](https://0xpolygonmiden.github.io/miden-vm/user_docs/assembly/field_operations.html)
+See the full instruction list in the [Miden VM book](https://0xmiden.github.io/miden-vm/user_docs/assembly/field_operations.html)
 
 ### Not yet implemented Miden VM instructions:
 


### PR DESCRIPTION
# Summery

Fix broken URLs in the repository

# Description

1. "0xpolygonmiden.github.io" is invalid. This changed to "0xmiden.github.io" in several files.

2. docs/src/design/frontends.md
"[README] (https://github.com/0xPolygonMiden/compiler/frontend-wasm/README.md)" is invalid. Changed to "[README] (https://github.com/0xMiden/compiler/blob/next/frontend/wasm/README.md)"
