### PR TITLE
fix(codegen): emit trace events to fix stack traces in debugger

### DIFF
--- a/codegen/masm/src/emit/mod.rs
+++ b/codegen/masm/src/emit/mod.rs
@@ -94,7 +94,10 @@ use miden_assembly::ast::InvokeKind;
 use midenc_hir::{Immediate, Operation, SourceSpan, Type, ValueRef};
 
 use super::{Operand, OperandStack};
-use crate::masm::{self as masm, Op};
+use crate::{
+    masm::{self as masm, Op},
+    TraceEvent,
+};
 
 /// This structure is used to emit the Miden Assembly ops corresponding to an IR instruction.
 ///
@@ -202,8 +205,11 @@ impl<'a> OpEmitter<'a> {
         )));
         let path = masm::LibraryPath::new(callee.module.as_str()).unwrap();
         let target = masm::InvocationTarget::AbsoluteProcedurePath { name, path };
-        let inst = masm::Instruction::Exec(target);
-        self.emit(inst, span);
+        self.emit(masm::Instruction::Trace(TraceEvent::FrameStart.as_u32().into()), span);
+        self.emit(masm::Instruction::Nop, span);
+        self.emit(masm::Instruction::Exec(target), span);
+        self.emit(masm::Instruction::Trace(TraceEvent::FrameEnd.as_u32().into()), span);
+        self.emit(masm::Instruction::Nop, span);
     }
 
     /// Emit `op` to the current block

--- a/codegen/masm/src/emit/primop.rs
+++ b/codegen/masm/src/emit/primop.rs
@@ -4,6 +4,7 @@ use midenc_hir::{
 };
 
 use super::{int64, masm, OpEmitter};
+use crate::TraceEvent;
 
 impl OpEmitter<'_> {
     /// Assert that an integer value on the stack has the value 1
@@ -254,7 +255,11 @@ impl OpEmitter<'_> {
     ) {
         self.process_call_signature(&callee, signature, span);
 
+        self.emit(masm::Instruction::Trace(TraceEvent::FrameStart.as_u32().into()), span);
+        self.emit(masm::Instruction::Nop, span);
         self.emit(masm::Instruction::Exec(callee), span);
+        self.emit(masm::Instruction::Trace(TraceEvent::FrameEnd.as_u32().into()), span);
+        self.emit(masm::Instruction::Nop, span);
     }
 
     /// Execute the given procedure in a new context.
@@ -268,7 +273,11 @@ impl OpEmitter<'_> {
     ) {
         self.process_call_signature(&callee, signature, span);
 
+        self.emit(masm::Instruction::Trace(TraceEvent::FrameStart.as_u32().into()), span);
+        self.emit(masm::Instruction::Nop, span);
         self.emit(masm::Instruction::Call(callee), span);
+        self.emit(masm::Instruction::Trace(TraceEvent::FrameEnd.as_u32().into()), span);
+        self.emit(masm::Instruction::Nop, span);
     }
 
     fn process_call_signature(

--- a/codegen/masm/src/events.rs
+++ b/codegen/masm/src/events.rs
@@ -30,6 +30,16 @@ impl TraceEvent {
     pub fn is_frame_end(&self) -> bool {
         matches!(self, Self::FrameEnd)
     }
+
+    pub fn as_u32(self) -> u32 {
+        match self {
+            Self::FrameStart => TRACE_FRAME_START,
+            Self::FrameEnd => TRACE_FRAME_END,
+            Self::AssertionFailed(None) => 0,
+            Self::AssertionFailed(Some(code)) => code.get(),
+            Self::Unknown(event) => event,
+        }
+    }
 }
 impl From<u32> for TraceEvent {
     fn from(raw: u32) -> Self {

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -130,5 +130,6 @@ pub fn register_dialect_hooks(context: &midenc_hir::Context) {
         info.register_operation_trait::<hir::MemSize, dyn HirLowering>();
         info.register_operation_trait::<hir::MemSet, dyn HirLowering>();
         info.register_operation_trait::<hir::MemCpy, dyn HirLowering>();
+        info.register_operation_trait::<hir::Breakpoint, dyn HirLowering>();
     });
 }

--- a/codegen/masm/src/lower/lowering.rs
+++ b/codegen/masm/src/lower/lowering.rs
@@ -647,6 +647,14 @@ impl HirLowering for hir::AssertEq {
     }
 }
 
+impl HirLowering for hir::Breakpoint {
+    fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
+        emitter.emit_op(masm::Op::Inst(Span::new(self.span(), masm::Instruction::Breakpoint)));
+
+        Ok(())
+    }
+}
+
 impl HirLowering for ub::Unreachable {
     fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
         // This instruction, if reached, must cause the VM to trap, so we emit an assertion that

--- a/dialects/hir/src/builders.rs
+++ b/dialects/hir/src/builders.rs
@@ -65,6 +65,14 @@ pub trait HirOpBuilder<'f, B: ?Sized + Builder> {
         self.assert_eq(lhs, rhs, span)
     }
 
+    fn breakpoint(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<UnsafeIntrusiveEntityRef<crate::ops::Breakpoint>, Report> {
+        let op_builder = self.builder_mut().create::<crate::ops::Breakpoint, _>(span);
+        op_builder()
+    }
+
     /// Grow the global heap by `num_pages` pages, in 64kb units.
     ///
     /// Returns the previous size (in pages) of the heap, or -1 if the heap could not be grown.

--- a/dialects/hir/src/lib.rs
+++ b/dialects/hir/src/lib.rs
@@ -127,5 +127,6 @@ impl DialectRegistration for HirDialect {
         info.register_operation::<ops::MemCpy>();
         info.register_operation::<ops::Spill>();
         info.register_operation::<ops::Reload>();
+        info.register_operation::<ops::Breakpoint>();
     }
 }

--- a/dialects/hir/src/ops/primop.rs
+++ b/dialects/hir/src/ops/primop.rs
@@ -95,3 +95,18 @@ impl EffectOpInterface<MemoryEffect> for MemCpy {
         ])
     }
 }
+
+#[operation(
+    dialect = HirDialect,
+    implements(MemoryEffectOpInterface)
+)]
+pub struct Breakpoint {}
+
+impl EffectOpInterface<MemoryEffect> for Breakpoint {
+    fn effects(&self) -> EffectIterator<MemoryEffect> {
+        EffectIterator::from_smallvec(smallvec![
+            EffectInstance::new(MemoryEffect::Read),
+            EffectInstance::new(MemoryEffect::Write),
+        ])
+    }
+}

--- a/frontend/wasm/src/intrinsics/debug.rs
+++ b/frontend/wasm/src/intrinsics/debug.rs
@@ -1,0 +1,33 @@
+use midenc_dialect_hir::HirOpBuilder;
+use midenc_hir::{
+    dialects::builtin::FunctionRef,
+    interner::{symbols, Symbol},
+    smallvec, Builder, SmallVec, SourceSpan, SymbolNameComponent, ValueRef,
+};
+
+use crate::{error::WasmResult, module::function_builder_ext::FunctionBuilderExt};
+
+pub(crate) const MODULE_ID: &str = "intrinsics::debug";
+pub(crate) const MODULE_PREFIX: &[SymbolNameComponent] = &[
+    SymbolNameComponent::Root,
+    SymbolNameComponent::Component(symbols::Intrinsics),
+    SymbolNameComponent::Component(symbols::Debug),
+];
+
+/// Convert a call to a debugging intrinsic function into instruction(s)
+pub(crate) fn convert_debug_intrinsics<B: ?Sized + Builder>(
+    function: Symbol,
+    _function_ref: Option<FunctionRef>,
+    args: &[ValueRef],
+    builder: &mut FunctionBuilderExt<'_, B>,
+    span: SourceSpan,
+) -> WasmResult<SmallVec<[ValueRef; 1]>> {
+    match function.as_str() {
+        "break" => {
+            assert_eq!(args.len(), 0, "{function} takes exactly one argument");
+            builder.breakpoint(span)?;
+            Ok(smallvec![])
+        }
+        _ => panic!("no debug intrinsics found named '{function}'"),
+    }
+}

--- a/frontend/wasm/src/intrinsics/mod.rs
+++ b/frontend/wasm/src/intrinsics/mod.rs
@@ -2,6 +2,7 @@ mod intrinsic;
 
 pub use self::intrinsic::*;
 
+pub mod debug;
 pub mod felt;
 pub mod mem;
 
@@ -21,6 +22,7 @@ fn modules() -> &'static FxHashSet<SymbolPath> {
         let mut s = FxHashSet::default();
         s.insert(SymbolPath::from_iter(mem::MODULE_PREFIX.iter().copied()));
         s.insert(SymbolPath::from_iter(felt::MODULE_PREFIX.iter().copied()));
+        s.insert(SymbolPath::from_iter(debug::MODULE_PREFIX.iter().copied()));
         s
     });
     &MODULES
@@ -35,6 +37,9 @@ pub fn convert_intrinsics_call<B: ?Sized + Builder>(
     span: SourceSpan,
 ) -> WasmResult<SmallVec<[ValueRef; 1]>> {
     match intrinsic {
+        Intrinsic::Debug(function) => {
+            debug::convert_debug_intrinsics(function, function_ref, args, builder, span)
+        }
         Intrinsic::Mem(function) => {
             mem::convert_mem_intrinsics(function, function_ref, args, builder, span)
         }

--- a/frontend/wasm/src/miden_abi/mod.rs
+++ b/frontend/wasm/src/miden_abi/mod.rs
@@ -114,6 +114,8 @@ pub fn recover_imported_masm_module(wasm_module_id: &str) -> Result<SymbolPath, 
         Ok(SymbolPath::from_masm_module_id(intrinsics::mem::MODULE_ID))
     } else if wasm_module_id.starts_with("miden:core-import/intrinsics-felt") {
         Ok(SymbolPath::from_masm_module_id(intrinsics::felt::MODULE_ID))
+    } else if wasm_module_id.starts_with("miden:core-import/intrinsics-debug") {
+        Ok(SymbolPath::from_masm_module_id(intrinsics::debug::MODULE_ID))
     } else if wasm_module_id.starts_with("miden:core-import/account") {
         Ok(SymbolPath::from_masm_module_id(tx_kernel::account::MODULE_ID))
     } else if wasm_module_id.starts_with("miden:core-import/note") {

--- a/hir-symbol/src/symbols.toml
+++ b/hir-symbol/src/symbols.toml
@@ -104,6 +104,7 @@ ub = {}
 account = {}
 blake3 = {}
 crypto = {}
+debug = {}
 dsa = {}
 hashes = {}
 intrinsics = {}

--- a/sdk/stdlib-sys/src/intrinsics/debug.rs
+++ b/sdk/stdlib-sys/src/intrinsics/debug.rs
@@ -1,0 +1,14 @@
+#[link(wasm_import_module = "miden:core-import/intrinsics-debug@1.0.0")]
+extern "C" {
+    #[link_name = "break"]
+    fn extern_break();
+}
+
+/// Sets a breakpoint in the emitted Miden Assembly at the point this function is called.
+#[inline(always)]
+#[track_caller]
+pub fn breakpoint() {
+    unsafe {
+        extern_break();
+    }
+}

--- a/sdk/stdlib-sys/src/intrinsics/mod.rs
+++ b/sdk/stdlib-sys/src/intrinsics/mod.rs
@@ -1,5 +1,6 @@
 use core::ops::{Deref, DerefMut};
 
+pub mod debug;
 mod felt;
 mod word;
 

--- a/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
+++ b/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -11,14 +13,22 @@ end
 # mod root_ns:root@1.0.0::abi_transform_stdlib_blake3_hash
 
 proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
+    trace.240
+    nop
     exec.::std::crypto::hashes::blake3::hash_1to1
+    trace.252
+    nop
     movup.8
     dup.0
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -28,7 +38,11 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     push.8
     dup.1
     swap.1
@@ -38,7 +52,11 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     push.12
     dup.1
     swap.1
@@ -48,7 +66,11 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     push.16
     dup.1
     swap.1
@@ -58,7 +80,11 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     push.20
     dup.1
     swap.1
@@ -68,7 +94,11 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     push.24
     dup.1
     swap.1
@@ -78,20 +108,32 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     push.28
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
 end
 
 export.entrypoint
     push.1048576
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.4294967264
     push.32
     dup.2
@@ -103,60 +145,96 @@ export.entrypoint
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
     dup.3
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.4
     dup.5
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.8
     dup.6
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.12
     dup.7
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.16
     dup.8
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.20
     dup.9
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.24
     dup.10
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.28
     movup.11
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     dup.8
     movup.3
     swap.5
@@ -168,7 +246,11 @@ export.entrypoint
     swap.7
     swap.1
     swap.8
+    trace.240
+    nop
     exec.::root_ns:root@1.0.0::abi_transform_stdlib_blake3_hash::miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
+    trace.252
+    nop
     push.24
     dup.1
     add
@@ -181,14 +263,22 @@ export.entrypoint
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.24
     dup.5
     swap.1
     u32wrapping_add
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.16
     dup.1
     add
@@ -201,14 +291,22 @@ export.entrypoint
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.16
     dup.5
     swap.1
     u32wrapping_add
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.8
     dup.1
     add
@@ -221,14 +319,22 @@ export.entrypoint
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.8
     dup.5
     swap.1
     u32wrapping_add
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.8
     dup.1
     swap.1
@@ -237,14 +343,26 @@ export.entrypoint
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     movup.3
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.1048576
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/add_felt.masm
+++ b/tests/integration/expected/add_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/add_i16.masm
+++ b/tests/integration/expected/add_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/add_i32.masm
+++ b/tests/integration/expected/add_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/add_i64.masm
+++ b/tests/integration/expected/add_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_cc1ebe8ed410a033febcc7c6a7e1b2473b2337e0dff32b08d3c91be5bbc2cc0a
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::wrapping_add
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/add_i8.masm
+++ b/tests/integration/expected/add_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/add_u16.masm
+++ b/tests/integration/expected/add_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/add_u32.masm
+++ b/tests/integration/expected/add_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/add_u64.masm
+++ b/tests/integration/expected/add_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_2c24c814fbf0c5ee22a60f52279e8f7639d56708da347e071f1130dc19dc9c07
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::wrapping_add
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/add_u8.masm
+++ b/tests/integration/expected/add_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/and_bool.masm
+++ b/tests/integration/expected/and_bool.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/band_i16.masm
+++ b/tests/integration/expected/band_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/band_i32.masm
+++ b/tests/integration/expected/band_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/band_i64.masm
+++ b/tests/integration/expected/band_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_fdee33d480318f3f6165aabcaf90e290011f2d459d009ce9a6ea019e73b0e6b4
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::and
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/band_i8.masm
+++ b/tests/integration/expected/band_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/band_u16.masm
+++ b/tests/integration/expected/band_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/band_u32.masm
+++ b/tests/integration/expected/band_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/band_u64.masm
+++ b/tests/integration/expected/band_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_8509e2e84a91835b60f651a4adb33e43024ab7f31520e5ee5b5a97f181859a40
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::and
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/band_u8.masm
+++ b/tests/integration/expected/band_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bnot_bool.masm
+++ b/tests/integration/expected/bnot_bool.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bnot_i16.masm
+++ b/tests/integration/expected/bnot_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bnot_i32.masm
+++ b/tests/integration/expected/bnot_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bnot_i64.masm
+++ b/tests/integration/expected/bnot_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     push.4294967295
     push.4294967295
+    trace.240
+    nop
     exec.::std::math::u64::xor
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/bnot_i8.masm
+++ b/tests/integration/expected/bnot_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bnot_u16.masm
+++ b/tests/integration/expected/bnot_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bnot_u32.masm
+++ b/tests/integration/expected/bnot_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bnot_u64.masm
+++ b/tests/integration/expected/bnot_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     push.4294967295
     push.4294967295
+    trace.240
+    nop
     exec.::std::math::u64::xor
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/bnot_u8.masm
+++ b/tests/integration/expected/bnot_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bor_i16.masm
+++ b/tests/integration/expected/bor_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bor_i32.masm
+++ b/tests/integration/expected/bor_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bor_i64.masm
+++ b/tests/integration/expected/bor_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_19d92981d2d7f148eaa97011bd0bd979fbc793cadadb334c67791824f38e7bf8
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::or
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/bor_i8.masm
+++ b/tests/integration/expected/bor_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bor_u16.masm
+++ b/tests/integration/expected/bor_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bor_u32.masm
+++ b/tests/integration/expected/bor_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bor_u64.masm
+++ b/tests/integration/expected/bor_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_e8616ef7e15d87b491a1dbcccfe42b1dcb7a90b965c27549b2b5d9604d28acee
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::or
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/bor_u8.masm
+++ b/tests/integration/expected/bor_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bxor_i16.masm
+++ b/tests/integration/expected/bxor_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bxor_i32.masm
+++ b/tests/integration/expected/bxor_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bxor_i64.masm
+++ b/tests/integration/expected/bxor_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_bbe2169ccd3bb4080a705f38ed5ef633d3af9e172e8f9b41ae4ee10f8059e176
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::xor
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/bxor_i8.masm
+++ b/tests/integration/expected/bxor_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bxor_u16.masm
+++ b/tests/integration/expected/bxor_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bxor_u32.masm
+++ b/tests/integration/expected/bxor_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/bxor_u64.masm
+++ b/tests/integration/expected/bxor_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_ab1d59bc3952451e2ac6a22333bf5458760622594546976d2d1488d607497ae7
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::xor
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/bxor_u8.masm
+++ b/tests/integration/expected/bxor_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/collatz.masm
+++ b/tests/integration/expected/collatz.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -39,7 +41,11 @@ export.entrypoint
             push.3
             dup.6
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::i32::wrapping_mul
+            trace.252
+            nop
             u32wrapping_add
             push.0
             push.1

--- a/tests/integration/expected/core::cmp::max_u8_u8.masm
+++ b/tests/integration/expected/core::cmp::max_u8_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/core::cmp::min_i32_i32.masm
+++ b/tests/integration/expected/core::cmp::min_i32_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -20,7 +22,11 @@ export.entrypoint
     push.0
     dup.2
     dup.2
+    trace.240
+    nop
     exec.::intrinsics::i32::is_lt
+    trace.252
+    nop
     neq
     movup.2
     swap.1

--- a/tests/integration/expected/core::cmp::min_u32_u32.masm
+++ b/tests/integration/expected/core::cmp::min_u32_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/core::cmp::min_u8_u8.masm
+++ b/tests/integration/expected/core::cmp::min_u8_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/div_felt.masm
+++ b/tests/integration/expected/div_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/eq_felt.masm
+++ b/tests/integration/expected/eq_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/eq_i16.masm
+++ b/tests/integration/expected/eq_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/eq_i32.masm
+++ b/tests/integration/expected/eq_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/eq_i64.masm
+++ b/tests/integration/expected/eq_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_bcf098a70fb61198130acb429b0b2900b9c9d11c5cab0241410bb862be7ce2a8
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::eq
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/eq_i8.masm
+++ b/tests/integration/expected/eq_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/eq_u16.masm
+++ b/tests/integration/expected/eq_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/eq_u32.masm
+++ b/tests/integration/expected/eq_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/eq_u64.masm
+++ b/tests/integration/expected/eq_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_90e3e1f038c3b9b7ba2a8c0e9313f59dc3bc3f54fe235a4c5c325df06e46d3b0
 
 export.entrypoint
+    trace.240
+    nop
     exec.::std::math::u64::eq
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/eq_u8.masm
+++ b/tests/integration/expected/eq_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/examples/counter.masm
+++ b/tests/integration/expected/examples/counter.masm
@@ -1,16 +1,26 @@
 # mod miden:counter-contract/counter@0.1.0
 
 export.get-count
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden:counter-contract/counter@0.1.0#get-count
+    trace.252
+    nop
 end
 
 export.increment-count
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden:counter-contract/counter@0.1.0#increment-count
+    trace.252
+    nop
 end
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.5121323707957172480
     push.16385291266171272914
     push.3612753469884014922
@@ -18,7 +28,9 @@ export.init
     adv.push_mapval
     push.262144
     push.3
+    trace.240
     exec.::std::mem::pipe_preimage_to_memory
+    trace.252
     drop
     push.1048576
     u32assert
@@ -28,18 +40,30 @@ end
 # mod miden:counter-contract/counter@0.1.0::counter_contract
 
 proc.miden_base_sys::bindings::account::extern_account_incr_nonce
+    trace.240
+    nop
     exec.::miden::account::incr_nonce
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::extern_get_storage_map_item
+    trace.240
+    nop
     exec.::miden::account::get_map_item
+    trace.252
+    nop
     movup.4
     dup.0
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -49,7 +73,11 @@ proc.miden_base_sys::bindings::storage::extern_get_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     swap.1
@@ -59,24 +87,40 @@ proc.miden_base_sys::bindings::storage::extern_get_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.12
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
+    trace.240
+    nop
     exec.::miden::account::set_map_item
+    trace.252
+    nop
     movup.8
     dup.0
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -86,7 +130,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     swap.1
@@ -96,7 +144,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.12
     dup.1
     swap.1
@@ -106,7 +158,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.16
     dup.1
     swap.1
@@ -116,7 +172,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.20
     dup.1
     swap.1
@@ -126,7 +186,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.24
     dup.1
     swap.1
@@ -136,13 +200,21 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.28
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.__wasm_call_ctors
@@ -157,7 +229,11 @@ proc.__rustc::__rust_alloc
     push.1048612
     movup.2
     swap.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
 end
 
 proc.__rustc::__rust_realloc
@@ -166,7 +242,11 @@ proc.__rustc::__rust_realloc
     swap.2
     swap.4
     swap.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
     push.0
     push.0
     dup.2
@@ -218,7 +298,11 @@ proc.__rustc::__rust_realloc
                 assertz
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.128
                 u32and
                 swap.1
@@ -226,13 +310,21 @@ proc.__rustc::__rust_realloc
                 swap.1
                 dup.1
                 dup.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.4294967040
                 u32and
                 movup.3
                 u32or
                 movdn.2
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 u32wrapping_add.1
                 dup.0
                 dup.4
@@ -247,7 +339,11 @@ export.miden:counter-contract/counter@0.1.0#get-count
     push.1048576
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.4294967264
     push.64
     dup.2
@@ -259,8 +355,16 @@ export.miden:counter-contract/counter@0.1.0#get-count
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::wit_bindgen_rt::run_ctors_once
+    trace.252
+    nop
     push.3735929054
     push.0
     push.0
@@ -311,7 +415,11 @@ export.miden:counter-contract/counter@0.1.0#get-count
             swap.1
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::store_felt
+            trace.252
+            nop
             push.1
             push.0
             push.4
@@ -353,7 +461,11 @@ export.miden:counter-contract/counter@0.1.0#get-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.8
     dup.3
     add
@@ -366,7 +478,11 @@ export.miden:counter-contract/counter@0.1.0#get-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.32
     dup.1
     add
@@ -379,7 +495,11 @@ export.miden:counter-contract/counter@0.1.0#get-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     dup.2
     push.8
     dup.1
@@ -389,7 +509,11 @@ export.miden:counter-contract/counter@0.1.0#get-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.0
     push.32
     dup.2
@@ -398,7 +522,11 @@ export.miden:counter-contract/counter@0.1.0#get-count
     dup.2
     swap.2
     swap.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden_base_sys::bindings::storage::get_map_item
+    trace.252
+    nop
     push.44
     swap.1
     add
@@ -411,20 +539,32 @@ export.miden:counter-contract/counter@0.1.0#get-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.1048576
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
 end
 
 export.miden:counter-contract/counter@0.1.0#increment-count
     push.1048576
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.4294967264
     push.160
     dup.2
@@ -436,8 +576,16 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::wit_bindgen_rt::run_ctors_once
+    trace.252
+    nop
     push.3735929054
     push.0
     push.0
@@ -488,7 +636,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
             swap.1
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::store_felt
+            trace.252
+            nop
             push.1
             push.0
             push.4
@@ -530,7 +682,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.8
     dup.3
     add
@@ -543,7 +699,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.32
     dup.1
     add
@@ -556,7 +716,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     dup.2
     push.8
     dup.1
@@ -566,7 +730,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.0
     push.32
     dup.2
@@ -575,7 +743,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     dup.2
     swap.2
     swap.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden_base_sys::bindings::storage::get_map_item
+    trace.252
+    nop
     push.44
     dup.1
     add
@@ -588,7 +760,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.1
     add
     push.24
@@ -603,7 +779,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.120
     dup.4
     add
@@ -616,7 +796,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.16
     dup.2
     add
@@ -629,7 +813,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.112
     dup.4
     add
@@ -642,7 +830,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.8
     dup.2
     add
@@ -655,7 +847,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.104
     dup.4
     add
@@ -668,7 +864,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     dup.1
     push.8
     dup.1
@@ -678,7 +878,11 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
     push.96
     dup.4
     add
@@ -691,14 +895,22 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
     push.128
     dup.2
     swap.1
     u32wrapping_add
     dup.1
     swap.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdlib_sys::intrinsics::felt::Felt>>::from
+    trace.252
+    nop
     push.128
     dup.2
     swap.1
@@ -712,19 +924,35 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     movup.5
     swap.1
     u32wrapping_add
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden_base_sys::bindings::storage::set_map_item
+    trace.252
+    nop
     push.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden_base_sys::bindings::account::incr_nonce
+    trace.252
+    nop
     push.1048576
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
 end
 
 export.cabi_realloc_wit_bindgen_0_28_0
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::wit_bindgen_rt::cabi_realloc
+    trace.252
+    nop
 end
 
 proc.wit_bindgen_rt::cabi_realloc
@@ -733,7 +961,11 @@ proc.wit_bindgen_rt::cabi_realloc
     swap.1
     neq
     if.true
+        trace.240
+        nop
         exec.::miden:counter-contract/counter@0.1.0::counter_contract::__rustc::__rust_realloc
+        trace.252
+        nop
         push.0
         push.3735929054
         movup.2
@@ -755,7 +987,11 @@ proc.wit_bindgen_rt::cabi_realloc
             swap.1
         else
             swap.1
+            trace.240
+            nop
             exec.::miden:counter-contract/counter@0.1.0::counter_contract::__rustc::__rust_alloc
+            trace.252
+            nop
             push.0
             push.3735929054
             movup.2
@@ -803,7 +1039,11 @@ proc.wit_bindgen_rt::run_ctors_once
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.128
     u32and
     push.0
@@ -812,7 +1052,11 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
+        trace.240
+        nop
         exec.::miden:counter-contract/counter@0.1.0::counter_contract::__wasm_call_ctors
+        trace.252
+        nop
         push.1
         push.1048617
         push.0
@@ -822,13 +1066,21 @@ proc.wit_bindgen_rt::run_ctors_once
         swap.1
         dup.1
         dup.1
+        trace.240
+        nop
         exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.4294967040
         u32and
         movup.3
         u32or
         movdn.2
+        trace.240
+        nop
         exec.::intrinsics::mem::store_sw
+        trace.252
+        nop
     end
 end
 
@@ -858,7 +1110,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
         push.3735929054
     else
         movup.2
+        trace.240
+        nop
         exec.::miden:counter-contract/counter@0.1.0::counter_contract::core::ptr::alignment::Alignment::max
+        trace.252
+        nop
         push.0
         push.2147483648
         dup.2
@@ -893,15 +1149,27 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             neq
             if.true
                 push.0
                 swap.3
             else
+                trace.240
+                nop
                 exec.::intrinsics::mem::heap_base
+                trace.252
+                nop
+                trace.240
+                nop
                 exec.::intrinsics::mem::memory_size
+                trace.252
+                nop
                 dup.4
                 push.4
                 dup.1
@@ -919,7 +1187,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.0
                 swap.3
             end
@@ -932,7 +1204,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             dup.3
             push.268435456
@@ -961,7 +1237,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.1
                 swap.1
                 movup.2
@@ -983,7 +1263,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
 end
 
 proc.miden_base_sys::bindings::account::incr_nonce
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden_base_sys::bindings::account::extern_account_incr_nonce
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::get_map_item
@@ -996,7 +1280,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.4
     dup.4
     add
@@ -1009,7 +1297,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.8
     dup.5
     add
@@ -1022,7 +1314,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.12
     movup.6
     add
@@ -1035,7 +1331,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.255
     movup.6
     swap.1
@@ -1046,7 +1346,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     swap.1
     swap.4
     swap.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden_base_sys::bindings::storage::extern_get_storage_map_item
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::set_map_item
@@ -1059,7 +1363,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.4
     dup.4
     add
@@ -1072,7 +1380,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.8
     dup.5
     add
@@ -1085,7 +1397,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.12
     movup.6
     add
@@ -1098,7 +1414,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     dup.6
     push.4
     dup.1
@@ -1108,7 +1428,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.4
     dup.8
     add
@@ -1121,7 +1445,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.8
     dup.9
     add
@@ -1134,7 +1462,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.12
     movup.10
     add
@@ -1147,7 +1479,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.255
     movup.10
     swap.1
@@ -1164,7 +1500,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     swap.1
     swap.8
     swap.1
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::miden_base_sys::bindings::storage::extern_set_storage_map_item
+    trace.252
+    nop
 end
 
 proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdlib_sys::intrinsics::felt::Felt>>::from
@@ -1182,7 +1522,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     add
@@ -1197,7 +1541,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     add
@@ -1212,7 +1560,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -1223,7 +1575,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.core::ptr::alignment::Alignment::max
@@ -1237,6 +1593,10 @@ proc.core::ptr::alignment::Alignment::max
 end
 
 export.cabi_realloc
+    trace.240
+    nop
     exec.::miden:counter-contract/counter@0.1.0::counter_contract::cabi_realloc_wit_bindgen_0_28_0
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/examples/fib.masm
+++ b/tests/integration/expected/examples/fib.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/examples/storage_example.masm
+++ b/tests/integration/expected/examples/storage_example.masm
@@ -1,16 +1,26 @@
 # mod miden:storage-example/foo@1.0.0
 
 export.set-asset-qty
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::miden:storage-example/foo@1.0.0#set-asset-qty
+    trace.252
+    nop
 end
 
 export.get-asset-qty
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::miden:storage-example/foo@1.0.0#get-asset-qty
+    trace.252
+    nop
 end
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.5121323707957172480
     push.16385291266171272914
     push.3612753469884014922
@@ -18,7 +28,9 @@ export.init
     adv.push_mapval
     push.262144
     push.3
+    trace.240
     exec.::std::mem::pipe_preimage_to_memory
+    trace.252
     drop
     push.1048576
     u32assert
@@ -28,14 +40,22 @@ end
 # mod miden:storage-example/foo@1.0.0::storage_example
 
 proc.miden_base_sys::bindings::storage::extern_get_storage_item
+    trace.240
+    nop
     exec.::miden::account::get_item
+    trace.252
+    nop
     movup.4
     dup.0
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -45,7 +65,11 @@ proc.miden_base_sys::bindings::storage::extern_get_storage_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     swap.1
@@ -55,24 +79,40 @@ proc.miden_base_sys::bindings::storage::extern_get_storage_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.12
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::extern_get_storage_map_item
+    trace.240
+    nop
     exec.::miden::account::get_map_item
+    trace.252
+    nop
     movup.4
     dup.0
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -82,7 +122,11 @@ proc.miden_base_sys::bindings::storage::extern_get_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     swap.1
@@ -92,24 +136,40 @@ proc.miden_base_sys::bindings::storage::extern_get_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.12
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
+    trace.240
+    nop
     exec.::miden::account::set_map_item
+    trace.252
+    nop
     movup.8
     dup.0
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -119,7 +179,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     swap.1
@@ -129,7 +193,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.12
     dup.1
     swap.1
@@ -139,7 +207,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.16
     dup.1
     swap.1
@@ -149,7 +221,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.20
     dup.1
     swap.1
@@ -159,7 +235,11 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.24
     dup.1
     swap.1
@@ -169,13 +249,21 @@ proc.miden_base_sys::bindings::storage::extern_set_storage_map_item
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.28
     add
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.__wasm_call_ctors
@@ -190,7 +278,11 @@ proc.__rustc::__rust_alloc
     push.1048612
     movup.2
     swap.1
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
 end
 
 proc.__rustc::__rust_realloc
@@ -199,7 +291,11 @@ proc.__rustc::__rust_realloc
     swap.2
     swap.4
     swap.1
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
     push.0
     push.0
     dup.2
@@ -251,7 +347,11 @@ proc.__rustc::__rust_realloc
                 assertz
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.128
                 u32and
                 swap.1
@@ -259,13 +359,21 @@ proc.__rustc::__rust_realloc
                 swap.1
                 dup.1
                 dup.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.4294967040
                 u32and
                 movup.3
                 u32or
                 movdn.2
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 u32wrapping_add.1
                 dup.0
                 dup.4
@@ -280,7 +388,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     push.1048576
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.4294967264
     push.128
     dup.2
@@ -292,8 +404,16 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::wit_bindgen_rt::run_ctors_once
+    trace.252
+    nop
     push.12
     dup.1
     add
@@ -308,7 +428,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     add
@@ -323,7 +447,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     add
@@ -338,7 +466,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     dup.0
     push.4
     dup.1
@@ -350,13 +482,21 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.0
     push.32
     dup.2
     swap.1
     u32wrapping_add
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::miden_base_sys::bindings::storage::get_item
+    trace.252
+    nop
     push.44
     dup.1
     add
@@ -369,7 +509,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.40
     dup.2
     add
@@ -382,7 +526,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.36
     dup.3
     add
@@ -395,7 +543,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.32
     dup.4
     add
@@ -408,7 +560,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.0
     push.1
     movup.8
@@ -469,7 +625,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
                     u32wrapping_add
                     movup.3
                     swap.1
+                    trace.240
+                    nop
                     exec.::miden:storage-example/foo@1.0.0::storage_example::<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdlib_sys::intrinsics::felt::Felt>>::from
+                    trace.252
+                    nop
                     push.96
                     dup.1
                     swap.1
@@ -482,7 +642,11 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
                     movup.2
                     swap.3
                     movdn.2
+                    trace.240
+                    nop
                     exec.::miden:storage-example/foo@1.0.0::storage_example::miden_base_sys::bindings::storage::set_map_item
+                    trace.252
+                    nop
                 end
             end
         end
@@ -490,14 +654,22 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     push.1048576
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
 end
 
 export.miden:storage-example/foo@1.0.0#get-asset-qty
     push.1048576
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.4294967264
     push.64
     dup.2
@@ -509,8 +681,16 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::wit_bindgen_rt::run_ctors_once
+    trace.252
+    nop
     push.12
     dup.1
     add
@@ -525,7 +705,11 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     add
@@ -540,7 +724,11 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     add
@@ -555,7 +743,11 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     dup.0
     push.4
     dup.1
@@ -567,7 +759,11 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.1
     push.32
     dup.2
@@ -576,7 +772,11 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     dup.2
     swap.2
     swap.1
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::miden_base_sys::bindings::storage::get_map_item
+    trace.252
+    nop
     push.44
     swap.1
     add
@@ -589,17 +789,29 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.1048576
     movup.2
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
 end
 
 export.cabi_realloc_wit_bindgen_0_28_0
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::wit_bindgen_rt::cabi_realloc
+    trace.252
+    nop
 end
 
 proc.wit_bindgen_rt::cabi_realloc
@@ -608,7 +820,11 @@ proc.wit_bindgen_rt::cabi_realloc
     swap.1
     neq
     if.true
+        trace.240
+        nop
         exec.::miden:storage-example/foo@1.0.0::storage_example::__rustc::__rust_realloc
+        trace.252
+        nop
         push.0
         push.3735929054
         movup.2
@@ -630,7 +846,11 @@ proc.wit_bindgen_rt::cabi_realloc
             swap.1
         else
             swap.1
+            trace.240
+            nop
             exec.::miden:storage-example/foo@1.0.0::storage_example::__rustc::__rust_alloc
+            trace.252
+            nop
             push.0
             push.3735929054
             movup.2
@@ -678,7 +898,11 @@ proc.wit_bindgen_rt::run_ctors_once
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.128
     u32and
     push.0
@@ -687,7 +911,11 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
+        trace.240
+        nop
         exec.::miden:storage-example/foo@1.0.0::storage_example::__wasm_call_ctors
+        trace.252
+        nop
         push.1
         push.1048617
         push.0
@@ -697,13 +925,21 @@ proc.wit_bindgen_rt::run_ctors_once
         swap.1
         dup.1
         dup.1
+        trace.240
+        nop
         exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.4294967040
         u32and
         movup.3
         u32or
         movdn.2
+        trace.240
+        nop
         exec.::intrinsics::mem::store_sw
+        trace.252
+        nop
     end
 end
 
@@ -733,7 +969,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
         push.3735929054
     else
         movup.2
+        trace.240
+        nop
         exec.::miden:storage-example/foo@1.0.0::storage_example::core::ptr::alignment::Alignment::max
+        trace.252
+        nop
         push.0
         push.2147483648
         dup.2
@@ -768,15 +1008,27 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             neq
             if.true
                 push.0
                 swap.3
             else
+                trace.240
+                nop
                 exec.::intrinsics::mem::heap_base
+                trace.252
+                nop
+                trace.240
+                nop
                 exec.::intrinsics::mem::memory_size
+                trace.252
+                nop
                 dup.4
                 push.4
                 dup.1
@@ -794,7 +1046,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.0
                 swap.3
             end
@@ -807,7 +1063,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             dup.3
             push.268435456
@@ -836,7 +1096,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.1
                 swap.1
                 movup.2
@@ -862,7 +1126,11 @@ proc.miden_base_sys::bindings::storage::get_item
     movup.2
     swap.1
     u32and
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::miden_base_sys::bindings::storage::extern_get_storage_item
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::get_map_item
@@ -875,7 +1143,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.4
     dup.4
     add
@@ -888,7 +1160,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.8
     dup.5
     add
@@ -901,7 +1177,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.12
     movup.6
     add
@@ -914,7 +1194,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.255
     movup.6
     swap.1
@@ -925,7 +1209,11 @@ proc.miden_base_sys::bindings::storage::get_map_item
     swap.1
     swap.4
     swap.1
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::miden_base_sys::bindings::storage::extern_get_storage_map_item
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::storage::set_map_item
@@ -938,7 +1226,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.4
     dup.4
     add
@@ -951,7 +1243,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.8
     dup.5
     add
@@ -964,7 +1260,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.12
     movup.6
     add
@@ -977,7 +1277,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     dup.6
     push.4
     dup.1
@@ -987,7 +1291,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.4
     dup.8
     add
@@ -1000,7 +1308,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.8
     dup.9
     add
@@ -1013,7 +1325,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.12
     movup.10
     add
@@ -1026,7 +1342,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     assertz.err=250
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_felt
+    trace.252
+    nop
     push.255
     movup.10
     swap.1
@@ -1043,7 +1363,11 @@ proc.miden_base_sys::bindings::storage::set_map_item
     swap.1
     swap.8
     swap.1
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::miden_base_sys::bindings::storage::extern_set_storage_map_item
+    trace.252
+    nop
 end
 
 proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdlib_sys::intrinsics::felt::Felt>>::from
@@ -1061,7 +1385,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.8
     dup.1
     add
@@ -1076,7 +1404,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     add
@@ -1091,7 +1423,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
     push.4
     dup.1
     swap.1
@@ -1102,7 +1438,11 @@ proc.<miden_stdlib_sys::intrinsics::word::Word as core::convert::From<miden_stdl
     swap.1
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.core::ptr::alignment::Alignment::max
@@ -1116,6 +1456,10 @@ proc.core::ptr::alignment::Alignment::max
 end
 
 export.cabi_realloc
+    trace.240
+    nop
     exec.::miden:storage-example/foo@1.0.0::storage_example::cabi_realloc_wit_bindgen_0_28_0
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/ge_felt.masm
+++ b/tests/integration/expected/ge_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/ge_i32.masm
+++ b/tests/integration/expected/ge_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -18,6 +20,10 @@ end
 
 export.entrypoint
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::i32::is_gte
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/ge_i64.masm
+++ b/tests/integration/expected/ge_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::intrinsics::i64::gte
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/ge_u16.masm
+++ b/tests/integration/expected/ge_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/ge_u32.masm
+++ b/tests/integration/expected/ge_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/ge_u64.masm
+++ b/tests/integration/expected/ge_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -23,6 +25,10 @@ export.entrypoint
     movdn.3
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::std::math::u64::gte
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/ge_u8.masm
+++ b/tests/integration/expected/ge_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/gt_felt.masm
+++ b/tests/integration/expected/gt_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/gt_i32.masm
+++ b/tests/integration/expected/gt_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -18,6 +20,10 @@ end
 
 export.entrypoint
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::i32::is_gt
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/gt_i64.masm
+++ b/tests/integration/expected/gt_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::intrinsics::i64::gt
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/gt_u16.masm
+++ b/tests/integration/expected/gt_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/gt_u32.masm
+++ b/tests/integration/expected/gt_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/gt_u64.masm
+++ b/tests/integration/expected/gt_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -23,6 +25,10 @@ export.entrypoint
     movdn.3
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::std::math::u64::gt
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/gt_u8.masm
+++ b/tests/integration/expected/gt_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/is_prime.masm
+++ b/tests/integration/expected/is_prime.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -74,7 +76,11 @@ export.entrypoint
                         dup.1
                         dup.1
                         dup.2
+                        trace.240
+                        nop
                         exec.::intrinsics::i32::wrapping_mul
+                        trace.252
+                        nop
                         swap.1
                         u32gt
                         push.0

--- a/tests/integration/expected/le_felt.masm
+++ b/tests/integration/expected/le_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/le_i32.masm
+++ b/tests/integration/expected/le_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -18,6 +20,10 @@ end
 
 export.entrypoint
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::i32::is_lte
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/le_i64.masm
+++ b/tests/integration/expected/le_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::intrinsics::i64::lte
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/le_u16.masm
+++ b/tests/integration/expected/le_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/le_u32.masm
+++ b/tests/integration/expected/le_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/le_u64.masm
+++ b/tests/integration/expected/le_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -23,6 +25,10 @@ export.entrypoint
     movdn.3
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::std::math::u64::lte
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/le_u8.masm
+++ b/tests/integration/expected/le_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/lt_felt.masm
+++ b/tests/integration/expected/lt_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/lt_i32.masm
+++ b/tests/integration/expected/lt_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -18,6 +20,10 @@ end
 
 export.entrypoint
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::i32::is_lt
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/lt_i64.masm
+++ b/tests/integration/expected/lt_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::intrinsics::i64::lt
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/lt_u16.masm
+++ b/tests/integration/expected/lt_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/lt_u32.masm
+++ b/tests/integration/expected/lt_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/lt_u64.masm
+++ b/tests/integration/expected/lt_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -23,6 +25,10 @@ export.entrypoint
     movdn.3
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::std::math::u64::lt
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/lt_u8.masm
+++ b/tests/integration/expected/lt_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/mul_felt.masm
+++ b/tests/integration/expected/mul_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/mul_i32.masm
+++ b/tests/integration/expected/mul_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_4a870fe7a144fba5513f0d246ed1179aba172aab8f12afb574634dd1bb298024
 
 export.entrypoint
+    trace.240
+    nop
     exec.::intrinsics::i32::wrapping_mul
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/mul_i64.masm
+++ b/tests/integration/expected/mul_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_ee95318918a451f864b66b576532b422841bcd75ad8a62c4d4d3489a9158c08d
 
 export.entrypoint
+    trace.240
+    nop
     exec.::intrinsics::i64::wrapping_mul
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/mul_u16.masm
+++ b/tests/integration/expected/mul_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -20,7 +22,11 @@ export.entrypoint
     push.65535
     swap.1
     movup.2
+    trace.240
+    nop
     exec.::intrinsics::i32::wrapping_mul
+    trace.252
+    nop
     u32and
 end
 

--- a/tests/integration/expected/mul_u32.masm
+++ b/tests/integration/expected/mul_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_774ac315a535180c25b481293c43de2ad5b38b8ed718ccd906a367b8df969453
 
 export.entrypoint
+    trace.240
+    nop
     exec.::intrinsics::i32::wrapping_mul
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/mul_u64.masm
+++ b/tests/integration/expected/mul_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -17,6 +19,10 @@ end
 # mod root_ns:root@1.0.0::test_rust_ef43647914852c132ded20e7ab9569f69610af521a6074095544ea088f8908ae
 
 export.entrypoint
+    trace.240
+    nop
     exec.::intrinsics::i64::wrapping_mul
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/mul_u8.masm
+++ b/tests/integration/expected/mul_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -20,7 +22,11 @@ export.entrypoint
     push.255
     swap.1
     movup.2
+    trace.240
+    nop
     exec.::intrinsics::i32::wrapping_mul
+    trace.252
+    nop
     u32and
 end
 

--- a/tests/integration/expected/neg_felt.masm
+++ b/tests/integration/expected/neg_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/neg_i16.masm
+++ b/tests/integration/expected/neg_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/neg_i32.masm
+++ b/tests/integration/expected/neg_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/neg_i64.masm
+++ b/tests/integration/expected/neg_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -21,6 +23,10 @@ export.entrypoint
     push.0
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::std::math::u64::wrapping_sub
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/neg_i8.masm
+++ b/tests/integration/expected/neg_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/or_bool.masm
+++ b/tests/integration/expected/or_bool.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.masm
@@ -1,12 +1,18 @@
 # mod miden:cross-ctx-account/foo@1.0.0
 
 export.process-felt
+    trace.240
+    nop
     exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::miden:cross-ctx-account/foo@1.0.0#process-felt
+    trace.252
+    nop
 end
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.5121323707957172480
     push.16385291266171272914
     push.3612753469884014922
@@ -14,7 +20,9 @@ export.init
     adv.push_mapval
     push.262144
     push.3
+    trace.240
     exec.::std::mem::pipe_preimage_to_memory
+    trace.252
     drop
     push.1048576
     u32assert
@@ -35,7 +43,11 @@ proc.__rustc::__rust_alloc
     push.1048612
     movup.2
     swap.1
+    trace.240
+    nop
     exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
 end
 
 proc.__rustc::__rust_realloc
@@ -44,7 +56,11 @@ proc.__rustc::__rust_realloc
     swap.2
     swap.4
     swap.1
+    trace.240
+    nop
     exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
     push.0
     push.0
     dup.2
@@ -96,7 +112,11 @@ proc.__rustc::__rust_realloc
                 assertz
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.128
                 u32and
                 swap.1
@@ -104,13 +124,21 @@ proc.__rustc::__rust_realloc
                 swap.1
                 dup.1
                 dup.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.4294967040
                 u32and
                 movup.3
                 u32or
                 movdn.2
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 u32wrapping_add.1
                 dup.0
                 dup.4
@@ -122,13 +150,21 @@ proc.__rustc::__rust_realloc
 end
 
 export.miden:cross-ctx-account/foo@1.0.0#process-felt
+    trace.240
+    nop
     exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::wit_bindgen_rt::run_ctors_once
+    trace.252
+    nop
     push.3
     add
 end
 
 export.cabi_realloc_wit_bindgen_0_28_0
+    trace.240
+    nop
     exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::wit_bindgen_rt::cabi_realloc
+    trace.252
+    nop
 end
 
 proc.wit_bindgen_rt::cabi_realloc
@@ -137,7 +173,11 @@ proc.wit_bindgen_rt::cabi_realloc
     swap.1
     neq
     if.true
+        trace.240
+        nop
         exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::__rustc::__rust_realloc
+        trace.252
+        nop
         push.0
         push.3735929054
         movup.2
@@ -159,7 +199,11 @@ proc.wit_bindgen_rt::cabi_realloc
             swap.1
         else
             swap.1
+            trace.240
+            nop
             exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::__rustc::__rust_alloc
+            trace.252
+            nop
             push.0
             push.3735929054
             movup.2
@@ -207,7 +251,11 @@ proc.wit_bindgen_rt::run_ctors_once
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.128
     u32and
     push.0
@@ -216,7 +264,11 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
+        trace.240
+        nop
         exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::__wasm_call_ctors
+        trace.252
+        nop
         push.1
         push.1048617
         push.0
@@ -226,13 +278,21 @@ proc.wit_bindgen_rt::run_ctors_once
         swap.1
         dup.1
         dup.1
+        trace.240
+        nop
         exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.4294967040
         u32and
         movup.3
         u32or
         movdn.2
+        trace.240
+        nop
         exec.::intrinsics::mem::store_sw
+        trace.252
+        nop
     end
 end
 
@@ -262,7 +322,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
         push.3735929054
     else
         movup.2
+        trace.240
+        nop
         exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::core::ptr::alignment::Alignment::max
+        trace.252
+        nop
         push.0
         push.2147483648
         dup.2
@@ -297,15 +361,27 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             neq
             if.true
                 push.0
                 swap.3
             else
+                trace.240
+                nop
                 exec.::intrinsics::mem::heap_base
+                trace.252
+                nop
+                trace.240
+                nop
                 exec.::intrinsics::mem::memory_size
+                trace.252
+                nop
                 dup.4
                 push.4
                 dup.1
@@ -323,7 +399,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.0
                 swap.3
             end
@@ -336,7 +416,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             dup.3
             push.268435456
@@ -365,7 +449,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.1
                 swap.1
                 movup.2
@@ -397,6 +485,10 @@ proc.core::ptr::alignment::Alignment::max
 end
 
 export.cabi_realloc
+    trace.240
+    nop
     exec.::miden:cross-ctx-account/foo@1.0.0::cross_ctx_account::cabi_realloc_wit_bindgen_0_28_0
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.masm
@@ -1,12 +1,18 @@
 # mod miden:base/note-script@1.0.0
 
 export.note-script
+    trace.240
+    nop
     exec.::miden:base/note-script@1.0.0::cross_ctx_note::miden:base/note-script@1.0.0#note-script
+    trace.252
+    nop
 end
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.9021226855565145792
     push.4948740029366688057
     push.7925211860580638461
@@ -14,7 +20,9 @@ export.init
     adv.push_mapval
     push.262144
     push.3
+    trace.240
     exec.::std::mem::pipe_preimage_to_memory
+    trace.252
     drop
     push.1048576
     u32assert
@@ -24,7 +32,11 @@ end
 # mod miden:base/note-script@1.0.0::cross_ctx_note
 
 proc.cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1
+    trace.240
+    nop
     call.::miden:cross-ctx-account/foo@1.0.0::process-felt
+    trace.252
+    nop
 end
 
 proc.__wasm_call_ctors
@@ -39,7 +51,11 @@ proc.__rustc::__rust_alloc
     push.1048616
     movup.2
     swap.1
+    trace.240
+    nop
     exec.::miden:base/note-script@1.0.0::cross_ctx_note::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
 end
 
 proc.__rustc::__rust_realloc
@@ -48,7 +64,11 @@ proc.__rustc::__rust_realloc
     swap.2
     swap.4
     swap.1
+    trace.240
+    nop
     exec.::miden:base/note-script@1.0.0::cross_ctx_note::<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+    trace.252
+    nop
     push.0
     push.0
     dup.2
@@ -100,7 +120,11 @@ proc.__rustc::__rust_realloc
                 assertz
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.128
                 u32and
                 swap.1
@@ -108,13 +132,21 @@ proc.__rustc::__rust_realloc
                 swap.1
                 dup.1
                 dup.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
                 push.4294967040
                 u32and
                 movup.3
                 u32or
                 movdn.2
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 u32wrapping_add.1
                 dup.0
                 dup.4
@@ -126,15 +158,27 @@ proc.__rustc::__rust_realloc
 end
 
 export.miden:base/note-script@1.0.0#note-script
+    trace.240
+    nop
     exec.::miden:base/note-script@1.0.0::cross_ctx_note::wit_bindgen_rt::run_ctors_once
+    trace.252
+    nop
     push.7
+    trace.240
+    nop
     exec.::miden:base/note-script@1.0.0::cross_ctx_note::cross_ctx_note::bindings::miden::cross_ctx_account::foo::process_felt::wit_import1
+    trace.252
+    nop
     push.10
     assert_eq
 end
 
 export.cabi_realloc_wit_bindgen_0_28_0
+    trace.240
+    nop
     exec.::miden:base/note-script@1.0.0::cross_ctx_note::wit_bindgen_rt::cabi_realloc
+    trace.252
+    nop
 end
 
 proc.wit_bindgen_rt::cabi_realloc
@@ -143,7 +187,11 @@ proc.wit_bindgen_rt::cabi_realloc
     swap.1
     neq
     if.true
+        trace.240
+        nop
         exec.::miden:base/note-script@1.0.0::cross_ctx_note::__rustc::__rust_realloc
+        trace.252
+        nop
         push.0
         push.3735929054
         movup.2
@@ -165,7 +213,11 @@ proc.wit_bindgen_rt::cabi_realloc
             swap.1
         else
             swap.1
+            trace.240
+            nop
             exec.::miden:base/note-script@1.0.0::cross_ctx_note::__rustc::__rust_alloc
+            trace.252
+            nop
             push.0
             push.3735929054
             movup.2
@@ -213,7 +265,11 @@ proc.wit_bindgen_rt::run_ctors_once
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.128
     u32and
     push.0
@@ -222,7 +278,11 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
+        trace.240
+        nop
         exec.::miden:base/note-script@1.0.0::cross_ctx_note::__wasm_call_ctors
+        trace.252
+        nop
         push.1
         push.1048621
         push.0
@@ -232,13 +292,21 @@ proc.wit_bindgen_rt::run_ctors_once
         swap.1
         dup.1
         dup.1
+        trace.240
+        nop
         exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.4294967040
         u32and
         movup.3
         u32or
         movdn.2
+        trace.240
+        nop
         exec.::intrinsics::mem::store_sw
+        trace.252
+        nop
     end
 end
 
@@ -268,7 +336,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
         push.3735929054
     else
         movup.2
+        trace.240
+        nop
         exec.::miden:base/note-script@1.0.0::cross_ctx_note::core::ptr::alignment::Alignment::max
+        trace.252
+        nop
         push.0
         push.2147483648
         dup.2
@@ -303,15 +375,27 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             neq
             if.true
                 push.0
                 swap.3
             else
+                trace.240
+                nop
                 exec.::intrinsics::mem::heap_base
+                trace.252
+                nop
+                trace.240
+                nop
                 exec.::intrinsics::mem::memory_size
+                trace.252
+                nop
                 dup.4
                 push.4
                 dup.1
@@ -329,7 +413,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.0
                 swap.3
             end
@@ -342,7 +430,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             push.0
             dup.3
             push.268435456
@@ -371,7 +463,11 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 swap.1
                 u32divmod.4
                 swap.1
+                trace.240
+                nop
                 exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
                 push.1
                 swap.1
                 movup.2
@@ -403,6 +499,10 @@ proc.core::ptr::alignment::Alignment::max
 end
 
 export.cabi_realloc
+    trace.240
+    nop
     exec.::miden:base/note-script@1.0.0::cross_ctx_note::cabi_realloc_wit_bindgen_0_28_0
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/shl_i16.masm
+++ b/tests/integration/expected/shl_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shl_i32.masm
+++ b/tests/integration/expected/shl_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shl_i64.masm
+++ b/tests/integration/expected/shl_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -29,6 +31,10 @@ export.entrypoint
     push.4294967295
     u32lte
     assert
+    trace.240
+    nop
     exec.::std::math::u64::shl
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/shl_i8.masm
+++ b/tests/integration/expected/shl_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shl_u16.masm
+++ b/tests/integration/expected/shl_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shl_u32.masm
+++ b/tests/integration/expected/shl_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shl_u64.masm
+++ b/tests/integration/expected/shl_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -29,6 +31,10 @@ export.entrypoint
     push.4294967295
     u32lte
     assert
+    trace.240
+    nop
     exec.::std::math::u64::shl
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/shl_u8.masm
+++ b/tests/integration/expected/shl_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shr_i64.masm
+++ b/tests/integration/expected/shr_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -29,6 +31,10 @@ export.entrypoint
     push.4294967295
     u32lte
     assert
+    trace.240
+    nop
     exec.::intrinsics::i64::checked_shr
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/shr_u16.masm
+++ b/tests/integration/expected/shr_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shr_u32.masm
+++ b/tests/integration/expected/shr_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/shr_u64.masm
+++ b/tests/integration/expected/shr_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -31,6 +33,10 @@ export.entrypoint
     assert
     movdn.2
     movup.2
+    trace.240
+    nop
     exec.::std::math::u64::shr
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/shr_u8.masm
+++ b/tests/integration/expected/shr_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/sub_felt.masm
+++ b/tests/integration/expected/sub_felt.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/sub_i16.masm
+++ b/tests/integration/expected/sub_i16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/sub_i32.masm
+++ b/tests/integration/expected/sub_i32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/sub_i64.masm
+++ b/tests/integration/expected/sub_i64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::std::math::u64::wrapping_sub
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/sub_i8.masm
+++ b/tests/integration/expected/sub_i8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/sub_u16.masm
+++ b/tests/integration/expected/sub_u16.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/sub_u32.masm
+++ b/tests/integration/expected/sub_u32.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/sub_u64.masm
+++ b/tests/integration/expected/sub_u64.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144
@@ -19,6 +21,10 @@ end
 export.entrypoint
     movdn.3
     movdn.3
+    trace.240
+    nop
     exec.::std::math::u64::wrapping_sub
+    trace.252
+    nop
 end
 

--- a/tests/integration/expected/sub_u8.masm
+++ b/tests/integration/expected/sub_u8.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144

--- a/tests/integration/expected/types/array.masm
+++ b/tests/integration/expected/types/array.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.2552035692683956824
     push.5323511717551755022
     push.6168074652703322390
@@ -10,7 +12,9 @@ export.init
     adv.push_mapval
     push.262144
     push.3
+    trace.240
     exec.::std::mem::pipe_preimage_to_memory
+    trace.252
     drop
     push.1048576
     u32assert
@@ -54,7 +58,11 @@ export.sum_arr
             assertz.err=250
             u32divmod.4
             swap.1
+            trace.240
+            nop
             exec.::intrinsics::mem::load_sw
+            trace.252
+            nop
             movup.2
             u32wrapping_add
             push.4294967295
@@ -109,10 +117,18 @@ end
 export.__main
     push.5
     push.1048576
+    trace.240
+    nop
     exec.::root_ns:root@1.0.0::test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6::sum_arr
+    trace.252
+    nop
     push.5
     push.1048596
+    trace.240
+    nop
     exec.::root_ns:root@1.0.0::test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6::sum_arr
+    trace.252
+    nop
     u32wrapping_add
 end
 

--- a/tests/integration/expected/types/static_mut.masm
+++ b/tests/integration/expected/types/static_mut.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.11434542961250426374
     push.12905227908764935604
     push.12374698099726530180
@@ -10,7 +12,9 @@ export.init
     adv.push_mapval
     push.262144
     push.1
+    trace.240
     exec.::std::mem::pipe_preimage_to_memory
+    trace.252
     drop
     push.1048576
     u32assert
@@ -32,7 +36,11 @@ export.global_var_update
     u32assert
     u32divmod.4
     swap.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.128
     u32and
     push.1
@@ -48,17 +56,29 @@ export.global_var_update
     swap.1
     dup.1
     dup.1
+    trace.240
+    nop
     exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
     push.4294967040
     u32and
     movup.3
     u32or
     movdn.2
+    trace.240
+    nop
     exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
 end
 
 export.__main
+    trace.240
+    nop
     exec.::root_ns:root@1.0.0::test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4::global_var_update
+    trace.252
+    nop
     push.3735929054
     push.0
     push.4294967287
@@ -72,7 +92,11 @@ export.__main
         u32wrapping_add
         u32divmod.4
         swap.1
+        trace.240
+        nop
         exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.128
         u32and
         movup.2

--- a/tests/integration/expected/xor_bool.masm
+++ b/tests/integration/expected/xor_bool.masm
@@ -2,7 +2,9 @@
 
 export.init
     push.2162688
+    trace.240
     exec.::intrinsics::mem::heap_init
+    trace.252
     push.1048576
     u32assert
     mem_store.262144


### PR DESCRIPTION
This reinstates call frame tracking for debugging purposes, using a pair of trace events that we listen for in the debug executor in order to construct stack traces.