### PR TITLE
wip: sketch out generic testnet integration test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +396,53 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -1231,6 +1300,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1710,12 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "faster-hex"
@@ -2311,6 +2415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2444,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -2421,6 +2540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "human-panic"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2574,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2471,6 +2597,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3044,6 +3183,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,7 +3329,16 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.14.4",
+]
+
+[[package]]
+name = "logos"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6f536c1af4c7cc81edf73da1f8029896e7e1e16a219ef09b184e76a296f3db"
+dependencies = [
+ "logos-derive 0.15.0",
 ]
 
 [[package]]
@@ -3198,12 +3357,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-codegen"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189bbfd0b61330abea797e5e9276408f2edbe4f822d7ad08685d67419aafb34e"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static 1.5.0",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.5",
+ "rustc_version 0.4.1",
+ "syn",
+]
+
+[[package]]
 name = "logos-derive"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.14.4",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
+dependencies = [
+ "logos-codegen 0.15.0",
 ]
 
 [[package]]
@@ -3242,6 +3426,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -3336,6 +3526,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-client"
+version = "0.9.0"
+source = "git+https://github.com/0xMiden/miden-client?rev=f98ae87fc3f77e269c3c1e412d1b8ac650aa6fe3#f98ae87fc3f77e269c3c1e412d1b8ac650aa6fe3"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "deadpool",
+ "deadpool-sync",
+ "hex",
+ "miden-lib",
+ "miden-node-proto-build",
+ "miden-objects",
+ "miden-proving-service-client",
+ "miden-tx",
+ "miette",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "protox 0.7.2",
+ "rand 0.9.1",
+ "rusqlite",
+ "rusqlite_migration",
+ "thiserror 2.0.12",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tracing",
+ "web-sys",
+]
+
+[[package]]
 name = "miden-core"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3618,7 @@ dependencies = [
  "glob",
  "log",
  "miden-assembly",
+ "miden-client",
  "miden-core",
  "miden-mast-package",
  "miden-objects",
@@ -3414,7 +3634,10 @@ dependencies = [
  "midenc-hir-eval",
  "midenc-session",
  "proptest",
+ "rand 0.9.1",
  "sha2",
+ "temp-dir",
+ "tokio",
  "walkdir",
  "wasmprinter 0.227.1",
 ]
@@ -3487,6 +3710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-node-proto-build"
+version = "0.9.0"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#1018275c652a14d9322027829695db6e7870f796"
+dependencies = [
+ "anyhow",
+ "prost 0.13.5",
+ "protox 0.8.0",
+ "tonic-build 0.12.3",
+]
+
+[[package]]
 name = "miden-objects"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,6 +3751,40 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "winter-prover",
+]
+
+[[package]]
+name = "miden-prover"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bc4b989306ca1b8bdba364af72547c563419e77220f4cd244ed2bf3557d351"
+dependencies = [
+ "miden-air",
+ "miden-processor",
+ "tracing",
+ "winter-maybe-async",
+ "winter-prover",
+]
+
+[[package]]
+name = "miden-proving-service-client"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbd9676d8f6e8b9cbeba33a1c7fb115ef376d2f4101a5f97b5572ce9e10fb47"
+dependencies = [
+ "async-trait",
+ "getrandom 0.3.3",
+ "miden-objects",
+ "miden-tx",
+ "miette",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "protox 0.7.2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic 0.12.3",
+ "tonic-build 0.12.3",
+ "tonic-web-wasm-client",
 ]
 
 [[package]]
@@ -3555,6 +3823,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "miden-tx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbea7c2a870e69e86e4d7bdf21936447552442f4ec274e499d2d9b8a90a70653"
+dependencies = [
+ "async-trait",
+ "miden-lib",
+ "miden-objects",
+ "miden-processor",
+ "miden-prover",
+ "miden-verifier",
+ "rand 0.9.1",
+ "thiserror 2.0.12",
+ "winter-maybe-async",
 ]
 
 [[package]]
@@ -3879,8 +4164,16 @@ version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
+ "backtrace",
+ "backtrace-ext",
  "cfg-if",
  "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size 0.4.2",
+ "textwrap",
  "unicode-width 0.1.14",
 ]
 
@@ -4089,6 +4382,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
 ]
 
 [[package]]
@@ -4395,8 +4698,8 @@ checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.11.0",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
 ]
 
 [[package]]
@@ -4409,8 +4712,8 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost",
- "prost-build",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
  "serde",
 ]
 
@@ -4494,6 +4797,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,7 +4863,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix 0.38.44",
  "tracing",
@@ -4698,7 +5021,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -4715,8 +5048,28 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "regex",
  "syn",
  "tempfile",
@@ -4736,16 +5089,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-reflect"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
 dependencies = [
- "logos",
+ "logos 0.14.4",
  "miette",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+dependencies = [
+ "logos 0.14.4",
+ "miette",
+ "once_cell",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
+dependencies = [
+ "logos 0.15.0",
+ "miette",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
 ]
 
 [[package]]
@@ -4754,7 +5145,16 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -4765,11 +5165,41 @@ checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
 dependencies = [
  "bytes",
  "miette",
- "prost",
- "prost-reflect",
- "prost-types",
- "protox-parse",
+ "prost 0.12.6",
+ "prost-reflect 0.13.1",
+ "prost-types 0.12.6",
+ "protox-parse 0.6.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f352af331bf637b8ecc720f7c87bf903d2571fa2e14a66e9b2558846864b54a"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost 0.13.5",
+ "prost-reflect 0.14.7",
+ "prost-types 0.13.5",
+ "protox-parse 0.7.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424c2bd294b69c49b949f3619362bc3c5d28298cd1163b6d1a62df37c16461aa"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost 0.13.5",
+ "prost-reflect 0.15.3",
+ "prost-types 0.13.5",
+ "protox-parse 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4778,10 +5208,34 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
 dependencies = [
- "logos",
+ "logos 0.14.4",
  "miette",
- "prost-types",
+ "prost-types 0.12.6",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a462d115462c080ae000c29a47f0b3985737e5d3a995fcdbcaa5c782068dde"
+dependencies = [
+ "logos 0.14.4",
+ "miette",
+ "prost-types 0.13.5",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57927f9dbeeffcce7192404deee6157a640cbb3fe8ac11eabbe571565949ab75"
+dependencies = [
+ "logos 0.15.0",
+ "miette",
+ "prost-types 0.13.5",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5106,7 +5560,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-socks",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5182,6 +5636,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
+dependencies = [
+ "bitflags 2.9.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rusqlite_migration"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bec955369ac93728d3864d56b5d663ec7495f83648c560750a56c50fefcbf8"
+dependencies = [
+ "log",
+ "rusqlite",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,12 +5731,25 @@ version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -5340,6 +5831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5973,6 +6473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
+name = "temp-dir"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6228,6 +6734,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6283,10 +6800,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "rustls-native-certs",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-web-wasm-client"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8957be1a1c7aa12d4c9d67882060dd57aed816bbc553fa60949312e839f4a8ea"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httparse",
+ "js-sys",
+ "pin-project",
+ "thiserror 1.0.69",
+ "tonic 0.12.3",
+ "tower-service",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "topological-sort"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -6296,11 +6946,15 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.9.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6720,10 +7374,10 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost",
- "prost-build",
- "prost-types",
- "protox",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "prost-types 0.12.6",
+ "protox 0.6.1",
  "regex",
  "serde",
  "warg-crypto",
@@ -6740,8 +7394,8 @@ dependencies = [
  "hex",
  "indexmap 2.9.0",
  "pbjson-types",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "semver 1.0.26",
  "serde",
  "serde_with",
@@ -6760,7 +7414,7 @@ checksum = "8b8d8110b6800c43422676201a6a62167769b015ca29a8fcab67d789ac8b9c63"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
- "prost",
+ "prost 0.12.6",
  "thiserror 1.0.69",
  "warg-crypto",
  "warg-protobuf",
@@ -7863,7 +8517,7 @@ checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.8.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ midenc-expect-test = { version = "0.1.0", path = "tools/expect-test" }
 [patch.crates-io]
 #miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
 #miden-core = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
+#miden-client = { git = "https://github.com/0xMiden/miden-client", rev = "f98ae87fc3f77e269c3c1e412d1b8ac650aa6fe3" }
 #miden-processor = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
 #miden-lib = { git = "https://github.com/0xMiden/miden-base", rev = "64ba4d0f8a077dd7d8f2643ebafa155f95b1c241" }
 #miden-stdlib = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -177,7 +177,7 @@ run_task = [{ name = ["midenc"] }]
 [tasks.install]
 category = "Install"
 description = "Installs the compiler via cargo"
-run_task = [{ name = ["install-midenc"] }]
+run_task = [{ name = ["install-midenc"] }, { name = ["install-cargo-miden"] }]
 
 [tasks.check]
 category = "Build"

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -22,7 +22,12 @@ glob = "0.3.1"
 log.workspace = true
 miden-assembly.workspace = true
 miden-core.workspace = true
+miden-client = { version = "0.9", git = "https://github.com/0xMiden/miden-client", rev = "f98ae87fc3f77e269c3c1e412d1b8ac650aa6fe3", features = [
+    "tonic",
+    "sqlite",
+] }
 miden-mast-package.workspace = true
+miden-objects = { workspace = true, features = ["std"] }
 miden-processor.workspace = true
 midenc-dialect-arith.workspace = true
 midenc-dialect-hir.workspace = true
@@ -36,14 +41,15 @@ midenc-debug.workspace = true
 cargo-miden.workspace = true
 wasmprinter = "0.227"
 proptest.workspace = true
+rand = "0.9"
 sha2 = "0.10"
+temp-dir = "0.1"
+tokio.workspace = true
 walkdir = "2.5.0"
 
 [dev-dependencies]
 blake3 = "1.5"
 concat-idents = "1.1"
-miden-core.workspace = true
-miden-objects = { workspace = true, features = ["std"] }
 
 [package.metadata.cargo-machete]
 ignored = ["blake3"]

--- a/tests/integration/src/compiler_test.rs
+++ b/tests/integration/src/compiler_test.rs
@@ -308,6 +308,24 @@ impl CompilerTestBuilder {
         self
     }
 
+    /// Override the Cargo target directory to the specified path
+    pub fn with_target_dir(&mut self, path: impl AsRef<Path>) -> &mut Self {
+        match &mut self.source {
+            CompilerTestInputType::Cargo(CargoTest {
+                ref mut target_dir, ..
+            })
+            | CompilerTestInputType::CargoMiden(CargoTest {
+                ref mut target_dir, ..
+            })
+            | CompilerTestInputType::Rustc(RustcTest {
+                ref mut target_dir, ..
+            }) => {
+                *target_dir = Some(path.as_ref().to_path_buf());
+            }
+        }
+        self
+    }
+
     /// Add additional Miden Assembly module sources, to be linked with the program under test.
     pub fn link_with_masm_module(
         &mut self,

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, env, path::PathBuf, sync::Arc};
 use miden_core::{
     crypto::hash::RpoDigest,
     utils::{Deserializable, Serializable},
-    FieldElement,
+    Felt, FieldElement,
 };
 use miden_mast_package::Package;
 use miden_objects::account::{AccountComponentMetadata, AccountComponentTemplate, InitStorageData};
@@ -183,47 +183,53 @@ fn rust_sdk_cross_ctx_account_and_note() {
 }
 
 #[test]
+fn pure_rust_hir2() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let config = WasmTranslationConfig::default();
+    let mut test =
+        CompilerTest::rust_source_cargo_miden("../rust-apps-wasm/rust-sdk/add", config, []);
+    let artifact_name = test.artifact_name().to_string();
+    test.expect_wasm(expect_file![format!("../../expected/rust_sdk/{artifact_name}.wat")]);
+    test.expect_ir(expect_file![format!("../../expected/rust_sdk/{artifact_name}.hir")]);
+}
+
+/// This test demonstrates the use of the testnet integration test infrastructure
+#[test]
+#[ignore = "this test needs refinement before it can be run by default"]
 fn rust_sdk_counter_testnet_example() {
-    use miden_client::{
-        account::{
-            component::{BasicWallet, RpoFalcon512},
-            AccountStorageMode, AccountType,
-        },
-        builder::ClientBuilder,
-        crypto::FeltRng,
-        rpc::{Endpoint, TonicRpcClient},
-        transaction::{TransactionKernel, TransactionRequestBuilder},
-        ClientError, Felt,
-    };
-    use miden_objects::{
-        account::{AccountBuilder, AccountComponent, StorageMap, StorageSlot},
-        assembly::Assembler,
-        transaction::TransactionScript,
-    };
-    use rand::RngCore;
+    use cargo_miden::BuildOutput;
+
+    use crate::testing::testnet::Scenario;
+
+    let mut scenario = Scenario::default();
+
+    let target_dir = scenario.temp_dir().child("target");
 
     // Build counter package
-    let args: Vec<String> = [
+    let mut args: Vec<String> = [
         "cargo",
         "miden",
         "build",
         "--manifest-path",
-        "../../examples/counter/Cargo.toml",
+        "../../examples/counter-contract/Cargo.toml",
         "--lib",
         "--release",
-        // Use the target dir of this test's cargo project to avoid issues running tests in parallel
-        // i.e. avoid using the same target dir as the basic-wallet test (see above)
-        "--target-dir",
-        "../../examples/counter-note/target",
     ]
     .iter()
     .map(|s| s.to_string())
     .collect();
+
+    // Use a new, temporary target directory to avoid conflict with other tests that compile the
+    // counter example projects in parallel, but share it for both crates so that we don't recompile
+    // dependencies needlessly
+    args.push("--target-dir".to_string());
+    args.push(target_dir.to_string_lossy().into_owned());
+
     dbg!(env::current_dir().unwrap().display());
 
     let outputs = cargo_miden::run(args.into_iter(), cargo_miden::OutputType::Masm)
         .expect("Failed to compile the counter account package for counter-note");
-    let masp_path: PathBuf = outputs.first().unwrap().clone();
+    let masp_path = outputs.unwrap().unwrap_build_output().into_artifact_path();
 
     dbg!(&masp_path);
 
@@ -234,173 +240,28 @@ fn rust_sdk_counter_testnet_example() {
     let mut builder = CompilerTestBuilder::rust_source_cargo_miden(
         "../../examples/counter-note",
         config,
-        [
-            "-l".into(),
-            "std".into(),
-            "-l".into(),
-            "base".into(),
-            "--link-library".into(),
-            masp_path.clone().into_os_string().into_string().unwrap().into(),
-        ],
+        ["-l".into(), masp_path.clone().into_os_string().into_string().unwrap().into()],
     );
+    builder.with_target_dir(&target_dir);
     builder.with_entrypoint(FunctionIdent {
         module: Ident::new(Symbol::intern("miden:base/note-script@1.0.0"), SourceSpan::default()),
         function: Ident::new(Symbol::intern("note-script"), SourceSpan::default()),
     });
     let mut test = builder.build();
-    let artifact_name = test.artifact_name().to_string();
-    test.expect_wasm(expect_file![format!("../../expected/rust_sdk/{artifact_name}.wat")]);
-    test.expect_ir(expect_file![format!("../../expected/rust_sdk/{artifact_name}.hir")]);
-    test.expect_masm(expect_file![format!("../../expected/rust_sdk/{artifact_name}.masm")]);
-    let package = test.compiled_package();
+    let note_package = test.compiled_package();
 
     let account_package =
         Arc::new(Package::read_from_bytes(&std::fs::read(masp_path).unwrap()).unwrap());
 
-    let mut builder = tokio::runtime::Builder::new_current_thread();
-    let rt = builder.enable_all().build().unwrap();
-    rt.block_on(async move {
-        // Initialize client
-        let endpoint =
-            Endpoint::new("https".to_string(), "rpc.testnet.miden.io".to_string(), Some(443));
-        let timeout_ms = 10_000;
-        let rpc_api = Arc::new(TonicRpcClient::new(&endpoint, timeout_ms));
+    let key = [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(0)];
+    let expected = [Felt::new(1), Felt::new(0), Felt::new(0), Felt::new(0)];
+    scenario
+        .create_account("example", account_package)
+        .then()
+        .create_note(note_package, "example", "example")
+        .then()
+        .submit_transaction("example")
+        .assert_account_storage_map_entry_eq("example", 0, key, expected);
 
-        let tmp_dir = std::env::temp_dir();
-        let keystore_path = tmp_dir.join("keystore");
-        let mut client = ClientBuilder::new()
-            .with_rpc(rpc_api)
-            .with_filesystem_keystore(keystore_path.as_path().to_str().unwrap())
-            .in_debug_mode(true)
-            .build()
-            .await
-            .unwrap();
-
-        let sync_summary = client.sync_state().await.unwrap();
-        println!("Latest block: {}", sync_summary.block_num);
-
-        println!("\n[STEP 1] Deploy a smart contract with a mapping");
-
-        let account_component = match account_package.account_component_metadata_bytes.as_deref() {
-            None => todo!(),
-            Some(bytes) => {
-                let metadata = AccountComponentMetadata::read_from_bytes(bytes).unwrap();
-                let template = AccountComponentTemplate::new(
-                    metadata,
-                    account_package.unwrap_library().as_ref().clone(),
-                );
-                let init_storage_data = InitStorageData::default();
-                AccountComponent::from_template(&template, &init_storage_data)
-                    .unwrap()
-                    .with_supported_type(AccountType::RegularAccountImmutableCode)
-            }
-        };
-
-        // Init seed for the counter contract
-        let mut init_seed = [0_u8; 32];
-        client.rng().fill_bytes(&mut init_seed);
-
-        // Anchor block of the account
-        let anchor_block = client.get_latest_epoch_block().await.unwrap();
-
-        // Build the new `Account` with the component
-        let key_pair = miden_client::crypto::SecretKey::with_rng(client.rng());
-        let (example_contract, _seed) = AccountBuilder::new(init_seed)
-            .anchor((&anchor_block).try_into().unwrap())
-            .account_type(AccountType::RegularAccountImmutableCode)
-            .storage_mode(AccountStorageMode::Public)
-            .with_component(account_component.clone())
-            .with_component(RpoFalcon512::new(key_pair.public_key()))
-            .with_component(BasicWallet)
-            .build()
-            .unwrap();
-
-        client.add_account(&example_contract.clone(), Some(_seed), false).await.unwrap();
-
-        // -------------------------------------------------------------------------
-        // STEP 2: Call the contract with a script
-        // -------------------------------------------------------------------------
-        println!("\n[STEP 2] Call contract with script");
-
-        // Compile the transaction script with the library.
-        /*
-        let tx_script = TransactionScript::compile(
-            script_code,
-            [],
-            assembler.with_library(&account_component_lib).unwrap(),
-        )
-        .unwrap();
-         */
-
-        // Build a note
-        let note_program = package.unwrap_program();
-        let note_script = miden_client::note::NoteScript::from_parts(
-            note_program.mast_forest().clone(),
-            note_program.entrypoint(),
-        );
-
-        let tag = miden_client::note::NoteTag::from_account_id(
-            example_contract.id(),
-            miden_client::note::NoteExecutionMode::Local,
-        )
-        .unwrap();
-        let inputs = miden_client::note::NoteInputs::new(vec![]).unwrap();
-        let serial_num = client.rng().draw_word();
-        let vault = miden_client::note::NoteAssets::new(vec![]).unwrap();
-        let note_type = miden_client::note::NoteType::Public;
-        let metadata = miden_client::note::NoteMetadata::new(
-            example_contract.id(),
-            note_type,
-            tag,
-            miden_client::note::NoteExecutionHint::always(),
-            Felt::ZERO,
-        )
-        .unwrap();
-        let recipient = miden_client::note::NoteRecipient::new(serial_num, note_script, inputs);
-        let note = miden_client::note::Note::new(vault, metadata, recipient);
-
-        // Build a transaction request
-        let tx_increment_request = TransactionRequestBuilder::new()
-            .with_own_output_notes([miden_client::transaction::OutputNote::Full(note)])
-            .build()
-            .unwrap();
-
-        // Execute the transaction locally
-        let tx_result = client
-            .new_transaction(example_contract.id(), tx_increment_request)
-            .await
-            .unwrap();
-
-        let tx_id = tx_result.executed_transaction().id();
-        println!("View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}", tx_id);
-
-        // Submit transaction to the network
-        let _ = client.submit_transaction(tx_result).await;
-
-        client.sync_state().await.unwrap();
-
-        let account = client.get_account(example_contract.id()).await.unwrap();
-
-        let index = 0;
-        let key = [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(0)];
-        println!(
-            "Mapping state\n Index: {:?}\n Key: {:?}\n Value: {:?}",
-            index,
-            key,
-            account.unwrap().account().storage().get_map_item(index, key)
-        );
-    });
-
-    panic!("finished");
-}
-
-#[test]
-fn pure_rust_hir2() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let config = WasmTranslationConfig::default();
-    let mut test =
-        CompilerTest::rust_source_cargo_miden("../rust-apps-wasm/rust-sdk/add", config, []);
-    let artifact_name = test.artifact_name().to_string();
-    test.expect_wasm(expect_file![format!("../../expected/rust_sdk/{artifact_name}.wat")]);
-    test.expect_ir(expect_file![format!("../../expected/rust_sdk/{artifact_name}.hir")]);
+    scenario.run().unwrap();
 }

--- a/tests/integration/src/testing/mod.rs
+++ b/tests/integration/src/testing/mod.rs
@@ -3,6 +3,7 @@
 mod eval;
 mod initializer;
 pub mod setup;
+pub mod testnet;
 
 pub use self::{
     eval::{eval_link_output, eval_package},

--- a/tests/integration/src/testing/testnet.rs
+++ b/tests/integration/src/testing/testnet.rs
@@ -1,0 +1,508 @@
+//! This module provides infrastructure for writing integration tests that execute against the
+//! Miden testnet.
+use std::{collections::BTreeMap, sync::Arc};
+
+use miden_client::{
+    account::{
+        component::{BasicWallet, RpoFalcon512},
+        Account, AccountId, AccountStorageMode, AccountType,
+    },
+    asset::Asset,
+    builder::ClientBuilder,
+    crypto::FeltRng,
+    note::{Note, NoteType},
+    rpc::{Endpoint, NodeRpcClient, TonicRpcClient},
+    sync::SyncSummary,
+    transaction::{TransactionId, TransactionRequestBuilder},
+    Client, Felt,
+};
+use miden_core::{utils::Deserializable, FieldElement, Word};
+use miden_objects::{
+    account::{
+        AccountBuilder, AccountComponent, AccountComponentMetadata, AccountComponentTemplate,
+        InitStorageData,
+    },
+    //transaction::TransactionScript,
+};
+use rand::RngCore;
+
+/// 10s
+const RPC_TIMEOUT: u64 = 10_000;
+
+/// Represents an integration test that executes against the Miden testnet
+///
+/// A scenario consists of one or more steps/actions which build up some desired state, and then
+/// asserts facts about that state, before continuing to make further changes, or terminating
+/// successfully.
+///
+/// A scenario can fail for a number of different reasons:
+///
+/// * Invalid parameters provided to the client
+/// * Invalid account/note creation parameters
+/// * A transaction request failed, or the transaction could not be submitted
+/// * An attempt to perform an action that is not valid at that point (e.g. creating an account
+///   that already exists).
+/// * An assertion about the state of the network doesn't hold
+///
+/// Currently, these all result in asserts/panics, so that we can pinpoint the source of errors,
+/// but as a result, a failed tests may be due to factors out of your control, such as the testnet
+/// being temporarily unavailable. You must assess the panic output to determine if the failure
+/// is truly a failed test, or something spurious.
+///
+/// NOTE: Created transactions can be viewed online via MidenScan given the transaction id, using
+/// the URL `https://testnet.midenscan.com/tx/{id}`.
+pub struct Scenario {
+    dir: temp_dir::TempDir,
+    rpc_client: Arc<dyn NodeRpcClient + Send>,
+    actions: Vec<Action>,
+    accounts: BTreeMap<&'static str, AccountId>,
+    notes: Vec<Note>,
+    transactions: Vec<TransactionId>,
+    sync_summary: Option<miden_client::sync::SyncSummary>,
+}
+
+impl Default for Scenario {
+    fn default() -> Self {
+        let endpoint =
+            Endpoint::new("https".to_string(), "rpc.testnet.miden.io".to_string(), Some(443));
+        Self::with_endpoint(endpoint)
+    }
+}
+
+impl Scenario {
+    /// Create a new, empty test scenario targeting the public testnet
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new, empty test scenario targeting the testnet at the specified endpoint
+    pub fn with_endpoint(endpoint: Endpoint) -> Self {
+        let dir = temp_dir::TempDir::new().unwrap();
+        let rpc_client = Arc::new(TonicRpcClient::new(&endpoint, RPC_TIMEOUT));
+
+        Self {
+            dir,
+            rpc_client,
+            actions: Default::default(),
+            accounts: Default::default(),
+            notes: Default::default(),
+            transactions: Default::default(),
+            sync_summary: None,
+        }
+    }
+
+    /// An existing account will be made available to subsequent scenario steps via `alias`
+    pub fn with_existing_account(&mut self, id: AccountId, alias: &'static str) -> &mut Self {
+        self.accounts.insert(alias, id);
+        self
+    }
+
+    /// A new account will be created with the given alias and code.
+    ///
+    /// Subsequent actions in this scenario may refer to this account using the provided alias.
+    ///
+    /// Returns a builder that can be used to customize how the account is created.
+    pub fn create_account(
+        &mut self,
+        alias: &'static str,
+        code: Arc<miden_mast_package::Package>,
+    ) -> ScenarioAccountBuilder<'_> {
+        ScenarioAccountBuilder::new(self, alias, code)
+    }
+
+    /// A new note will be created with the given code, to be sent from the account aliased by
+    /// `sender`, to the account aliased by `recipient`.
+    ///
+    /// NOTE: The sender/recipient aliases must correspond to accounts which are created, or are
+    /// mapped to existing accounts, when the scenario executes this step, or an error will occur.
+    ///
+    /// Returns a builder that can be used to customize the note that will be created.
+    pub fn create_note(
+        &mut self,
+        code: Arc<miden_mast_package::Package>,
+        sender: &'static str,
+        recipient: &'static str,
+    ) -> ScenarioNoteBuilder<'_> {
+        ScenarioNoteBuilder::new(self, code, sender, recipient)
+    }
+
+    /// A new transaction will be created against the account aliased by `to`, containing all of
+    /// the notes created so far (and consuming them in the process).
+    ///
+    /// NOTE: The provided account alias must correspond to an account which was created, or was
+    /// mapped to an existing account, when the scenario executes this step, or an error will occur.
+    ///
+    /// When this step is executed, the transaction will be submitted to the network, and the client
+    /// state will be synchronized so that transaction effects are visible.
+    pub fn submit_transaction(&mut self, to: &'static str) -> &mut Self {
+        self.actions.push(Action::SubmitTransaction { account: to });
+        self
+    }
+
+    /// The scenario will assert that the storage map at `index` of `account`, contains `expected`
+    /// as the value of `key` when this step is executed.
+    pub fn assert_account_storage_map_entry_eq(
+        &mut self,
+        account: &'static str,
+        index: u8,
+        key: Word,
+        expected: Word,
+    ) -> &mut Self {
+        self.actions.push(Action::AssertStorageMapEq {
+            account,
+            index,
+            key,
+            expected,
+        });
+        self
+    }
+
+    /// Get a reference to the temporary directory used for this scenario
+    pub fn temp_dir(&self) -> &temp_dir::TempDir {
+        &self.dir
+    }
+
+    /// Get a new [Client] for interacting with the testnet
+    async fn get_client(&self) -> Client {
+        let keystore_dir = self.dir.child("keystore");
+        ClientBuilder::new()
+            .with_rpc(self.rpc_client.clone())
+            .with_filesystem_keystore(keystore_dir.as_path().to_str().unwrap())
+            .in_debug_mode(true)
+            .build()
+            .await
+            .unwrap_or_else(|err| panic!("failed to create testnet client: {err}"))
+    }
+
+    /// Run this scenario to completion.
+    ///
+    /// Returns the sync summary of the client if successful
+    pub fn run(mut self) -> Option<SyncSummary> {
+        let mut builder = tokio::runtime::Builder::new_current_thread();
+        let rt = builder.enable_all().build().unwrap();
+        rt.block_on(async move {
+            let mut client = self.get_client().await;
+
+            // Synchronize with the network before continuing
+            let sync_summary = client.sync_state().await.unwrap();
+            self.sync_summary = Some(sync_summary);
+
+            let actions = core::mem::take(&mut self.actions);
+            for action in actions {
+                action.execute(&mut client, &mut self).await;
+            }
+
+            self.sync_summary.take()
+        })
+    }
+}
+
+enum Action {
+    /// Create an account with the given alias, code, and initial storage contents
+    CreateAccount(CreateAccountParams),
+    /// Create a note to be sent from one account to another
+    CreateNote(CreateNoteParams),
+    /// Submit all notes created so far to the given account alias
+    SubmitTransaction {
+        /// The account alias we're submitting the transaction against
+        account: &'static str,
+    },
+    /// Assert that the given storage map entry matches an expected value
+    AssertStorageMapEq {
+        /// The account alias whose storage we're asserting against
+        account: &'static str,
+        /// The storage slot index
+        ///
+        /// NOTE: The referenced slot must be a storage map slot
+        index: u8,
+        /// The storage map key to assert against
+        key: Word,
+        /// The expected value stored under the key
+        expected: Word,
+    },
+}
+
+/// A builder pattern struct for customizing the creation of an account during a given scenario
+pub struct ScenarioAccountBuilder<'a> {
+    scenario: &'a mut Scenario,
+    params: CreateAccountParams,
+}
+
+impl<'a> ScenarioAccountBuilder<'a> {
+    fn new(
+        scenario: &'a mut Scenario,
+        alias: &'static str,
+        account: Arc<miden_mast_package::Package>,
+    ) -> Self {
+        Self {
+            scenario,
+            params: CreateAccountParams {
+                alias,
+                account,
+                init_storage_data: None,
+            },
+        }
+    }
+
+    /// Provide the initial storage data for the account when it is created
+    pub fn with_init_storage_data(&mut self, data: InitStorageData) -> &mut Self {
+        self.params.init_storage_data = Some(data);
+        self
+    }
+
+    /// Finalizes the account creation parameters and returns to the current [Scenario]
+    pub fn then(self) -> &'a mut Scenario {
+        let ScenarioAccountBuilder { scenario, params } = self;
+        scenario.actions.push(Action::CreateAccount(params));
+        scenario
+    }
+}
+
+/// A builder pattern struct for customizing the creation of a note during a given scenario
+pub struct ScenarioNoteBuilder<'a> {
+    scenario: &'a mut Scenario,
+    params: CreateNoteParams,
+}
+
+impl<'a> ScenarioNoteBuilder<'a> {
+    fn new(
+        scenario: &'a mut Scenario,
+        note: Arc<miden_mast_package::Package>,
+        sender: &'static str,
+        recipient: &'static str,
+    ) -> Self {
+        Self {
+            scenario,
+            params: CreateNoteParams {
+                note,
+                note_ty: NoteType::Public,
+                inputs: Default::default(),
+                assets: Default::default(),
+                sender,
+                recipient,
+            },
+        }
+    }
+
+    /// Override the default note type of `Public`
+    pub fn with_note_type(&mut self, ty: NoteType) -> &mut Self {
+        self.params.note_ty = ty;
+        self
+    }
+
+    /// Specify the note inputs
+    pub fn with_inputs(&mut self, inputs: impl IntoIterator<Item = Felt>) -> &mut Self {
+        self.params.inputs.extend(inputs);
+        self
+    }
+
+    /// Specify the assets attached to the note
+    pub fn with_assets(&mut self, assets: impl IntoIterator<Item = Asset>) -> &mut Self {
+        self.params.assets.extend(assets);
+        self
+    }
+
+    /// Finalizes the note creation parameters and returns to the current [Scenario]
+    pub fn then(self) -> &'a mut Scenario {
+        let ScenarioNoteBuilder { scenario, params } = self;
+        scenario.actions.push(Action::CreateNote(params));
+        scenario
+    }
+}
+
+struct CreateAccountParams {
+    /// The friendly name by which this account can be referenced before and after it is
+    /// created within the context of a [Scenario]
+    alias: &'static str,
+    /// The code for the account
+    account: Arc<miden_mast_package::Package>,
+    /// The initial storage data to populate the account with
+    init_storage_data: Option<InitStorageData>,
+    // TODO: Support overriding account components
+    //components: Vec<AccountComponent>,
+}
+
+struct CreateNoteParams {
+    note: Arc<miden_mast_package::Package>,
+    note_ty: NoteType,
+    inputs: Vec<Felt>,
+    assets: Vec<Asset>,
+    sender: &'static str,
+    recipient: &'static str,
+}
+
+impl Action {
+    pub async fn execute(&self, client: &mut Client, scenario: &mut Scenario) {
+        match self {
+            Self::CreateAccount(CreateAccountParams {
+                alias,
+                account,
+                init_storage_data,
+            }) => {
+                let account = match init_storage_data.as_ref() {
+                    Some(data) => create_account(client, account, data).await,
+                    None => {
+                        let init_storage_data = InitStorageData::default();
+                        create_account(client, account, &init_storage_data).await
+                    }
+                };
+
+                scenario.accounts.insert(*alias, account.id());
+            }
+            Self::CreateNote(params) => {
+                let note = create_note(client, scenario, params).await;
+
+                scenario.notes.push(note);
+            }
+            Self::SubmitTransaction { account } => {
+                let id = submit_transaction(client, scenario, account).await;
+
+                scenario.transactions.push(id);
+
+                // Sync the client with the network so we can observe the transaction effects
+                let summary = client.sync_state().await.unwrap();
+
+                match scenario.sync_summary.as_mut() {
+                    Some(current_summary) => {
+                        current_summary.combine_with(summary);
+                    }
+                    None => {
+                        scenario.sync_summary = Some(summary);
+                    }
+                }
+            }
+            Self::AssertStorageMapEq {
+                account,
+                index,
+                key,
+                expected,
+            } => {
+                assert_account_storage_map_eq(client, scenario, account, *index, *key, *expected)
+                    .await;
+            }
+        }
+    }
+}
+
+async fn create_account(
+    client: &mut Client,
+    account_package: &miden_mast_package::Package,
+    init_storage_data: &InitStorageData,
+) -> Account {
+    let account_component = match account_package.account_component_metadata_bytes.as_deref() {
+        None => todo!("unsupported account package: no account component metadata present"),
+        Some(bytes) => {
+            let metadata = AccountComponentMetadata::read_from_bytes(bytes).unwrap();
+            let template = AccountComponentTemplate::new(
+                metadata,
+                account_package.unwrap_library().as_ref().clone(),
+            );
+            AccountComponent::from_template(&template, init_storage_data)
+                .unwrap()
+                .with_supported_type(AccountType::RegularAccountImmutableCode)
+        }
+    };
+
+    // Init seed for the account
+    let mut init_seed = [0_u8; 32];
+    client.rng().fill_bytes(&mut init_seed);
+
+    // Anchor block of the account
+    let anchor_block = client.get_latest_epoch_block().await.unwrap();
+
+    // Build the new `Account` with the component
+    let key_pair = miden_client::crypto::SecretKey::with_rng(client.rng());
+    let (account, seed) = AccountBuilder::new(init_seed)
+        .anchor((&anchor_block).try_into().unwrap())
+        .account_type(AccountType::RegularAccountImmutableCode)
+        .storage_mode(AccountStorageMode::Public)
+        .with_component(account_component.clone())
+        .with_component(RpoFalcon512::new(key_pair.public_key()))
+        .with_component(BasicWallet)
+        .build()
+        .unwrap_or_else(|err| panic!("failed to build account: {err}"));
+
+    client
+        .add_account(&account, Some(seed), false)
+        .await
+        .unwrap_or_else(|err| panic!("account creation failed: {err}"));
+
+    account
+}
+
+/// Build a note
+async fn create_note(client: &mut Client, scenario: &Scenario, params: &CreateNoteParams) -> Note {
+    let note_program = params.note.unwrap_program();
+    let note_script = miden_client::note::NoteScript::from_parts(
+        note_program.mast_forest().clone(),
+        note_program.entrypoint(),
+    );
+
+    let sender = scenario.accounts[params.sender];
+    let recipient = scenario.accounts[params.recipient];
+
+    let tag = miden_client::note::NoteTag::from_account_id(
+        recipient,
+        miden_client::note::NoteExecutionMode::Local,
+    )
+    .unwrap();
+    let inputs = miden_client::note::NoteInputs::new(params.inputs.clone()).unwrap();
+    let serial_num = client.rng().draw_word();
+    let vault = miden_client::note::NoteAssets::new(params.assets.clone()).unwrap();
+    let metadata = miden_client::note::NoteMetadata::new(
+        sender,
+        params.note_ty,
+        tag,
+        miden_client::note::NoteExecutionHint::always(),
+        Felt::ZERO,
+    )
+    .unwrap();
+    let recipient = miden_client::note::NoteRecipient::new(serial_num, note_script, inputs);
+    miden_client::note::Note::new(vault, metadata, recipient)
+}
+
+async fn submit_transaction(
+    client: &mut Client,
+    scenario: &mut Scenario,
+    account: &'static str,
+) -> TransactionId {
+    let output_notes = core::mem::take(&mut scenario.notes)
+        .into_iter()
+        .map(miden_client::transaction::OutputNote::Full);
+    // Build a transaction request
+    let tx_request = TransactionRequestBuilder::new()
+        .with_own_output_notes(output_notes)
+        .build()
+        .unwrap();
+
+    // Execute the transaction locally
+    let target_account = scenario.accounts[account];
+    let tx_result = client.new_transaction(target_account, tx_request).await.unwrap();
+
+    let tx_id = tx_result.executed_transaction().id();
+
+    // Submit transaction to the network
+    let _ = client.submit_transaction(tx_result).await;
+
+    tx_id
+}
+
+async fn assert_account_storage_map_eq(
+    client: &Client,
+    scenario: &Scenario,
+    account: &'static str,
+    index: u8,
+    key: Word,
+    expected: Word,
+) {
+    let account_id = scenario.accounts[account];
+    let account = client
+        .get_account(account_id)
+        .await
+        .unwrap_or_else(|err| panic!("failed to get account record: {err}"))
+        .unwrap_or_else(|| panic!("no account found for the id associated with alias '{account}'"));
+
+    let item = account.account().storage().get_map_item(index, key).unwrap();
+
+    assert_eq!(item, expected);
+}

--- a/tools/cargo-miden/src/outputs.rs
+++ b/tools/cargo-miden/src/outputs.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Represents the structured output of a successful `cargo miden` command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,4 +50,20 @@ pub enum BuildOutput {
         /// Additional arguments passed to the Miden compiler.
         midenc_flags: Vec<String>,
     },
+}
+
+impl BuildOutput {
+    /// Get a reference to the filesystem path where the build artifact was placed
+    pub fn artifact_path(&self) -> &Path {
+        match self {
+            Self::Masm { artifact_path } | Self::Wasm { artifact_path, .. } => artifact_path,
+        }
+    }
+
+    /// Convert this build output to the underlying filesystem path of the build artifact
+    pub fn into_artifact_path(self) -> PathBuf {
+        match self {
+            Self::Masm { artifact_path } | Self::Wasm { artifact_path, .. } => artifact_path,
+        }
+    }
 }


### PR DESCRIPTION
This PR takes the integration test I sketched out in Mexico that ran against the testnet, and refactors it into two parts: a generic, builder pattern-style harness/infrastructure for creating tests of this type; and a test that demonstrates its usage.

The example test from which this derived, creates an account (from our `counter-contract` example), and then creates a transaction that executes a note (from our `counter-note` example) against that account.

I have not evaluated whether the test succeeds currently, and the example test is disabled for this reason. I think some further refinement is needed to the test itself to ensure that it can be run on a repeatable basis. On a related note, I think we should set some kind of tag for these sorts of tests, so that they are only run explicitly, not when running the test suite by default, at least until we have the ability to spin up local testnets that can be thrown away after the suite is executed. I haven't done that here, but as soon as we add tests that we wish to run in CI using this infra, we should do that.

