### PR TITLE
ci: switch release-plz action to new repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/next' }}
       - name: Publish
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
         with:
           # Only run the `release` command that publishes any unpublished crates.
           command: release


### PR DESCRIPTION
Hi devs!
Switch workflow to the new official repo (`release-plz/action`).
Upstream moved from `MarcoIeni/release-plz-action`; the old path is now
archived and will no longer receive updates or security fixes.
Thanks.

[Reference](https://github.com/release-plz/release-plz/pull/1849) 