### PR TITLE
fix(cfg-to-scf): incorrect folding of continuation region blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,6 +3734,7 @@ name = "midenc-dialect-scf"
 version = "0.0.8"
 dependencies = [
  "bitvec",
+ "env_logger 0.11.5",
  "expect-test",
  "log",
  "midenc-dialect-arith",

--- a/dialects/scf/Cargo.toml
+++ b/dialects/scf/Cargo.toml
@@ -26,3 +26,4 @@ bitvec.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true
+env_logger.workspace = true

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_after.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_after.hir
@@ -1,0 +1,51 @@
+public builtin.function @test(v0: u32, v1: u32, v2: u32, v3: u32) -> u32 {
+^block0(v0: u32, v1: u32, v2: u32, v3: u32):
+    v18 = arith.constant 1 : u32;
+    v17 = ub.poison u32 : u32;
+    v13 = arith.constant 0 : u32;
+    v5 = arith.constant 0 : u32;
+    v6 = arith.neq v1, v5 : i1;
+    v22, v23, v24 = scf.if v6 : u32, u32, u32 {
+    ^block2:
+        v9 = arith.incr v0 : u32;
+        scf.yield v9, v17, v13;
+    } else {
+    ^block3:
+        v10 = arith.neq v3, v5 : i1;
+        v33, v34, v35 = scf.if v10 : u32, u32, u32 {
+        ^block4:
+            v11 = arith.incr v3 : u32;
+            scf.yield v11, v17, v13;
+        } else {
+        ^block5:
+            scf.yield v17, v2, v18;
+        };
+        scf.yield v33, v34, v35;
+    };
+    v29, v30 = scf.index_switch v24 : u32, u32 
+    case 0 {
+    ^block1:
+        v7 = arith.eq v22, v5 : i1;
+        v8 = arith.neq v7, v5 : i1;
+        v31, v32 = scf.if v8 : u32, u32 {
+        ^block6:
+            scf.yield v17, v18;
+        } else {
+        ^block7:
+            scf.yield v22, v13;
+        };
+        scf.yield v31, v32;
+    }
+    default {
+    ^block13:
+        scf.yield v23, v13;
+    };
+    cf.switch v30 {
+        case 0 => ^block8(v29)
+        default => ^block9
+    };
+^block8(v12: u32):
+    builtin.ret v12;
+^block9:
+    ub.unreachable ;
+};

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_before.hir
@@ -1,0 +1,25 @@
+public builtin.function @test(v0: u32, v1: u32, v2: u32, v3: u32) -> u32 {
+^block0(v0: u32, v1: u32, v2: u32, v3: u32):
+    v5 = arith.constant 0 : u32;
+    v6 = arith.neq v1, v5 : i1;
+    cf.cond_br v6 ^block2, ^block3;
+^block1(v4: u32):
+    v7 = arith.eq v4, v5 : i1;
+    v8 = arith.neq v7, v5 : i1;
+    cf.cond_br v8 ^block6, ^block7;
+^block2:
+    v9 = arith.incr v0 : u32;
+    cf.br ^block1(v9);
+^block3:
+    v10 = arith.neq v3, v5 : i1;
+    cf.cond_br v10 ^block4, ^block5;
+^block4:
+    v11 = arith.incr v3 : u32;
+    cf.br ^block1(v11);
+^block5:
+    builtin.ret v2;
+^block6:
+    ub.unreachable ;
+^block7:
+    builtin.ret v4;
+};

--- a/hir-transform/src/cfg_to_scf/edges.rs
+++ b/hir-transform/src/cfg_to_scf/edges.rs
@@ -47,7 +47,7 @@ impl core::fmt::Display for Edge {
         write!(
             f,
             "{} -> {} (index {})",
-            self.get_predecessor(),
+            self.from_block,
             self.get_successor(),
             self.successor_index
         )

--- a/hir-transform/src/cfg_to_scf/transform.rs
+++ b/hir-transform/src/cfg_to_scf/transform.rs
@@ -274,6 +274,11 @@ impl<'a> TransformationContext<'a> {
     ) -> Result<SmallVec<[BlockRef; 4]>, Report> {
         use midenc_hir::cfg::StronglyConnectedComponents;
 
+        log::trace!(
+            target: "cfg-to-scf",
+            "transforming cycles to structured loops from region entry {region_entry}"
+        );
+
         let mut new_sub_regions = SmallVec::<[BlockRef; 4]>::default();
 
         let scc_iter = StronglyConnectedComponents::new(&region_entry);
@@ -411,7 +416,14 @@ impl<'a> TransformationContext<'a> {
         &mut self,
         mut region_entry: BlockRef,
     ) -> Result<SmallVec<[BlockRef; 4]>, Report> {
+        log::trace!(
+            target: "cfg-to-scf",
+            "transforming conditional control flow for region reachable from {region_entry}"
+        );
+
         let num_successors = region_entry.borrow().num_successors();
+
+        log::trace!(target: "cfg-to-scf", "{region_entry} has {num_successors} successors");
 
         // Trivial region.
         if num_successors == 0 {
@@ -489,8 +501,12 @@ impl<'a> TransformationContext<'a> {
                         not_continuation.insert(block);
                     }
                 }
+
+                log::trace!(target: "cfg-to-scf", "computed region for successor {dest} as [{}]", DisplayValues::new(block_list.iter()));
             }
         }
+
+        log::trace!(target: "cfg-to-scf", "non-continuation blocks: [{}]", DisplayValues::new(not_continuation.iter()));
 
         // Finds all relevant edges and checks the shape of the control flow graph at this point.
         //
@@ -563,11 +579,17 @@ impl<'a> TransformationContext<'a> {
         for (entry_edge, branch_region) in
             SuccessorEdges::new(region_entry).zip(successor_branch_regions.iter_mut())
         {
+            log::trace!(
+                target: "cfg-to-scf",
+                "analyzing branch region for edge {entry_edge}: [{}]",
+                DisplayValues::new(branch_region.iter())
+            );
+
             // If the branch region is empty then the branch target itself is part of the
             // continuation.
             if branch_region.is_empty() {
                 continuation_edges.push(entry_edge);
-                log::trace!(target: "cfg-to-scf", " empty branch region for edge {} -> {}", entry_edge.from_block, entry_edge.get_successor());
+                log::trace!(target: "cfg-to-scf", " branch region is empty");
                 no_successor_has_continuation_edge = false;
                 continue;
             }
@@ -575,6 +597,7 @@ impl<'a> TransformationContext<'a> {
             for block_ref in branch_region.iter() {
                 let block = block_ref.borrow();
                 if is_region_exit_block(&block) {
+                    log::trace!(target: "cfg-to-scf", " {} is a region exit", block);
                     // If a return-like op is part of the branch region then the continuation no
                     // longer post-dominates the branch region. Add all its incoming edges to edge
                     // list to create the single-exit block for all branch regions.
@@ -589,6 +612,7 @@ impl<'a> TransformationContext<'a> {
                 }
 
                 for edge in SuccessorEdges::new(*block_ref) {
+                    log::trace!(target: "cfg-to-scf",  "analyzing successor edge {edge}");
                     if not_continuation.contains(&edge.get_successor()) {
                         continue;
                     }
@@ -599,8 +623,14 @@ impl<'a> TransformationContext<'a> {
             }
         }
 
+        log::trace!(
+            target: "cfg-to-scf",
+            " found continuation edges: [{}]", DisplayValues::new(continuation_edges.iter())
+        );
+
         // Case 2: Keep the control flow op but process its successors further.
         if no_successor_has_continuation_edge {
+            log::trace!(target: "cfg-to-scf", " no successor has a continuation edge");
             let term = region_entry.borrow().terminator().unwrap();
             let term = term.borrow();
             return Ok(term.successor_iter().map(|s| s.dest.borrow().successor()).collect());
@@ -634,6 +664,7 @@ impl<'a> TransformationContext<'a> {
             let span = term.borrow().span();
             let multiplexer = self.create_single_entry_block(span, &continuation_edges)?;
             continuation = Some(multiplexer.get_multiplexer_block());
+            log::trace!(target: "cfg-to-scf", " created new single entry continuation = {}", multiplexer.get_multiplexer_block());
         }
 
         // Trigger reprocessing of Case 3 after creating the single entry block.


### PR DESCRIPTION
This fixes the issue reported in #510, adds a new test case that covers the structure of the IR that triggered it, and adds some additional instrumentation I found helpful when diagnosing it.