### PR TITLE
refactor: simplify function builder to enable better instrumentation

### DIFF
--- a/codegen/masm/src/lower/utils.rs
+++ b/codegen/masm/src/lower/utils.rs
@@ -511,7 +511,7 @@ mod tests {
 
         let mut builder = OpBuilder::new(context.clone());
 
-        let mut function_ref = builder.create_function(
+        let function_ref = builder.create_function(
             Ident::with_empty_span("test".into()),
             Signature::new(
                 [AbiParam::new(Type::U32), AbiParam::new(Type::U32)],
@@ -520,9 +520,8 @@ mod tests {
         )?;
 
         let (a, b) = {
-            let mut function = function_ref.borrow_mut();
-            let span = function.span();
-            let mut builder = FunctionBuilder::new(&mut function, &mut builder);
+            let span = function_ref.span();
+            let mut builder = FunctionBuilder::new(function_ref, &mut builder);
             let entry = builder.entry_block();
             let a = builder.entry_block().borrow().arguments()[0] as ValueRef;
             let b = builder.entry_block().borrow().arguments()[1] as ValueRef;
@@ -598,7 +597,7 @@ mod tests {
 
         let mut builder = OpBuilder::new(context.clone());
 
-        let mut function_ref = builder.create_function(
+        let function_ref = builder.create_function(
             Ident::with_empty_span("test".into()),
             Signature::new(
                 [AbiParam::new(Type::U32), AbiParam::new(Type::U32)],
@@ -607,9 +606,8 @@ mod tests {
         )?;
 
         let (a, b) = {
-            let mut function = function_ref.borrow_mut();
-            let span = function.span();
-            let mut builder = FunctionBuilder::new(&mut function, &mut builder);
+            let span = function_ref.span();
+            let mut builder = FunctionBuilder::new(function_ref, &mut builder);
             let entry = builder.entry_block();
             let a = builder.entry_block().borrow().arguments()[0] as ValueRef;
             let b = builder.entry_block().borrow().arguments()[1] as ValueRef;
@@ -828,7 +826,7 @@ mod tests {
     ) -> Result<(FunctionRef, masm::Block), Report> {
         let mut builder = OpBuilder::new(context.clone());
 
-        let mut function_ref = builder.create_function(
+        let function_ref = builder.create_function(
             Ident::with_empty_span("test".into()),
             Signature::new(
                 [AbiParam::new(Type::U32), AbiParam::new(Type::U32)],
@@ -837,9 +835,8 @@ mod tests {
         )?;
 
         let (a, b) = {
-            let mut function = function_ref.borrow_mut();
-            let span = function.span();
-            let mut builder = FunctionBuilder::new(&mut function, &mut builder);
+            let span = function_ref.span();
+            let mut builder = FunctionBuilder::new(function_ref, &mut builder);
             let entry = builder.entry_block();
             let a = builder.entry_block().borrow().arguments()[0] as ValueRef;
             let b = builder.entry_block().borrow().arguments()[1] as ValueRef;

--- a/dialects/scf/src/transforms/cfg_to_scf.rs
+++ b/dialects/scf/src/transforms/cfg_to_scf.rs
@@ -384,7 +384,7 @@ mod tests {
         let mut builder = OpBuilder::new(context.clone());
 
         let span = SourceSpan::default();
-        let mut function = {
+        let function = {
             let builder = builder.create::<builtin::Function, (_, _)>(span);
             let name = Ident::new("test".into(), span);
             let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
@@ -392,8 +392,7 @@ mod tests {
         };
 
         // Define function body
-        let mut func = function.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
 
         let if_is_zero = builder.create_block();
         let if_is_nonzero = builder.create_block();
@@ -418,9 +417,7 @@ mod tests {
         builder.switch_to_block(exit_block);
         builder.ret(Some(return_val), span)?;
 
-        let operation = func.as_operation_ref();
-        drop(func);
-
+        let operation = function.as_operation_ref();
         // Run transformation on function body
         let input = format!("{}", &operation.borrow());
         expect_file!["expected/cfg_to_scf_lift_simple_conditional_before.hir"].assert_eq(&input);
@@ -451,7 +448,7 @@ mod tests {
         let mut builder = OpBuilder::new(context.clone());
 
         let span = SourceSpan::default();
-        let mut function = {
+        let function = {
             let builder = builder.create::<builtin::Function, (_, _)>(span);
             let name = Ident::new("test".into(), span);
             let signature = Signature::new(
@@ -467,8 +464,7 @@ mod tests {
         };
 
         // Define function body
-        let mut func = function.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
 
         // This is the HIR we derived this test case from originally, as reported in issue #510
         //
@@ -549,8 +545,7 @@ mod tests {
         builder.switch_to_block(block40);
         builder.ret(Some(v343), span)?;
 
-        let operation = func.as_operation_ref();
-        drop(func);
+        let operation = function.as_operation_ref();
 
         // Run transformation on function body
         let input = format!("{}", &operation.borrow());
@@ -576,7 +571,7 @@ mod tests {
         let mut builder = OpBuilder::new(context.clone());
 
         let span = SourceSpan::default();
-        let mut function = {
+        let function = {
             let builder = builder.create::<builtin::Function, (_, _)>(span);
             let name = Ident::new("test".into(), span);
             let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
@@ -584,8 +579,7 @@ mod tests {
         };
 
         // Define function body
-        let mut func = function.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
 
         let loop_header = builder.create_block();
         let n = builder.append_block_param(loop_header, Type::U32, span);
@@ -612,8 +606,7 @@ mod tests {
         let counter_prime = builder.incr(counter, span)?;
         builder.br(loop_header, [n_prime, counter_prime], span)?;
 
-        let operation = func.as_operation_ref();
-        drop(func);
+        let operation = function.as_operation_ref();
 
         // Run transformation on function body
         let input = format!("{}", &operation.borrow());
@@ -637,7 +630,7 @@ mod tests {
         let mut builder = OpBuilder::new(context.clone());
 
         let span = SourceSpan::default();
-        let mut function = {
+        let function = {
             let builder = builder.create::<builtin::Function, (_, _)>(span);
             let name = Ident::new("test".into(), span);
             let signature = Signature::new(
@@ -670,8 +663,7 @@ mod tests {
         //     return sum;
         // }
         //
-        let mut func = function.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
 
         let outer_loop_header = builder.create_block();
         let inner_loop_header = builder.create_block();
@@ -727,8 +719,7 @@ mod tests {
         let new_sum = builder.add_unchecked(col_sum, cell, span)?;
         builder.br(inner_loop_header, [new_col_offset, new_sum], span)?;
 
-        let operation = func.as_operation_ref();
-        drop(func);
+        let operation = function.as_operation_ref();
 
         // Run transformation on function body
         let input = format!("{}", &operation.borrow());
@@ -752,7 +743,7 @@ mod tests {
         let mut builder = OpBuilder::new(context.clone());
 
         let span = SourceSpan::default();
-        let mut function = {
+        let function = {
             let builder = builder.create::<builtin::Function, (_, _)>(span);
             let name = Ident::new("test".into(), span);
             let signature = Signature::new(
@@ -789,8 +780,7 @@ mod tests {
         //     return sum;
         // }
         //
-        let mut func = function.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
 
         let outer_loop_header = builder.create_block();
         let inner_loop_header = builder.create_block();
@@ -857,8 +847,7 @@ mod tests {
         builder.switch_to_block(has_overflowed);
         builder.ret_imm(midenc_hir::Immediate::U32(u32::MAX), span)?;
 
-        let operation = func.as_operation_ref();
-        drop(func);
+        let operation = function.as_operation_ref();
 
         // Run transformation on function body
         let input = format!("{}", &operation.borrow());

--- a/eval/src/tests.rs
+++ b/eval/src/tests.rs
@@ -72,14 +72,13 @@ fn eval_callable_test() -> Result<(), Report> {
 
     let mut builder = OpBuilder::new(test_context.context.clone());
 
-    let mut function = builder.create_function(
+    let function = builder.create_function(
         Ident::with_empty_span("test".into()),
         Signature::new([AbiParam::new(Type::I1)], [AbiParam::new(Type::U32)]),
     )?;
 
     {
-        let mut function = function.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut function, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
         let cond = builder.current_block().borrow().arguments()[0] as ValueRef;
         let conditional = builder.r#if(cond, &[Type::U32], SourceSpan::default())?;
         let result = conditional.borrow().results()[0] as ValueRef;
@@ -126,7 +125,7 @@ fn call_handling_test() -> Result<(), Report> {
     builder.create_block(module_body, None, &[]);
 
     // Define entry
-    let mut entry = builder.create_function(
+    let entry = builder.create_function(
         Ident::with_empty_span("entrypoint".into()),
         Signature::new([AbiParam::new(Type::I1)], [AbiParam::new(Type::U32)]),
     )?;
@@ -137,7 +136,7 @@ fn call_handling_test() -> Result<(), Report> {
 
     // Define callee
     let callee_signature = Signature::new([AbiParam::new(Type::I1)], [AbiParam::new(Type::I1)]);
-    let mut callee = builder
+    let callee = builder
         .create_function(Ident::with_empty_span("callee".into()), callee_signature.clone())?;
     module
         .borrow_mut()
@@ -145,8 +144,7 @@ fn call_handling_test() -> Result<(), Report> {
         .insert_new(callee, ProgramPoint::Invalid);
 
     {
-        let mut function = entry.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut function, &mut builder);
+        let mut builder = FunctionBuilder::new(entry, &mut builder);
         let input = builder.current_block().borrow().arguments()[0] as ValueRef;
         let call = builder.exec(callee, callee_signature, [input], SourceSpan::default())?;
         let cond = call.borrow().results()[0] as ValueRef;
@@ -169,8 +167,7 @@ fn call_handling_test() -> Result<(), Report> {
 
     // This function inverts the boolean value it receives and returns it
     {
-        let mut function = callee.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut function, &mut builder);
+        let mut builder = FunctionBuilder::new(callee, &mut builder);
         let cond = builder.current_block().borrow().arguments()[0] as ValueRef;
         let truthy = builder.i1(true, SourceSpan::default());
         let falsey = builder.i1(false, SourceSpan::default());

--- a/frontend/wasm/src/module/build_ir.rs
+++ b/frontend/wasm/src/module/build_ir.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use midenc_hir::{
     constants::ConstantData,
     dialects::builtin::{
-        self, BuiltinOpBuilder, ComponentBuilder, Function, ModuleBuilder, World, WorldBuilder,
+        self, BuiltinOpBuilder, ComponentBuilder, ModuleBuilder, World, WorldBuilder,
     },
     interner::Symbol,
     version::Version,
@@ -125,20 +125,16 @@ pub fn build_ir_module(
         let func_index = parsed_module.module.func_index(defined_func_idx);
         let func_name = parsed_module.module.func_name(func_index).as_str();
 
-        let mut function_ref = module_state
-            .module_builder
-            .get_function(func_name)
-            .unwrap_or_else(|| {
+        let function_ref =
+            module_state.module_builder.get_function(func_name).unwrap_or_else(|| {
                 panic!("cannot build {func_name} function, since it is not defined in the module.")
-            })
-            .borrow_mut();
-        let func = function_ref.as_mut().downcast_mut::<Function>().unwrap();
+            });
         // let mut module_func_builder = module_builder.function(func_name.as_str(), sig.clone())?;
         let FunctionBodyData { validator, body } = body_data;
         let mut func_validator = validator.into_validator(Default::default());
         func_translator.translate_body(
             &body,
-            func,
+            function_ref,
             module_state,
             parsed_module,
             module_types,

--- a/hir/src/matchers/matcher.rs
+++ b/hir/src/matchers/matcher.rs
@@ -752,7 +752,7 @@ mod tests {
     fn setup(context: Rc<Context>) -> (ValueRef, ValueRef, ValueRef) {
         let mut builder = OpBuilder::new(Rc::clone(&context));
 
-        let mut function = {
+        let function = {
             let builder = builder.create::<Function, (_, _)>(SourceSpan::default());
             let name = Ident::new("test".into(), SourceSpan::default());
             let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
@@ -760,8 +760,7 @@ mod tests {
         };
 
         // Define function body
-        let mut func = function.borrow_mut();
-        let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
         let lhs = builder.u32(1, SourceSpan::default()).unwrap();
         let block = builder.current_block();
         let rhs = block.borrow().arguments()[0].upcast();

--- a/hir/src/patterns/pattern.rs
+++ b/hir/src/patterns/pattern.rs
@@ -327,7 +327,7 @@ mod tests {
         let pattern = ConvertShiftLeftBy1ToMultiply::new(Rc::clone(&context));
 
         let mut builder = OpBuilder::new(Rc::clone(&context));
-        let mut function = {
+        let function = {
             let builder = builder.create::<Function, (_, _)>(SourceSpan::default());
             let name = Ident::new("test".into(), SourceSpan::default());
             let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
@@ -336,8 +336,7 @@ mod tests {
 
         // Define function body
         {
-            let mut func = function.borrow_mut();
-            let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+            let mut builder = FunctionBuilder::new(function, &mut builder);
             let shift = builder.u32(1, SourceSpan::default()).unwrap();
             let block = builder.current_block();
             let lhs = block.borrow().arguments()[0].upcast();

--- a/tests/integration/src/testing/setup.rs
+++ b/tests/integration/src/testing/setup.rs
@@ -129,7 +129,7 @@ where
             .define_module(Ident::with_empty_span("test".into()))
             .unwrap_or_else(|err| panic!("failed to define module:\n{}", format_report(err)))
     };
-    let mut function = {
+    let function = {
         let mut module_builder = ModuleBuilder::new(module);
         module_builder
             .define_function(Ident::with_empty_span("main".into()), signature.clone())
@@ -138,10 +138,9 @@ where
 
     // Define function body
     {
-        let mut func = function.borrow_mut();
-        let context = func.as_operation().context_rc();
+        let context = function.borrow().as_operation().context_rc();
         let mut builder = OpBuilder::new(context);
-        let mut builder = FunctionBuilder::new(&mut func, &mut builder);
+        let mut builder = FunctionBuilder::new(function, &mut builder);
         build(&mut builder);
     }
 


### PR DESCRIPTION
The FunctionBuilder was requiring us to hold a mutable reference to the underlying Function, which meant that if we wished to print the current Function while tracing is enabled in the compiler, it would always fail when a FunctionBuilder is in scope.

This change refactors it to take a FunctionRef instead, and dynamically borrow as needed to avoid holding a borrow for the entire lifetime of the FunctionBuilder.