### PR TITLE
docs: update old GitHub and GitHub Pages URLs to new 0xMiden naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ version = "0.0.8"
 rust-version = "1.86"
 authors = ["Miden contributors"]
 description = "An intermediate representation and compiler for Miden Assembly"
-repository = "https://github.com/0xPolygonMiden/compiler"
-homepage = "https://github.com/0xPolygonMiden/compiler"
-documentation = "https://github.com/0xPolygonMiden/compiler"
+repository = "https://github.com/0xMiden/compiler"
+homepage = "https://github.com/0xMiden/compiler"
+documentation = "https://github.com/0xMiden/compiler"
 categories = ["compilers"]
 keywords = ["compiler", "miden"]
 license = "MIT"
@@ -99,7 +99,7 @@ miden-stdlib = { version = "0.13.0", default-features = false, features = [
 ] }
 miden-mast-package = { version = "0.13.0", default-features = false }
 # This is here for convenience if we need to quickly use a git ref of the VM crates
-#miden-assembly = { version = "0.11.0", git = "https://github.com/0xPolygonMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb" }
+#miden-assembly = { version = "0.11.0", git = "https://github.com/0xMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb" }
 midenc-codegen-masm = { version = "0.0.8", path = "codegen/masm" }
 midenc-dialect-arith = { version = "0.0.8", path = "dialects/arith" }
 midenc-dialect-hir = { version = "0.0.8", path = "dialects/hir" }

--- a/codegen/masm/CHANGELOG.md
+++ b/codegen/masm/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - switch to `Package` without rodata,
 - [**breaking**] move `Package` to `miden-package` in the VM repo
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.6...midenc-codegen-masm-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.6...midenc-codegen-masm-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.2...midenc-codegen-masm-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.2...midenc-codegen-masm-v0.0.3) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
@@ -68,12 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 - fix clippy warnings in tests
-- Merge pull request [#290](https://github.com/0xPolygonMiden/compiler/pull/290) from 0xPolygonMiden/greenhat/i263-mem-intrinsics-felts-tests
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#290](https://github.com/0xMiden/compiler/pull/290) from 0xMiden/greenhat/i263-mem-intrinsics-felts-tests
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 - *(codegen)* clippy suggested some improvements
 - *(codegen)* be consistent about the way in which we push to stack
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.1...midenc-codegen-masm-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.1...midenc-codegen-masm-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
@@ -84,9 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use less fragile method for rodata segment init
 
 ### Other
-- Merge pull request [#269](https://github.com/0xPolygonMiden/compiler/pull/269) from 0xPolygonMiden/greenhat/i267-store-load-dw
+- Merge pull request [#269](https://github.com/0xMiden/compiler/pull/269) from 0xMiden/greenhat/i267-store-load-dw
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.0...midenc-codegen-masm-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.0...midenc-codegen-masm-v0.0.1) - 2024-07-18
 
 ### Added
 - *(codegen)* implement lowering for local var ops
@@ -162,28 +162,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(stackify)* update pass, fix various bugs uncovered in testing
 
 ### Other
-- Merge pull request [#238](https://github.com/0xPolygonMiden/compiler/pull/238) from 0xPolygonMiden/greenhat/i230-get-inputs-clk451-assert
-- Merge pull request [#237](https://github.com/0xPolygonMiden/compiler/pull/237) from 0xPolygonMiden/greenhat/emu-print-stack-option
-- Merge pull request [#244](https://github.com/0xPolygonMiden/compiler/pull/244) from 0xPolygonMiden/bitwalker/load-store-reordering
-- Merge pull request [#241](https://github.com/0xPolygonMiden/compiler/pull/241) from 0xPolygonMiden/bitwalker/operand-stack-overflow
+- Merge pull request [#238](https://github.com/0xMiden/compiler/pull/238) from 0xMiden/greenhat/i230-get-inputs-clk451-assert
+- Merge pull request [#237](https://github.com/0xMiden/compiler/pull/237) from 0xMiden/greenhat/emu-print-stack-option
+- Merge pull request [#244](https://github.com/0xMiden/compiler/pull/244) from 0xMiden/bitwalker/load-store-reordering
+- Merge pull request [#241](https://github.com/0xMiden/compiler/pull/241) from 0xMiden/bitwalker/operand-stack-overflow
 - clean up docs and implementation of spills rewrite
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - restore running MASM on the emulator along the VM in integration tests
 - update VM to the commit in next branch after the merge
 - workaround for calling the absolute path functions in the emulator
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
-- Merge pull request [#203](https://github.com/0xPolygonMiden/compiler/pull/203) from 0xPolygonMiden/greenhat/get-inputs-compile-succ
+- Merge pull request [#203](https://github.com/0xMiden/compiler/pull/203) from 0xMiden/greenhat/get-inputs-compile-succ
 - add duplicated stack operands test for the stack operand
 - ensure all relevant crates are prefixed with `midenc-`
 - fix clippy warning
 - draft abi transform test for stdlib blake3 hash function
-- Merge pull request [#182](https://github.com/0xPolygonMiden/compiler/pull/182) from 0xPolygonMiden/bitwalker/emit-stores
-- Merge pull request [#187](https://github.com/0xPolygonMiden/compiler/pull/187) from 0xPolygonMiden/bitwalker/account-compilation-fixes
+- Merge pull request [#182](https://github.com/0xMiden/compiler/pull/182) from 0xMiden/bitwalker/emit-stores
+- Merge pull request [#187](https://github.com/0xMiden/compiler/pull/187) from 0xMiden/bitwalker/account-compilation-fixes
 - check rustfmt on CI, format code with rustfmt
 - run clippy on CI, fix all clippy warnings
-- Merge pull request [#179](https://github.com/0xPolygonMiden/compiler/pull/179) from 0xPolygonMiden/greenhat/inttoptr-for-gv-store
+- Merge pull request [#179](https://github.com/0xMiden/compiler/pull/179) from 0xMiden/greenhat/inttoptr-for-gv-store
 - add explanatory text regarding choice of data structure in codegen entities
 - update expect tests due to formatting changes in assembler
 - handle assembler refactoring changes
@@ -192,7 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update rust toolchain to latest nightly
 - a few minor improvements
 - *(docs)* fix typos
-- Merge pull request [#99](https://github.com/0xPolygonMiden/compiler/pull/99) from 0xPolygonMiden/bitwalker/book
+- Merge pull request [#99](https://github.com/0xMiden/compiler/pull/99) from 0xMiden/bitwalker/book
 - set up mdbook deploy
 - add guides for compiling rust->masm
 - remove unused dependencies

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -138,7 +138,7 @@ impl fmt::Display for MasmComponent {
             // Skip printing the standard library modules and intrinsics
             // modules to focus on the user-defined modules and avoid the
             // stack overflow error when printing large programs
-            // https://github.com/0xPolygonMiden/miden-formatting/issues/4
+            // https://github.com/0xMiden/miden-formatting/issues/4
             let module_name = module.path().path();
             if INTRINSICS_MODULE_NAMES.contains(&module_name.as_ref()) {
                 continue;

--- a/codegen/masm/src/opt/operands/solver.rs
+++ b/codegen/masm/src/opt/operands/solver.rs
@@ -460,7 +460,7 @@ mod tests {
         }
     }
 
-    /// This test reproduces https://github.com/0xPolygonMiden/compiler/issues/200
+    /// This test reproduces https://github.com/0xMiden/compiler/issues/200
     /// where v7 value should be duplicated on the stack
     #[test]
     fn operand_movement_constraint_solver_duplicate() {

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,7 +6,7 @@ multilingual = false
 title = "The Miden compiler"
 
 [output.html]
-git-repository-url = "https://github.com/0xPolygonMiden/compiler"
+git-repository-url = "https://github.com/0xMiden/compiler"
 
 [preprocessor.katex]
 after = ["links"]

--- a/docs/src/appendix/canonabi-adhocabi-mismatch.md
+++ b/docs/src/appendix/canonabi-adhocabi-mismatch.md
@@ -44,7 +44,7 @@ happen for any type that is larger than 8 bytes (i64).
 
 > [!TIP]
 > For a complete list of the transaction kernel functions, in WIT format, see
-> [miden.wit](https://github.com/0xPolygonMiden/compiler/blob/main/tests/rust-apps-wasm/wit-sdk/sdk/wit/miden.wit).
+> [miden.wit](https://github.com/0xMiden/compiler/blob/main/tests/rust-apps-wasm/wit-sdk/sdk/wit/miden.wit).
 
 For most transaction kernel functions, the adapter function can be generated automatically using the
 pattern recognition and adapter functions described below.

--- a/docs/src/appendix/known-limitations.md
+++ b/docs/src/appendix/known-limitations.md
@@ -36,8 +36,8 @@ find a better/more natural representation for `Felt` in WebAssembly.
 ### Function call indirection
 
 - Status: **Unimplemented**
-- Tracking Issue: [#32](https://github.com/0xPolygonMiden/compiler/issues/32)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#32](https://github.com/0xMiden/compiler/issues/32)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 This feature corresponds to `call_indirect` in WebAssembly, and is associated with Rust features
 such as trait objects (which use indirection to call trait methods), and closures. Note that the
@@ -109,8 +109,8 @@ fn main() -> u32 {
 ### Miden SDK
 
 - Status: **Incomplete**
-- Tracking Issue: [#159](https://github.com/0xPolygonMiden/compiler/issues/159) and [#158](https://github.com/0xPolygonMiden/compiler/issues/158)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#159](https://github.com/0xMiden/compiler/issues/159) and [#158](https://github.com/0xMiden/compiler/issues/158)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 The Miden SDK for Rust, is a Rust crate that provides the implementation of native Miden types, as
 well as bindings to the Miden standard library and transaction kernel APIs.
@@ -124,7 +124,7 @@ APIs which are lesser used.
 ### Rust/Miden FFI (foreign function interface) and interop
 
 - Status: **Internal Use Only**
-- Tracking Issue: [#304](https://github.com/0xPolygonMiden/compiler/issues/304)
+- Tracking Issue: [#304](https://github.com/0xMiden/compiler/issues/304)
 - Release Milestone: TBD
 
 While the compiler has functionality to link against native Miden Assembly libraries, binding
@@ -150,8 +150,8 @@ and Miden packaging. Once present, we can open up the FFI for general use.
 ### Dynamic procedure invocation
 
 - Status: **Unimplemented**
-- Tracking Issue: [#32](https://github.com/0xPolygonMiden/compiler/issues/32)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#32](https://github.com/0xMiden/compiler/issues/32)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 This is a dependency of [Function Call Indirection](#function-call-indirection) described above,
 and is the mechanism by which we can perform indirect calls in Miden. In order to implement support
@@ -175,8 +175,8 @@ which has its "address" taken, and use the hash of the stub in place of the actu
 ### Cross-context procedure invocation
 
 - Status: **Unimplemented**
-- Tracking Issue: [#303](https://github.com/0xPolygonMiden/compiler/issues/303)
-- Release Milestone: [Beta 2](https://github.com/0xPolygonMiden/compiler/milestone/5)
+- Tracking Issue: [#303](https://github.com/0xMiden/compiler/issues/303)
+- Release Milestone: [Beta 2](https://github.com/0xMiden/compiler/milestone/5)
 
 This is required in order to support representing Miden accounts and note scripts in Rust, and
 compilation to Miden Assembly.
@@ -213,8 +213,8 @@ subfeatures being implemented first.
 ### Package format
 
 - Status: **Experimental**
-- Tracking Issue: [#121](https://github.com/0xPolygonMiden/compiler/issues/121)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#121](https://github.com/0xMiden/compiler/issues/121)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 This feature represents the ability to compile and distribute a single artifact that contains
 the compiled MAST, and all required and optional metadata to make linking against, and executing

--- a/docs/src/design/frontends.md
+++ b/docs/src/design/frontends.md
@@ -5,4 +5,4 @@
 TODO
 
 For the list of the unsupported Wasm core types, instructions and features, see the
-[README](https://github.com/0xPolygonMiden/compiler/frontend-wasm/README.md).
+[README](https://github.com/0xMiden/compiler/frontend-wasm/README.md).

--- a/docs/src/guides/develop_miden_in_rust.md
+++ b/docs/src/guides/develop_miden_in_rust.md
@@ -2,7 +2,7 @@
 
 This chapter will walk through how to develop Miden programs in Rust using the standard library
 provided by the `miden-stdlib-sys` crate (see the
-[README](https://github.com/0xPolygonMiden/compiler/blob/main/sdk/stdlib-sys/README.md).
+[README](https://github.com/0xMiden/compiler/blob/main/sdk/stdlib-sys/README.md).
 
 ## Getting started
 

--- a/docs/src/usage/cargo-miden.md
+++ b/docs/src/usage/cargo-miden.md
@@ -88,4 +88,4 @@ See `midenc run --help` for the inputs file format.
 
 ## Examples
 
-Check out the [examples](https://github.com/0xPolygonMiden/compiler/tree/next/examples) for some `cargo-miden` project examples.
+Check out the [examples](https://github.com/0xMiden/compiler/tree/next/examples) for some `cargo-miden` project examples.

--- a/examples/collatz/Cargo.toml
+++ b/examples/collatz/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Miden SDK consists of a stdlib (intrinsic functions for VM ops, stdlib functions and types)
 # and transaction kernel API for the Miden rollup
-#miden = { git = "https://github.com/0xPolygonMiden/compiler" }
+#miden = { git = "https://github.com/0xMiden/compiler" }
 
 
 [profile.release]

--- a/examples/collatz/README.md
+++ b/examples/collatz/README.md
@@ -2,7 +2,7 @@
 
 ## Useful commands
 
-`collatz` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).
+`collatz` is built using the [Miden compiler](https://github.com/0xMiden/compiler).
 
 `cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.

--- a/examples/fibonacci/Cargo.toml
+++ b/examples/fibonacci/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Miden SDK consists of a stdlib (intrinsic functions for VM ops, stdlib functions and types)
 # and transaction kernel API for the Miden rollup
-#miden = { git = "https://github.com/0xPolygonMiden/compiler" }
+#miden = { git = "https://github.com/0xMiden/compiler" }
 
 
 [profile.release]

--- a/examples/fibonacci/README.md
+++ b/examples/fibonacci/README.md
@@ -2,7 +2,7 @@
 
 ## Useful commands
 
-`fibonacci` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).
+`fibonacci` is built using the [Miden compiler](https://github.com/0xMiden/compiler).
 
 `cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.

--- a/examples/is-prime/Cargo.toml
+++ b/examples/is-prime/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Miden SDK consists of a stdlib (intrinsic functions for VM ops, stdlib functions and types)
 # and transaction kernel API for the Miden rollup
-#miden = { git = "https://github.com/0xPolygonMiden/compiler" }
+#miden = { git = "https://github.com/0xMiden/compiler" }
 
 
 [profile.release]

--- a/frontend/wasm/CHANGELOG.md
+++ b/frontend/wasm/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(frontend)* rework handling of symbols in frontend
 - Move the new Wasm frontend to `frontend/wasm` and remove the old
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-frontend-wasm-v0.0.6...midenc-frontend-wasm-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-frontend-wasm-v0.0.6...midenc-frontend-wasm-v0.0.7) - 2024-09-17
 
 ### Other
 - *(rustfmt)* disable wrap_comments due to broken behavior
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-frontend-wasm-v0.0.1...midenc-frontend-wasm-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-frontend-wasm-v0.0.1...midenc-frontend-wasm-v0.0.2) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
@@ -39,10 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(frontend-wasm)* incorrect types applied to certain primops
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 - update expect tests due to codegen changes
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-frontend-wasm-v0.0.0...midenc-frontend-wasm-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-frontend-wasm-v0.0.0...midenc-frontend-wasm-v0.0.1) - 2024-07-18
 
 ### Added
 - implement support for wasm typed select
@@ -124,24 +124,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pass SourceSpan in translate_operator
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - extend and update integration tests
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
 - rename `miden-prelude` to `miden-stdlib-sys` in SDK
 - ensure all relevant crates are prefixed with `midenc-`
-- Merge pull request [#187](https://github.com/0xPolygonMiden/compiler/pull/187) from 0xPolygonMiden/bitwalker/account-compilation-fixes
+- Merge pull request [#187](https://github.com/0xMiden/compiler/pull/187) from 0xMiden/bitwalker/account-compilation-fixes
 - check rustfmt on CI, format code with rustfmt
 - run clippy on CI, fix all clippy warnings
 - use midenc driver for non-cargo-based fixtures in
 - use midenc driver to compile cargo-based fixtures
 - handle assembler refactoring changes
-- Merge pull request [#170](https://github.com/0xPolygonMiden/compiler/pull/170) from 0xPolygonMiden/greenhat/i159-tx-kernel-func-11apr
-- Merge pull request [#155](https://github.com/0xPolygonMiden/compiler/pull/155) from 0xPolygonMiden/greenhat/i144-stdlib
+- Merge pull request [#170](https://github.com/0xMiden/compiler/pull/170) from 0xMiden/greenhat/i159-tx-kernel-func-11apr
+- Merge pull request [#155](https://github.com/0xMiden/compiler/pull/155) from 0xMiden/greenhat/i144-stdlib
 - remove repetitive words
-- Merge pull request [#151](https://github.com/0xPolygonMiden/compiler/pull/151) from 0xPolygonMiden/greenhat/i144-native-felt
-- Merge pull request [#140](https://github.com/0xPolygonMiden/compiler/pull/140) from 0xPolygonMiden/greenhat/i138-rust-miden-sdk
+- Merge pull request [#151](https://github.com/0xMiden/compiler/pull/151) from 0xMiden/greenhat/i144-native-felt
+- Merge pull request [#140](https://github.com/0xMiden/compiler/pull/140) from 0xMiden/greenhat/i138-rust-miden-sdk
 - remove `dylib` from `crate-type` in Miden SDK crates
 - do not inline `miden_sdk_function_type` function
 - add `FunctionType::abi` and ditch redundant `*FunctionType`
@@ -162,7 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update frontend expect tests with format changes
 - add formatter config, format most crates
 - update rust toolchain to latest nightly
-- Merge pull request [#100](https://github.com/0xPolygonMiden/compiler/pull/100) from 0xPolygonMiden/greenhat/i89-translate-wasm-cm
+- Merge pull request [#100](https://github.com/0xMiden/compiler/pull/100) from 0xMiden/greenhat/i89-translate-wasm-cm
 - move `LiftedFunctionType` to `miden-hir-type` crate
 - use `digest` name for MAST root hashes;
 - remove `MastRootHash` in favor of `RpoDigest`;
@@ -190,7 +190,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - lazy IR compilation in integration tests
 - move module specific code to separate module in frontend-wasm
 - remove unused dependencies
-- Merge pull request [#61](https://github.com/0xPolygonMiden/compiler/pull/61) from 0xPolygonMiden/greenhat/cargo-ext-i60
+- Merge pull request [#61](https://github.com/0xMiden/compiler/pull/61) from 0xMiden/greenhat/cargo-ext-i60
 - make `WasmTranslationConfig::module_name_fallback` non-optional
 - switch from emiting MASM in CodegenStage, and switch to output folder in cargo extension
 - remove `miden_frontend_wasm::translate_program`

--- a/frontend/wasm/src/component/lift_exports.rs
+++ b/frontend/wasm/src/component/lift_exports.rs
@@ -84,7 +84,7 @@ pub fn generate_export_lifting_function(
         .collect();
 
     // NOTE: handle CC lifting/lowering for non-scalar types
-    // see https://github.com/0xPolygonMiden/compiler/issues/369
+    // see https://github.com/0xMiden/compiler/issues/369
 
     let exec = fb
         .exec(core_export_func_ref, core_export_func_sig, args, span)

--- a/frontend/wasm/src/component/lower_imports.rs
+++ b/frontend/wasm/src/component/lower_imports.rs
@@ -90,7 +90,7 @@ pub fn generate_import_lowering_function(
         .expect("failed to define the import function");
 
     // NOTE: handle CC lifting/lowering for non-scalar types
-    // see https://github.com/0xPolygonMiden/compiler/issues/369
+    // see https://github.com/0xMiden/compiler/issues/369
 
     let call = fb
         .call(import_func_ref, core_func_sig.clone(), args.to_vec(), span)

--- a/frontend/wasm/src/module/build_ir.rs
+++ b/frontend/wasm/src/module/build_ir.rs
@@ -31,7 +31,7 @@ use crate::{
 ///
 /// This is a temporary solution until we compile an account code as Wasm
 /// component. To be able to do it we need wit-bindgen type re-mapping implemented first (see
-/// https://github.com/0xPolygonMiden/compiler/issues/116)
+/// https://github.com/0xMiden/compiler/issues/116)
 pub fn translate_module_as_component(
     wasm: &[u8],
     config: &WasmTranslationConfig,

--- a/hir-analysis/CHANGELOG.md
+++ b/hir-analysis/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - normalize use of fxhash-based hash maps
 - rename Call IR op to Exec
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.6...midenc-hir-analysis-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.6...midenc-hir-analysis-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -33,17 +33,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.2...midenc-hir-analysis-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.2...midenc-hir-analysis-v0.0.3) - 2024-08-30
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.1...midenc-hir-analysis-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.1...midenc-hir-analysis-v0.0.2) - 2024-08-28
 
 ### Fixed
 - *(frontend-wasm)* reserve memory allocated for use by rust
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.0...midenc-hir-analysis-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.0...midenc-hir-analysis-v0.0.1) - 2024-07-18
 
 ### Added
 - *(analysis)* implement iterated dominance frontier queries
@@ -73,10 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hir and hir-analysis tests
 
 ### Other
-- Merge pull request [#244](https://github.com/0xPolygonMiden/compiler/pull/244) from 0xPolygonMiden/bitwalker/load-store-reordering
+- Merge pull request [#244](https://github.com/0xMiden/compiler/pull/244) from 0xMiden/bitwalker/load-store-reordering
 - clean up docs and implementation of spills rewrite
 - *(analysis)* improve dominance frontier docs
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates

--- a/hir-macros/CHANGELOG.md
+++ b/hir-macros/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-macros-v0.0.1...midenc-hir-macros-v0.0.2) - 2024-08-16
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-macros-v0.0.1...midenc-hir-macros-v0.0.2) - 2024-08-16
 
 ### Fixed
 - *(cli)* improve help output, hide plumbing flags
@@ -47,12 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - unify diagnostics infa between compiler, assembler, vm
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-macros-v0.0.0...midenc-hir-macros-v0.0.1) - 2024-07-25
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-macros-v0.0.0...midenc-hir-macros-v0.0.1) - 2024-07-25
 
 ### Other
 - enable publish for `midenc-hir-macros` crate and restore
 - manually bump `midenc-hir-macros` version after release-plz
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - ensure all relevant crates are prefixed with `midenc-`
 - add formatter config, format most crates

--- a/hir-symbol/CHANGELOG.md
+++ b/hir-symbol/CHANGELOG.md
@@ -31,12 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - clean up unused deps
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-symbol-v0.0.1...midenc-hir-symbol-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-symbol-v0.0.1...midenc-hir-symbol-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-symbol-v0.0.0...midenc-hir-symbol-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-symbol-v0.0.0...midenc-hir-symbol-v0.0.1) - 2024-07-18
 
 ### Added
 - add attributes to the ir
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add hir-symbol crate
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates

--- a/hir-transform/CHANGELOG.md
+++ b/hir-transform/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - normalize use of fxhash-based hash maps
 - rename Call IR op to Exec
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-transform-v0.0.6...midenc-hir-transform-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.0.6...midenc-hir-transform-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-transform-v0.0.1...midenc-hir-transform-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.0.1...midenc-hir-transform-v0.0.2) - 2024-08-28
 
 ### Fixed
 - inoperative --print-ir-after-*, add --print-cfg-after-*
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add additional tracing to treeify pass
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-transform-v0.0.0...midenc-hir-transform-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.0.0...midenc-hir-transform-v0.0.1) - 2024-07-18
 
 ### Added
 - enable spills transformation in default pipeline
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - clean up docs and implementation of spills rewrite
 - transform tests, fixes
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates

--- a/hir-type/CHANGELOG.md
+++ b/hir-type/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update rust toolchain, clean up deps
 - implement hir dialect ops, flesh out remaining core ir infra
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.6...midenc-hir-type-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.6...midenc-hir-type-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -27,20 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.2...midenc-hir-type-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.2...midenc-hir-type-v0.0.3) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.1...midenc-hir-type-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.1...midenc-hir-type-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.0...midenc-hir-type-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.0...midenc-hir-type-v0.0.1) - 2024-07-18
 
 ### Added
 - draft Miden ABI function types encoding and retrieval
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rewrite incorrect type layout code
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add a description for miden-hir-type crate
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add Wasm component translation support to the integration tests;
 - add formatter config, format most crates
 - update rust toolchain to latest nightly
-- Merge pull request [#100](https://github.com/0xPolygonMiden/compiler/pull/100) from 0xPolygonMiden/greenhat/i89-translate-wasm-cm
+- Merge pull request [#100](https://github.com/0xMiden/compiler/pull/100) from 0xMiden/greenhat/i89-translate-wasm-cm
 - move `LiftedFunctionType` to `miden-hir-type` crate
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/hir/CHANGELOG.md
+++ b/hir/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add note script compilation test;
 - remove digest-in-function-name encoding and `MidenAbiImport::digest`,
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-v0.0.6...midenc-hir-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.0.6...midenc-hir-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - clean up unused deps
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-v0.0.1...midenc-hir-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.0.1...midenc-hir-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
@@ -85,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-v0.0.0...midenc-hir-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.0.0...midenc-hir-v0.0.1) - 2024-07-18
 
 ### Added
 - implement memset, memcpy, mem_grow, mem_size, and bitcast ops
@@ -191,10 +191,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hir and hir-analysis tests
 
 ### Other
-- Merge pull request [#237](https://github.com/0xPolygonMiden/compiler/pull/237) from 0xPolygonMiden/greenhat/emu-print-stack-option
+- Merge pull request [#237](https://github.com/0xMiden/compiler/pull/237) from 0xMiden/greenhat/emu-print-stack-option
 - use `BTreeSet` for "dirty" memory addresses(ordered) in the emulator
 - add `Emulator::print_trace` option to print the current stack
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
 - update the Miden VM deps to the `ddf536c` commit with `if.true` empty
@@ -208,7 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove formatter
 - draft a layout for intrinsics semantic tests,
 - since all the Miden ABI transformation happens in the frontend
-- Merge pull request [#140](https://github.com/0xPolygonMiden/compiler/pull/140) from 0xPolygonMiden/greenhat/i138-rust-miden-sdk
+- Merge pull request [#140](https://github.com/0xMiden/compiler/pull/140) from 0xMiden/greenhat/i138-rust-miden-sdk
 - add `FunctionType::abi` and ditch redundant `*FunctionType`
 - skip printing the import name for `MidenAbiImport` component import
 - intern module name and all names used in the module
@@ -218,13 +218,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add Wasm component translation support to the integration tests;
 - add formatter config, format most crates
 - update rust toolchain to latest nightly
-- Merge pull request [#100](https://github.com/0xPolygonMiden/compiler/pull/100) from 0xPolygonMiden/greenhat/i89-translate-wasm-cm
+- Merge pull request [#100](https://github.com/0xMiden/compiler/pull/100) from 0xMiden/greenhat/i89-translate-wasm-cm
 - move `LiftedFunctionType` to `miden-hir-type` crate
 - use `digest` name for MAST root hashes;
 - remove `MastRootHash` in favor of `RpoDigest`;
 - move `MastRootHash` and `Interface*` types to their modules;
 - add missing doc comments
-- Merge pull request [#99](https://github.com/0xPolygonMiden/compiler/pull/99) from 0xPolygonMiden/bitwalker/book
+- Merge pull request [#99](https://github.com/0xMiden/compiler/pull/99) from 0xMiden/bitwalker/book
 - set up mdbook deploy
 - add guides for compiling rust->masm
 - remove unused dependencies

--- a/hir/src/derive.rs
+++ b/hir/src/derive.rs
@@ -191,7 +191,7 @@ mod tests {
         ));
     }
 
-    #[ignore = "until https://github.com/0xPolygonMiden/compiler/issues/378 is fixed"]
+    #[ignore = "until https://github.com/0xMiden/compiler/issues/378 is fixed"]
     #[test]
     #[should_panic = "expected 'u32', got 'i64'"]
     fn derived_op_verifier_test() {

--- a/midenc-compile/CHANGELOG.md
+++ b/midenc-compile/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-compile-v0.0.0...midenc-compile-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-compile-v0.0.0...midenc-compile-v0.0.1) - 2024-07-18
 
 ### Added
 - enable spills transformation in default pipeline
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - properly handle emitting final artifacts in midenc-compile
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - ensure all relevant crates are prefixed with `midenc-`
 - run clippy on CI, fix all clippy warnings
@@ -91,12 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use midenc driver to compile cargo-based fixtures
 - handle assembler refactoring changes
 - add formatter config, format most crates
-- Merge pull request [#100](https://github.com/0xPolygonMiden/compiler/pull/100) from 0xPolygonMiden/greenhat/i89-translate-wasm-cm
+- Merge pull request [#100](https://github.com/0xMiden/compiler/pull/100) from 0xMiden/greenhat/i89-translate-wasm-cm
 - a few minor improvements
 - *(docs)* fix typos
 - set up mdbook deploy
 - add guides for compiling rust->masm
-- Merge pull request [#61](https://github.com/0xPolygonMiden/compiler/pull/61) from 0xPolygonMiden/greenhat/cargo-ext-i60
+- Merge pull request [#61](https://github.com/0xMiden/compiler/pull/61) from 0xMiden/greenhat/cargo-ext-i60
 - make `WasmTranslationConfig::module_name_fallback` non-optional
 - switch from emiting MASM in CodegenStage, and switch to output folder in cargo extension
 - split up driver components into separate crates

--- a/midenc-compile/src/stages/cross_ctx/lift_exports.rs
+++ b/midenc-compile/src/stages/cross_ctx/lift_exports.rs
@@ -143,7 +143,7 @@ fn generate_lifting_function(
     }
     let span = export.function.function.span();
     // NOTE: handle lifting/lowering for non-scalar types
-    // see https://github.com/0xPolygonMiden/compiler/pull/357
+    // see https://github.com/0xMiden/compiler/pull/357
     let call = builder.ins().exec(export.function, &params, span);
     // dbg!(&sig);
     let result = builder.first_result(call);

--- a/midenc-debug/CHANGELOG.md
+++ b/midenc-debug/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - switch to `Package` without rodata,
 - [**breaking**] move `Package` to `miden-package` in the VM repo
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.6...midenc-debug-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.0.6...midenc-debug-v0.0.7) - 2024-09-17
 
 ### Other
 - update rust toolchain
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - revisit/update documentation and guides
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.1...midenc-debug-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.0.1...midenc-debug-v0.0.2) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
@@ -55,13 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - fix clippy warnings in tests
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.0...midenc-debug-v0.0.1) - 2024-08-16
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.0.0...midenc-debug-v0.0.1) - 2024-08-16
 
 ### Other
 - set `midenc-debug` version to `0.0.0` to be in sync with crates.io
 - clean up naming in midenc-debug
 - rename midenc-runner to midenc-debug
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - a few minor improvements
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/midenc-driver/CHANGELOG.md
+++ b/midenc-driver/CHANGELOG.md
@@ -22,13 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-driver-v0.0.0...midenc-driver-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-driver-v0.0.0...midenc-driver-v0.0.1) - 2024-07-18
 
 ### Added
 - implement compiler driver, update midenc
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - ensure all relevant crates are prefixed with `midenc-`
 - add formatter config, format most crates

--- a/midenc-session/CHANGELOG.md
+++ b/midenc-session/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [**breaking**] move `Package` to `miden-package` in the VM repo
 - add note script compilation test;
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.6...midenc-session-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.6...midenc-session-v0.0.7) - 2024-09-17
 
 ### Other
 - update rust toolchain
@@ -42,12 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.4](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.3...midenc-session-v0.0.4) - 2024-08-30
+## [0.0.4](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.3...midenc-session-v0.0.4) - 2024-08-30
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.2...midenc-session-v0.0.3) - 2024-08-28
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.2...midenc-session-v0.0.3) - 2024-08-28
 
 ### Added
 - implement packaging prototype
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.1...midenc-session-v0.0.2) - 2024-08-16
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.1...midenc-session-v0.0.2) - 2024-08-16
 
 ### Added
 - *(codegen)* propagate source spans from hir to masm
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - unify diagnostics infa between compiler, assembler, vm
 - unify compilation, rodata init, test harness
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.0...midenc-session-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.0...midenc-session-v0.0.1) - 2024-07-18
 
 ### Added
 - implement compiler driver, update midenc
@@ -98,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - properly handle emitting final artifacts in midenc-compile
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
 - ensure all relevant crates are prefixed with `midenc-`
@@ -110,7 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - set up mdbook deploy
 - add guides for compiling rust->masm
 - remove unused dependencies
-- Merge pull request [#61](https://github.com/0xPolygonMiden/compiler/pull/61) from 0xPolygonMiden/greenhat/cargo-ext-i60
+- Merge pull request [#61](https://github.com/0xMiden/compiler/pull/61) from 0xMiden/greenhat/cargo-ext-i60
 - add mdbook skeleton
 - clear up clippy warnings
 - split up driver components into separate crates

--- a/midenc/CHANGELOG.md
+++ b/midenc/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - update Cargo.lock dependencies
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-v0.0.6...midenc-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-v0.0.6...midenc-v0.0.7) - 2024-09-17
 
 ### Other
 - update Cargo.lock dependencies
@@ -21,19 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-v0.0.1...midenc-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-v0.0.1...midenc-v0.0.2) - 2024-08-30
 
 ### Other
 - update Cargo.lock dependencies
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-v0.0.0...midenc-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-v0.0.0...midenc-v0.0.1) - 2024-07-18
 
 ### Added
 - implement compiler driver, update midenc
 
 ### Other
 - update deps and min rust version
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - run clippy on CI, fix all clippy warnings
 - add formatter config, format most crates

--- a/sdk/alloc/CHANGELOG.md
+++ b/sdk/alloc/CHANGELOG.md
@@ -19,19 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-alloc-v0.0.1...miden-sdk-alloc-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-sdk-alloc-v0.0.1...miden-sdk-alloc-v0.0.2) - 2024-08-30
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-alloc-v0.0.0...miden-sdk-alloc-v0.0.1) - 2024-08-28
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-sdk-alloc-v0.0.0...miden-sdk-alloc-v0.0.1) - 2024-08-28
 
 ### Added
 - *(sdk)* introduce miden-sdk-alloc
 
 ### Other
 - set `miden-sdk-alloc` version to `0.0.0` to be in sync with
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - a few minor improvements
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/sdk/base-sys/CHANGELOG.md
+++ b/sdk/base-sys/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [**breaking**] revamp Miden SDK API and expose some modules;
 - remove digest-in-function-name encoding and `MidenAbiImport::digest`,
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.6...miden-base-sys-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.6...miden-base-sys-v0.0.7) - 2024-09-17
 
 ### Other
 - remove `miden-assembly` dependency from `sdk/base-sys` for `bindings` feature
@@ -35,12 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.2...miden-base-sys-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.2...miden-base-sys-v0.0.3) - 2024-08-30
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.1...miden-base-sys-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.1...miden-base-sys-v0.0.2) - 2024-08-28
 
 ### Fixed
 - *(sdk)* be more explicit about alignment of felt/word types
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.0...miden-base-sys-v0.0.1) - 2024-08-16
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.0...miden-base-sys-v0.0.1) - 2024-08-16
 
 ### Fixed
 - fix the build after VM v0.10.3 update
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - delete `miden-tx-kernel-sys` crate and move the code to `miden-base-sys`
 - build the MASL for the tx kernel stubs in `build.rs` and
 - rename `midenc-tx-kernel` to `miden-base-sys` and move it to
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - a few minor improvements
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/sdk/base-sys/src/bindings/note.rs
+++ b/sdk/base-sys/src/bindings/note.rs
@@ -25,7 +25,7 @@ pub fn get_inputs() -> Vec<Felt> {
         // and by 4 again we get the word address).
         let ptr = (inputs.as_mut_ptr() as usize) / 16;
         // The MASM for this function is here:
-        // https://github.com/0xPolygonMiden/miden-base/blob/3cbe8d59dcf4ccc9c380b7c8417ac6178fc6b86a/miden-lib/asm/miden/note.masm#L69-L102
+        // https://github.com/0xMiden/miden-base/blob/3cbe8d59dcf4ccc9c380b7c8417ac6178fc6b86a/miden-lib/asm/miden/note.masm#L69-L102
         // #! Writes the inputs of the currently execute note into memory starting at the specified
         // address. #!
         // #! Inputs: [dest_ptr]

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -50,12 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-v0.0.1...miden-sdk-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-sdk-v0.0.1...miden-sdk-v0.0.2) - 2024-08-30
 
 ### Other
 - updated the following local packages: miden-base-sys, miden-stdlib-sys, miden-sdk-alloc
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-v0.0.0...miden-sdk-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-sdk-v0.0.0...miden-sdk-v0.0.1) - 2024-07-18
 
 ### Added
 - introduce TransformStrategy and add the "return-via-pointer"

--- a/sdk/stdlib-sys/CHANGELOG.md
+++ b/sdk/stdlib-sys/CHANGELOG.md
@@ -27,20 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/miden-stdlib-sys-v0.0.2...miden-stdlib-sys-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.0.2...miden-stdlib-sys-v0.0.3) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-stdlib-sys-v0.0.1...miden-stdlib-sys-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.0.1...miden-stdlib-sys-v0.0.2) - 2024-08-28
 
 ### Fixed
 - *(sdk)* be more explicit about alignment of felt/word types
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-stdlib-sys-v0.0.0...miden-stdlib-sys-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.0.0...miden-stdlib-sys-v0.0.1) - 2024-07-18
 
 ### Fixed
 - felt representation mismatch between rust and miden

--- a/sdk/stdlib-sys/src/intrinsics/felt.rs
+++ b/sdk/stdlib-sys/src/intrinsics/felt.rs
@@ -74,7 +74,7 @@ macro_rules! felt {
         const VALUE: u64 = $value as u64;
         // assert!(VALUE <= Felt::M, "Invalid Felt value, must be >= 0 and <= 2^64 - 2^32 + 1");
         // Temporarily switch to `from_u32` to use `bitcast` and avoid checks.
-        // see https://github.com/0xPolygonMiden/compiler/issues/361
+        // see https://github.com/0xMiden/compiler/issues/361
         assert!(VALUE <= u32::MAX as u64, "Invalid value, must be >= 0 and <= 2^32");
         const VALUE_U32: u32 = $value as u32;
         Felt::from_u32(VALUE_U32)

--- a/sdk/stdlib-sys/src/stdlib/mem.rs
+++ b/sdk/stdlib-sys/src/stdlib/mem.rs
@@ -119,7 +119,7 @@ pub fn pipe_double_words_to_memory(num_words: Felt) -> (Word, Vec<Felt>) {
             ret_area.as_mut_ptr() as *mut Felt,
         );
         let Result { b, .. } = ret_area.assume_init();
-        // B (second) is the hash (see https://github.com/0xPolygonMiden/miden-vm/blob/3a957f7c90176914bda2139f74bff9e5700d59ac/stdlib/asm/crypto/hashes/native.masm#L1-L16 )
+        // B (second) is the hash (see https://github.com/0xMiden/miden-vm/blob/3a957f7c90176914bda2139f74bff9e5700d59ac/stdlib/asm/crypto/hashes/native.masm#L1-L16 )
         (b, buf)
     }
 }

--- a/tests/integration/src/rust_masm_tests/instructions.rs
+++ b/tests/integration/src/rust_masm_tests/instructions.rs
@@ -205,7 +205,7 @@ test_unary_op!(neg, -, i64, (i64::MIN + 1)..=i64::MAX);
 
 // Comparison ops
 
-// enable when https://github.com/0xPolygonMiden/compiler/issues/56 is fixed
+// enable when https://github.com/0xMiden/compiler/issues/56 is fixed
 test_func_two_arg!(min, core::cmp::min, i32, i32, i32);
 test_func_two_arg!(min, core::cmp::min, u32, u32, u32);
 test_func_two_arg!(min, core::cmp::min, u8, u8, u8);

--- a/tests/integration/src/rust_masm_tests/intrinsics.rs
+++ b/tests/integration/src/rust_masm_tests/intrinsics.rs
@@ -94,7 +94,7 @@ test_bool_op_total!(eq, ==);
 
 // TODO: Comparison operators are not defined for Felt, so we cannot compile a Rust equivalent for
 // the semantic test
-// see https://github.com/0xPolygonMiden/compiler/issues/175
+// see https://github.com/0xMiden/compiler/issues/175
 // test_bool_op_total!(gt, >);
 // test_bool_op_total!(lt, <);
 // test_bool_op_total!(ge, >=);

--- a/tests/integration/src/rust_masm_tests/mod.rs
+++ b/tests/integration/src/rust_masm_tests/mod.rs
@@ -30,7 +30,7 @@ where
     let output = exec.execute_into(&package.unwrap_program(), session);
     std::dbg!(&output);
     prop_assert_eq!(rust_out.clone(), output, "VM output mismatch");
-    // TODO: Uncomment after https://github.com/0xPolygonMiden/compiler/issues/228 is fixed
+    // TODO: Uncomment after https://github.com/0xMiden/compiler/issues/228 is fixed
     // let emul_out: T = (*execute_emulator(ir_program.clone(), args).first().unwrap()).into();
     // prop_assert_eq!(rust_out, emul_out, "Emulator output mismatch");
     Ok(())

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[test]
-#[ignore = "until https://github.com/0xPolygonMiden/compiler/issues/439 is fixed"]
+#[ignore = "until https://github.com/0xMiden/compiler/issues/439 is fixed"]
 fn account() {
     let artifact_name = "miden_sdk_account_test";
     let mut test = CompilerTest::rust_source_cargo_lib(

--- a/tests/integration/src/rust_masm_tests/types.rs
+++ b/tests/integration/src/rust_masm_tests/types.rs
@@ -7,7 +7,7 @@ fn test_enum() {
     let mut test = CompilerTest::rust_source_program(include_str!("types_src/enum.rs"));
     test.expect_wasm(expect_file!["../../expected/types/enum.wat"]);
     test.expect_ir(expect_file!["../../expected/types/enum.hir"]);
-    // uncomment when https://github.com/0xPolygonMiden/compiler/issues/281 is fixed
+    // uncomment when https://github.com/0xMiden/compiler/issues/281 is fixed
     // test.expect_masm(expect_file!["../../expected/types/enum.masm"]);
 }
 

--- a/tools/cargo-miden/CHANGELOG.md
+++ b/tools/cargo-miden/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - skip Miden SDK function generation in bindings.rs
 - add check for the proper artifact file extension in the cargo-miden test
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/cargo-miden-v0.0.6...cargo-miden-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.0.6...cargo-miden-v0.0.7) - 2024-09-17
 
 ### Fixed
 - switch cargo-miden to v0.4.0 of the new project template with
@@ -55,12 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - clean up unused deps
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/cargo-miden-v0.0.1...cargo-miden-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.0.1...cargo-miden-v0.0.2) - 2024-08-30
 
 ### Other
 - update Cargo.lock dependencies
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/cargo-miden-v0.0.0...cargo-miden-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.0.0...cargo-miden-v0.0.1) - 2024-07-18
 
 ### Added
 - *(cargo)* allow configuring compiler version for generated projects
@@ -70,19 +70,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rename `compile` cargo extension command to `build`; imports cleanup;
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
 - rename `miden-prelude` to `miden-stdlib-sys` in SDK
 - run clippy on CI, fix all clippy warnings
-- Merge pull request [#164](https://github.com/0xPolygonMiden/compiler/pull/164) from 0xPolygonMiden/greenhat/i163-cargo-ext-for-alpha
+- Merge pull request [#164](https://github.com/0xMiden/compiler/pull/164) from 0xMiden/greenhat/i163-cargo-ext-for-alpha
 - remove repetitive words
 - add formatter config, format most crates
 - a few minor improvements
 - sync cargo-component crate version to v0.6 in test apps
 - set up mdbook deploy
 - add guides for compiling rust->masm
-- Merge pull request [#61](https://github.com/0xPolygonMiden/compiler/pull/61) from 0xPolygonMiden/greenhat/cargo-ext-i60
+- Merge pull request [#61](https://github.com/0xMiden/compiler/pull/61) from 0xMiden/greenhat/cargo-ext-i60
 - make `WasmTranslationConfig::module_name_fallback` non-optional
 - remove `path-absolutize` dependency
 - remove `next_display_order` option in `Command`

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -148,7 +148,7 @@ impl NewCommand {
                     None => ProjectTemplate::default().to_string(),
                 };
                 TemplatePath {
-                    git: Some("https://github.com/0xPolygonMiden/rust-templates".into()),
+                    git: Some("https://github.com/0xMiden/rust-templates".into()),
                     tag: Some(TEMPLATES_REPO_TAG.into()),
                     auto_path: Some(project_kind_str),
                     ..Default::default()

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -173,7 +173,7 @@ where
                 package.metadata.section.bindings.skip = vec![
                     // Our function names can clash with user's function names leading to
                     // skipping the bindings generation of the user's function names
-                    // see https://github.com/0xPolygonMiden/compiler/issues/341
+                    // see https://github.com/0xMiden/compiler/issues/341
                     "remove-asset",
                     "create-note",
                     "heap-base",


### PR DESCRIPTION
This PR updates outdated URLs across all Markdown files to reflect the repository renaming from `0xPolygonMiden` to `0xMiden`.  