### PR TITLE
chore: update org references from 0xPolygonMiden to 0xMiden

### DIFF
--- a/codegen/masm/CHANGELOG.md
+++ b/codegen/masm/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - switch to `Package` without rodata,
 - [**breaking**] move `Package` to `miden-package` in the VM repo
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.6...midenc-codegen-masm-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.6...midenc-codegen-masm-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.2...midenc-codegen-masm-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.2...midenc-codegen-masm-v0.0.3) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
@@ -68,12 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 - fix clippy warnings in tests
-- Merge pull request [#290](https://github.com/0xPolygonMiden/compiler/pull/290) from 0xPolygonMiden/greenhat/i263-mem-intrinsics-felts-tests
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#290](https://github.com/0xMiden/compiler/pull/290) from 0xMiden/greenhat/i263-mem-intrinsics-felts-tests
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 - *(codegen)* clippy suggested some improvements
 - *(codegen)* be consistent about the way in which we push to stack
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.1...midenc-codegen-masm-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.1...midenc-codegen-masm-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
@@ -84,9 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use less fragile method for rodata segment init
 
 ### Other
-- Merge pull request [#269](https://github.com/0xPolygonMiden/compiler/pull/269) from 0xPolygonMiden/greenhat/i267-store-load-dw
+- Merge pull request [#269](https://github.com/0xMiden/compiler/pull/269) from 0xMiden/greenhat/i267-store-load-dw
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.0...midenc-codegen-masm-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.0...midenc-codegen-masm-v0.0.1) - 2024-07-18
 
 ### Added
 - *(codegen)* implement lowering for local var ops
@@ -162,28 +162,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(stackify)* update pass, fix various bugs uncovered in testing
 
 ### Other
-- Merge pull request [#238](https://github.com/0xPolygonMiden/compiler/pull/238) from 0xPolygonMiden/greenhat/i230-get-inputs-clk451-assert
-- Merge pull request [#237](https://github.com/0xPolygonMiden/compiler/pull/237) from 0xPolygonMiden/greenhat/emu-print-stack-option
-- Merge pull request [#244](https://github.com/0xPolygonMiden/compiler/pull/244) from 0xPolygonMiden/bitwalker/load-store-reordering
-- Merge pull request [#241](https://github.com/0xPolygonMiden/compiler/pull/241) from 0xPolygonMiden/bitwalker/operand-stack-overflow
+- Merge pull request [#238](https://github.com/0xMiden/compiler/pull/238) from 0xMiden/greenhat/i230-get-inputs-clk451-assert
+- Merge pull request [#237](https://github.com/0xMiden/compiler/pull/237) from 0xMiden/greenhat/emu-print-stack-option
+- Merge pull request [#244](https://github.com/0xMiden/compiler/pull/244) from 0xMiden/bitwalker/load-store-reordering
+- Merge pull request [#241](https://github.com/0xMiden/compiler/pull/241) from 0xMiden/bitwalker/operand-stack-overflow
 - clean up docs and implementation of spills rewrite
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - restore running MASM on the emulator along the VM in integration tests
 - update VM to the commit in next branch after the merge
 - workaround for calling the absolute path functions in the emulator
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
-- Merge pull request [#203](https://github.com/0xPolygonMiden/compiler/pull/203) from 0xPolygonMiden/greenhat/get-inputs-compile-succ
+- Merge pull request [#203](https://github.com/0xMiden/compiler/pull/203) from 0xMiden/greenhat/get-inputs-compile-succ
 - add duplicated stack operands test for the stack operand
 - ensure all relevant crates are prefixed with `midenc-`
 - fix clippy warning
 - draft abi transform test for stdlib blake3 hash function
-- Merge pull request [#182](https://github.com/0xPolygonMiden/compiler/pull/182) from 0xPolygonMiden/bitwalker/emit-stores
-- Merge pull request [#187](https://github.com/0xPolygonMiden/compiler/pull/187) from 0xPolygonMiden/bitwalker/account-compilation-fixes
+- Merge pull request [#182](https://github.com/0xMiden/compiler/pull/182) from 0xMiden/bitwalker/emit-stores
+- Merge pull request [#187](https://github.com/0xMiden/compiler/pull/187) from 0xMiden/bitwalker/account-compilation-fixes
 - check rustfmt on CI, format code with rustfmt
 - run clippy on CI, fix all clippy warnings
-- Merge pull request [#179](https://github.com/0xPolygonMiden/compiler/pull/179) from 0xPolygonMiden/greenhat/inttoptr-for-gv-store
+- Merge pull request [#179](https://github.com/0xMiden/compiler/pull/179) from 0xMiden/greenhat/inttoptr-for-gv-store
 - add explanatory text regarding choice of data structure in codegen entities
 - update expect tests due to formatting changes in assembler
 - handle assembler refactoring changes
@@ -192,7 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update rust toolchain to latest nightly
 - a few minor improvements
 - *(docs)* fix typos
-- Merge pull request [#99](https://github.com/0xPolygonMiden/compiler/pull/99) from 0xPolygonMiden/bitwalker/book
+- Merge pull request [#99](https://github.com/0xMiden/compiler/pull/99) from 0xMiden/bitwalker/book
 - set up mdbook deploy
 - add guides for compiling rust->masm
 - remove unused dependencies

--- a/hir-analysis/CHANGELOG.md
+++ b/hir-analysis/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - normalize use of fxhash-based hash maps
 - rename Call IR op to Exec
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.6...midenc-hir-analysis-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.6...midenc-hir-analysis-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -33,17 +33,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.2...midenc-hir-analysis-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.2...midenc-hir-analysis-v0.0.3) - 2024-08-30
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.1...midenc-hir-analysis-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.1...midenc-hir-analysis-v0.0.2) - 2024-08-28
 
 ### Fixed
 - *(frontend-wasm)* reserve memory allocated for use by rust
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.0...midenc-hir-analysis-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-analysis-v0.0.0...midenc-hir-analysis-v0.0.1) - 2024-07-18
 
 ### Added
 - *(analysis)* implement iterated dominance frontier queries
@@ -73,10 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hir and hir-analysis tests
 
 ### Other
-- Merge pull request [#244](https://github.com/0xPolygonMiden/compiler/pull/244) from 0xPolygonMiden/bitwalker/load-store-reordering
+- Merge pull request [#244](https://github.com/0xMiden/compiler/pull/244) from 0xMiden/bitwalker/load-store-reordering
 - clean up docs and implementation of spills rewrite
 - *(analysis)* improve dominance frontier docs
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates

--- a/hir-macros/CHANGELOG.md
+++ b/hir-macros/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-macros-v0.0.1...midenc-hir-macros-v0.0.2) - 2024-08-16
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-macros-v0.0.1...midenc-hir-macros-v0.0.2) - 2024-08-16
 
 ### Fixed
 - *(cli)* improve help output, hide plumbing flags
@@ -47,12 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - unify diagnostics infa between compiler, assembler, vm
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-macros-v0.0.0...midenc-hir-macros-v0.0.1) - 2024-07-25
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-macros-v0.0.0...midenc-hir-macros-v0.0.1) - 2024-07-25
 
 ### Other
 - enable publish for `midenc-hir-macros` crate and restore
 - manually bump `midenc-hir-macros` version after release-plz
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - ensure all relevant crates are prefixed with `midenc-`
 - add formatter config, format most crates

--- a/hir-symbol/CHANGELOG.md
+++ b/hir-symbol/CHANGELOG.md
@@ -31,12 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - clean up unused deps
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-symbol-v0.0.1...midenc-hir-symbol-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-symbol-v0.0.1...midenc-hir-symbol-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-symbol-v0.0.0...midenc-hir-symbol-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-symbol-v0.0.0...midenc-hir-symbol-v0.0.1) - 2024-07-18
 
 ### Added
 - add attributes to the ir
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add hir-symbol crate
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates

--- a/hir-transform/CHANGELOG.md
+++ b/hir-transform/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - normalize use of fxhash-based hash maps
 - rename Call IR op to Exec
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-transform-v0.0.6...midenc-hir-transform-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.0.6...midenc-hir-transform-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-transform-v0.0.1...midenc-hir-transform-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.0.1...midenc-hir-transform-v0.0.2) - 2024-08-28
 
 ### Fixed
 - inoperative --print-ir-after-*, add --print-cfg-after-*
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add additional tracing to treeify pass
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-transform-v0.0.0...midenc-hir-transform-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.0.0...midenc-hir-transform-v0.0.1) - 2024-07-18
 
 ### Added
 - enable spills transformation in default pipeline
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - clean up docs and implementation of spills rewrite
 - transform tests, fixes
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates

--- a/hir-type/CHANGELOG.md
+++ b/hir-type/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update rust toolchain, clean up deps
 - implement hir dialect ops, flesh out remaining core ir infra
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.6...midenc-hir-type-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.6...midenc-hir-type-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -27,20 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.2...midenc-hir-type-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.2...midenc-hir-type-v0.0.3) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.1...midenc-hir-type-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.1...midenc-hir-type-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.0...midenc-hir-type-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-type-v0.0.0...midenc-hir-type-v0.0.1) - 2024-07-18
 
 ### Added
 - draft Miden ABI function types encoding and retrieval
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rewrite incorrect type layout code
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - Fix descriptions for crates
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add a description for miden-hir-type crate
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add Wasm component translation support to the integration tests;
 - add formatter config, format most crates
 - update rust toolchain to latest nightly
-- Merge pull request [#100](https://github.com/0xPolygonMiden/compiler/pull/100) from 0xPolygonMiden/greenhat/i89-translate-wasm-cm
+- Merge pull request [#100](https://github.com/0xMiden/compiler/pull/100) from 0xMiden/greenhat/i89-translate-wasm-cm
 - move `LiftedFunctionType` to `miden-hir-type` crate
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/hir/CHANGELOG.md
+++ b/hir/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add note script compilation test;
 - remove digest-in-function-name encoding and `MidenAbiImport::digest`,
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-v0.0.6...midenc-hir-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.0.6...midenc-hir-v0.0.7) - 2024-09-17
 
 ### Other
 - fix up new clippy warnings
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - clean up unused deps
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-v0.0.1...midenc-hir-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.0.1...midenc-hir-v0.0.2) - 2024-08-28
 
 ### Added
 - implement packaging prototype
@@ -85,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-v0.0.0...midenc-hir-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.0.0...midenc-hir-v0.0.1) - 2024-07-18
 
 ### Added
 - implement memset, memcpy, mem_grow, mem_size, and bitcast ops
@@ -191,10 +191,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hir and hir-analysis tests
 
 ### Other
-- Merge pull request [#237](https://github.com/0xPolygonMiden/compiler/pull/237) from 0xPolygonMiden/greenhat/emu-print-stack-option
+- Merge pull request [#237](https://github.com/0xMiden/compiler/pull/237) from 0xMiden/greenhat/emu-print-stack-option
 - use `BTreeSet` for "dirty" memory addresses(ordered) in the emulator
 - add `Emulator::print_trace` option to print the current stack
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
 - update the Miden VM deps to the `ddf536c` commit with `if.true` empty
@@ -208,7 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove formatter
 - draft a layout for intrinsics semantic tests,
 - since all the Miden ABI transformation happens in the frontend
-- Merge pull request [#140](https://github.com/0xPolygonMiden/compiler/pull/140) from 0xPolygonMiden/greenhat/i138-rust-miden-sdk
+- Merge pull request [#140](https://github.com/0xMiden/compiler/pull/140) from 0xMiden/greenhat/i138-rust-miden-sdk
 - add `FunctionType::abi` and ditch redundant `*FunctionType`
 - skip printing the import name for `MidenAbiImport` component import
 - intern module name and all names used in the module
@@ -218,13 +218,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add Wasm component translation support to the integration tests;
 - add formatter config, format most crates
 - update rust toolchain to latest nightly
-- Merge pull request [#100](https://github.com/0xPolygonMiden/compiler/pull/100) from 0xPolygonMiden/greenhat/i89-translate-wasm-cm
+- Merge pull request [#100](https://github.com/0xMiden/compiler/pull/100) from 0xMiden/greenhat/i89-translate-wasm-cm
 - move `LiftedFunctionType` to `miden-hir-type` crate
 - use `digest` name for MAST root hashes;
 - remove `MastRootHash` in favor of `RpoDigest`;
 - move `MastRootHash` and `Interface*` types to their modules;
 - add missing doc comments
-- Merge pull request [#99](https://github.com/0xPolygonMiden/compiler/pull/99) from 0xPolygonMiden/bitwalker/book
+- Merge pull request [#99](https://github.com/0xMiden/compiler/pull/99) from 0xMiden/bitwalker/book
 - set up mdbook deploy
 - add guides for compiling rust->masm
 - remove unused dependencies

--- a/midenc-compile/CHANGELOG.md
+++ b/midenc-compile/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-compile-v0.0.0...midenc-compile-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-compile-v0.0.0...midenc-compile-v0.0.1) - 2024-07-18
 
 ### Added
 - enable spills transformation in default pipeline
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - properly handle emitting final artifacts in midenc-compile
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - ensure all relevant crates are prefixed with `midenc-`
 - run clippy on CI, fix all clippy warnings
@@ -91,12 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use midenc driver to compile cargo-based fixtures
 - handle assembler refactoring changes
 - add formatter config, format most crates
-- Merge pull request [#100](https://github.com/0xPolygonMiden/compiler/pull/100) from 0xPolygonMiden/greenhat/i89-translate-wasm-cm
+- Merge pull request [#100](https://github.com/0xMiden/compiler/pull/100) from 0xMiden/greenhat/i89-translate-wasm-cm
 - a few minor improvements
 - *(docs)* fix typos
 - set up mdbook deploy
 - add guides for compiling rust->masm
-- Merge pull request [#61](https://github.com/0xPolygonMiden/compiler/pull/61) from 0xPolygonMiden/greenhat/cargo-ext-i60
+- Merge pull request [#61](https://github.com/0xMiden/compiler/pull/61) from 0xMiden/greenhat/cargo-ext-i60
 - make `WasmTranslationConfig::module_name_fallback` non-optional
 - switch from emiting MASM in CodegenStage, and switch to output folder in cargo extension
 - split up driver components into separate crates

--- a/midenc-debug/CHANGELOG.md
+++ b/midenc-debug/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - switch to `Package` without rodata,
 - [**breaking**] move `Package` to `miden-package` in the VM repo
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.6...midenc-debug-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.0.6...midenc-debug-v0.0.7) - 2024-09-17
 
 ### Other
 - update rust toolchain
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - revisit/update documentation and guides
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.1...midenc-debug-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.0.1...midenc-debug-v0.0.2) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
@@ -55,13 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - fix clippy warnings in tests
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.0...midenc-debug-v0.0.1) - 2024-08-16
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.0.0...midenc-debug-v0.0.1) - 2024-08-16
 
 ### Other
 - set `midenc-debug` version to `0.0.0` to be in sync with crates.io
 - clean up naming in midenc-debug
 - rename midenc-runner to midenc-debug
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - a few minor improvements
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/midenc-driver/CHANGELOG.md
+++ b/midenc-driver/CHANGELOG.md
@@ -22,13 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-driver-v0.0.0...midenc-driver-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-driver-v0.0.0...midenc-driver-v0.0.1) - 2024-07-18
 
 ### Added
 - implement compiler driver, update midenc
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - ensure all relevant crates are prefixed with `midenc-`
 - add formatter config, format most crates

--- a/midenc-session/CHANGELOG.md
+++ b/midenc-session/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [**breaking**] move `Package` to `miden-package` in the VM repo
 - add note script compilation test;
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.6...midenc-session-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.6...midenc-session-v0.0.7) - 2024-09-17
 
 ### Other
 - update rust toolchain
@@ -42,12 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.4](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.3...midenc-session-v0.0.4) - 2024-08-30
+## [0.0.4](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.3...midenc-session-v0.0.4) - 2024-08-30
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.2...midenc-session-v0.0.3) - 2024-08-28
+## [0.0.3](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.2...midenc-session-v0.0.3) - 2024-08-28
 
 ### Added
 - implement packaging prototype
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.1...midenc-session-v0.0.2) - 2024-08-16
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.1...midenc-session-v0.0.2) - 2024-08-16
 
 ### Added
 - *(codegen)* propagate source spans from hir to masm
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - unify diagnostics infa between compiler, assembler, vm
 - unify compilation, rodata init, test harness
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.0...midenc-session-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-session-v0.0.0...midenc-session-v0.0.1) - 2024-07-18
 
 ### Added
 - implement compiler driver, update midenc
@@ -98,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - properly handle emitting final artifacts in midenc-compile
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
 - ensure all relevant crates are prefixed with `midenc-`
@@ -110,7 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - set up mdbook deploy
 - add guides for compiling rust->masm
 - remove unused dependencies
-- Merge pull request [#61](https://github.com/0xPolygonMiden/compiler/pull/61) from 0xPolygonMiden/greenhat/cargo-ext-i60
+- Merge pull request [#61](https://github.com/0xMiden/compiler/pull/61) from 0xMiden/greenhat/cargo-ext-i60
 - add mdbook skeleton
 - clear up clippy warnings
 - split up driver components into separate crates

--- a/midenc/CHANGELOG.md
+++ b/midenc/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - update Cargo.lock dependencies
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/midenc-v0.0.6...midenc-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/midenc-v0.0.6...midenc-v0.0.7) - 2024-09-17
 
 ### Other
 - update Cargo.lock dependencies
@@ -21,19 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-v0.0.1...midenc-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/midenc-v0.0.1...midenc-v0.0.2) - 2024-08-30
 
 ### Other
 - update Cargo.lock dependencies
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-v0.0.0...midenc-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/midenc-v0.0.0...midenc-v0.0.1) - 2024-07-18
 
 ### Added
 - implement compiler driver, update midenc
 
 ### Other
 - update deps and min rust version
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - run clippy on CI, fix all clippy warnings
 - add formatter config, format most crates

--- a/sdk/alloc/CHANGELOG.md
+++ b/sdk/alloc/CHANGELOG.md
@@ -19,19 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-alloc-v0.0.1...miden-sdk-alloc-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-sdk-alloc-v0.0.1...miden-sdk-alloc-v0.0.2) - 2024-08-30
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-alloc-v0.0.0...miden-sdk-alloc-v0.0.1) - 2024-08-28
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-sdk-alloc-v0.0.0...miden-sdk-alloc-v0.0.1) - 2024-08-28
 
 ### Added
 - *(sdk)* introduce miden-sdk-alloc
 
 ### Other
 - set `miden-sdk-alloc` version to `0.0.0` to be in sync with
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - a few minor improvements
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/sdk/base-sys/CHANGELOG.md
+++ b/sdk/base-sys/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [**breaking**] revamp Miden SDK API and expose some modules;
 - remove digest-in-function-name encoding and `MidenAbiImport::digest`,
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.6...miden-base-sys-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.6...miden-base-sys-v0.0.7) - 2024-09-17
 
 ### Other
 - remove `miden-assembly` dependency from `sdk/base-sys` for `bindings` feature
@@ -35,12 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.2...miden-base-sys-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.2...miden-base-sys-v0.0.3) - 2024-08-30
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.1...miden-base-sys-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.1...miden-base-sys-v0.0.2) - 2024-08-28
 
 ### Fixed
 - *(sdk)* be more explicit about alignment of felt/word types
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - remove miden-diagnostics, start making midenc-session no-std-compatible
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.0...miden-base-sys-v0.0.1) - 2024-08-16
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.0...miden-base-sys-v0.0.1) - 2024-08-16
 
 ### Fixed
 - fix the build after VM v0.10.3 update
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - delete `miden-tx-kernel-sys` crate and move the code to `miden-base-sys`
 - build the MASL for the tx kernel stubs in `build.rs` and
 - rename `midenc-tx-kernel` to `miden-base-sys` and move it to
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - a few minor improvements
 - set up mdbook deploy
 - add guides for compiling rust->masm

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -50,12 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-v0.0.1...miden-sdk-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-sdk-v0.0.1...miden-sdk-v0.0.2) - 2024-08-30
 
 ### Other
 - updated the following local packages: miden-base-sys, miden-stdlib-sys, miden-sdk-alloc
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-v0.0.0...miden-sdk-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-sdk-v0.0.0...miden-sdk-v0.0.1) - 2024-07-18
 
 ### Added
 - introduce TransformStrategy and add the "return-via-pointer"

--- a/sdk/stdlib-sys/CHANGELOG.md
+++ b/sdk/stdlib-sys/CHANGELOG.md
@@ -27,20 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/miden-stdlib-sys-v0.0.2...miden-stdlib-sys-v0.0.3) - 2024-08-30
+## [0.0.3](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.0.2...miden-stdlib-sys-v0.0.3) - 2024-08-30
 
 ### Fixed
 - *(codegen)* broken return via pointer transformation
 
 ### Other
-- Merge pull request [#284](https://github.com/0xPolygonMiden/compiler/pull/284) from 0xPolygonMiden/bitwalker/abi-transform-test-fixes
+- Merge pull request [#284](https://github.com/0xMiden/compiler/pull/284) from 0xMiden/bitwalker/abi-transform-test-fixes
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-stdlib-sys-v0.0.1...miden-stdlib-sys-v0.0.2) - 2024-08-28
+## [0.0.2](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.0.1...miden-stdlib-sys-v0.0.2) - 2024-08-28
 
 ### Fixed
 - *(sdk)* be more explicit about alignment of felt/word types
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-stdlib-sys-v0.0.0...miden-stdlib-sys-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.0.0...miden-stdlib-sys-v0.0.1) - 2024-07-18
 
 ### Fixed
 - felt representation mismatch between rust and miden

--- a/tools/cargo-miden/CHANGELOG.md
+++ b/tools/cargo-miden/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - skip Miden SDK function generation in bindings.rs
 - add check for the proper artifact file extension in the cargo-miden test
 
-## [0.0.7](https://github.com/0xPolygonMiden/compiler/compare/cargo-miden-v0.0.6...cargo-miden-v0.0.7) - 2024-09-17
+## [0.0.7](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.0.6...cargo-miden-v0.0.7) - 2024-09-17
 
 ### Fixed
 - switch cargo-miden to v0.4.0 of the new project template with
@@ -55,12 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - clean up unused deps
 - switch all crates to a single workspace version (0.0.5)
 
-## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/cargo-miden-v0.0.1...cargo-miden-v0.0.2) - 2024-08-30
+## [0.0.2](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.0.1...cargo-miden-v0.0.2) - 2024-08-30
 
 ### Other
 - update Cargo.lock dependencies
 
-## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/cargo-miden-v0.0.0...cargo-miden-v0.0.1) - 2024-07-18
+## [0.0.1](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.0.0...cargo-miden-v0.0.1) - 2024-07-18
 
 ### Added
 - *(cargo)* allow configuring compiler version for generated projects
@@ -70,19 +70,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rename `compile` cargo extension command to `build`; imports cleanup;
 
 ### Other
-- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
 - set crates versions to 0.0.0, and `publish = false` for tests
 - add missing descriptions to all crates
 - rename `miden-prelude` to `miden-stdlib-sys` in SDK
 - run clippy on CI, fix all clippy warnings
-- Merge pull request [#164](https://github.com/0xPolygonMiden/compiler/pull/164) from 0xPolygonMiden/greenhat/i163-cargo-ext-for-alpha
+- Merge pull request [#164](https://github.com/0xMiden/compiler/pull/164) from 0xMiden/greenhat/i163-cargo-ext-for-alpha
 - remove repetitive words
 - add formatter config, format most crates
 - a few minor improvements
 - sync cargo-component crate version to v0.6 in test apps
 - set up mdbook deploy
 - add guides for compiling rust->masm
-- Merge pull request [#61](https://github.com/0xPolygonMiden/compiler/pull/61) from 0xPolygonMiden/greenhat/cargo-ext-i60
+- Merge pull request [#61](https://github.com/0xMiden/compiler/pull/61) from 0xMiden/greenhat/cargo-ext-i60
 - make `WasmTranslationConfig::module_name_fallback` non-optional
 - remove `path-absolutize` dependency
 - remove `next_display_order` option in `Command`


### PR DESCRIPTION
Hi, replace all occurrences of "0xPolygonMiden" with "0xMiden" across changelogs and metadata to reflect the org rename







