### PR TITLE
chore: remove `wasm32-wasi` in favor of `wasm32-wasip1`

### DIFF
--- a/examples/collatz/rust-toolchain.toml
+++ b/examples/collatz/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-01-16"
+channel = "nightly-2025-03-20"
 components = ["rustfmt", "rust-src"]
 targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/collatz/rust-toolchain.toml
+++ b/examples/collatz/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2025-01-16"
 components = ["rustfmt", "rust-src"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/fibonacci/rust-toolchain.toml
+++ b/examples/fibonacci/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-01-16"
+channel = "nightly-2025-03-20"
 components = ["rustfmt", "rust-src"]
 targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/fibonacci/rust-toolchain.toml
+++ b/examples/fibonacci/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2025-01-16"
 components = ["rustfmt", "rust-src"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/is-prime/rust-toolchain.toml
+++ b/examples/is-prime/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-01-16"
+channel = "nightly-2025-03-20"
 components = ["rustfmt", "rust-src"]
 targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/is-prime/rust-toolchain.toml
+++ b/examples/is-prime/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2025-01-16"
 components = ["rustfmt", "rust-src"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasip1"]
 profile = "minimal"


### PR DESCRIPTION
Close #513 