### PR TITLE
Add Op registration into symbol table inside OpBuilder 

### DIFF
--- a/hir/src/dialects/builtin/builders/component.rs
+++ b/hir/src/dialects/builtin/builders/component.rs
@@ -32,16 +32,6 @@ impl ComponentBuilder {
 
     pub fn define_module(&mut self, name: Ident) -> Result<ModuleRef, Report> {
         let module_ref = self.builder.create_module(name)?;
-        let is_new = self
-            .component
-            .borrow_mut()
-            .symbol_manager_mut()
-            .insert_new(module_ref, crate::ProgramPoint::Invalid);
-        assert!(
-            is_new,
-            "module with the name {name} already exists in component {}",
-            self.component.borrow().name()
-        );
         Ok(module_ref)
     }
 
@@ -67,12 +57,6 @@ impl ComponentBuilder {
         signature: Signature,
     ) -> Result<FunctionRef, Report> {
         let function_ref = self.builder.create_function(name, signature)?;
-        let is_new = self
-            .component
-            .borrow_mut()
-            .symbol_manager_mut()
-            .insert_new(function_ref, crate::ProgramPoint::Invalid);
-        assert!(is_new, "function with the name {name} already exists");
         Ok(function_ref)
     }
 }

--- a/hir/src/dialects/builtin/builders/module.rs
+++ b/hir/src/dialects/builtin/builders/module.rs
@@ -52,12 +52,6 @@ impl ModuleBuilder {
         signature: Signature,
     ) -> Result<FunctionRef, Report> {
         let function_ref = self.builder.create_function(name, signature)?;
-        let is_new = self
-            .module
-            .borrow_mut()
-            .symbol_manager_mut()
-            .insert_new(function_ref, crate::ProgramPoint::Invalid);
-        assert!(is_new, "function with the name {name} already exists");
         Ok(function_ref)
     }
 
@@ -72,12 +66,6 @@ impl ModuleBuilder {
         ty: Type,
     ) -> Result<UnsafeIntrusiveEntityRef<GlobalVariable>, Report> {
         let global_var_ref = self.builder.create_global_variable(name, visibility, ty)?;
-        let is_new = self
-            .module
-            .borrow_mut()
-            .symbol_manager_mut()
-            .insert_new(global_var_ref, crate::ProgramPoint::Invalid);
-        assert!(is_new, "global variable with the name {name} already exists");
         Ok(global_var_ref)
     }
 
@@ -119,12 +107,6 @@ impl ModuleBuilder {
     pub fn declare_module(&mut self, name: Ident) -> Result<ModuleRef, Report> {
         let builder = PrimModuleBuilder::new(&mut self.builder, name.span());
         let module_ref = builder(name)?;
-        let is_new = self
-            .module
-            .borrow_mut()
-            .symbol_manager_mut()
-            .insert_new(module_ref, crate::ProgramPoint::Invalid);
-        assert!(is_new, "module with the name {name} already exists in world",);
         Ok(module_ref)
     }
 

--- a/hir/src/dialects/builtin/builders/world.rs
+++ b/hir/src/dialects/builtin/builders/world.rs
@@ -43,20 +43,6 @@ impl WorldBuilder {
     ) -> Result<ComponentRef, Report> {
         let builder = PrimComponentBuilder::new(&mut self.builder, name.span());
         let component_ref = builder(ns, name, ver.clone())?;
-        let is_new = self
-            .world
-            .borrow_mut()
-            .symbol_manager_mut()
-            .insert_new(component_ref, crate::ProgramPoint::Invalid);
-        assert!(
-            is_new,
-            "component {} already exists in world",
-            ComponentId {
-                namespace: ns.name,
-                name: name.name,
-                version: ver
-            }
-        );
         Ok(component_ref)
     }
 
@@ -73,12 +59,6 @@ impl WorldBuilder {
     pub fn declare_module(&mut self, name: Ident) -> Result<ModuleRef, Report> {
         let builder = PrimModuleBuilder::new(&mut self.builder, name.span());
         let module_ref = builder(name)?;
-        let is_new = self
-            .world
-            .borrow_mut()
-            .symbol_manager_mut()
-            .insert_new(module_ref, crate::ProgramPoint::Invalid);
-        assert!(is_new, "module with the name {name} already exists in world",);
         Ok(module_ref)
     }
 

--- a/hir/src/ir/builder.rs
+++ b/hir/src/ir/builder.rs
@@ -140,9 +140,9 @@ pub trait Builder: Listener {
                 position: point,
                 ..
             } => match point {
-                crate::Position::Before => op.borrow_mut().insert_before(other_op),
+                crate::Position::Before => op.insert_before(other_op),
                 crate::Position::After => {
-                    op.borrow_mut().insert_after(other_op);
+                    op.insert_after(other_op);
                     self.set_insertion_point(ProgramPoint::after(op));
                 }
             },

--- a/hir/src/ir/builder.rs
+++ b/hir/src/ir/builder.rs
@@ -132,8 +132,8 @@ pub trait Builder: Listener {
                 block,
                 position: point,
             } => match point {
-                crate::Position::Before => op.borrow_mut().insert_at_start(block),
-                crate::Position::After => op.borrow_mut().insert_at_end(block),
+                crate::Position::Before => op.insert_at_start(block),
+                crate::Position::After => op.insert_at_end(block),
             },
             ProgramPoint::Op {
                 op: other_op,

--- a/hir/src/ir/builder.rs
+++ b/hir/src/ir/builder.rs
@@ -124,7 +124,7 @@ pub trait Builder: Listener {
     /// current op.
     ///
     /// This function will panic if no insertion point is set.
-    fn insert(&mut self, mut op: OperationRef) {
+    fn insert(&mut self, op: OperationRef) {
         let ip = self.insertion_point();
 
         match *ip {

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -181,33 +181,32 @@ impl EntityWithParent for Operation {
 }
 impl EntityListItem for Operation {
     fn on_inserted(this: OperationRef, _cursor: &mut EntityCursorMut<'_, Self>) {
-        let parent = this.nearest_symbol_table();
-        if let Some(mut parent) = parent {
-            // NOTE: We use OperationName, instead of the Operation itself, to avoid borrowing.
-            if this.name().implements::<dyn Symbol>()
-                && parent.name().implements::<dyn SymbolTable>()
-            {
-                // NOTE: We call `unwrap()` here because we are confident that these function calls
-                // are valid thanks to the `implements` check above.
-                let mut symbol_table = parent.borrow_mut();
-                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
-                let mut sym_manager = sym_manager.symbol_manager_mut();
+        // NOTE: We use OperationName, instead of the Operation itself, to avoid borrowing.
+        if this.name().implements::<dyn Symbol>() {
+            let parent = this.nearest_symbol_table();
+            if let Some(mut parent) = parent {
+                if parent.name().implements::<dyn SymbolTable>() {
+                    // NOTE: We call `unwrap()` here because we are confident that these function calls
+                    // are valid thanks to the `implements` check above.
+                    let mut symbol_table = parent.borrow_mut();
+                    let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
+                    let mut sym_manager = sym_manager.symbol_manager_mut();
 
-                let symbol_ref = this.borrow().as_symbol_ref().unwrap();
+                    let symbol_ref = this.borrow().as_symbol_ref().unwrap();
 
-                let is_new = sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
-                assert!(
-                    is_new,
-                    "Unable to insert {} in symbol table of {}: symbol {} is already registered \
-                     to another operation {}.",
-                    this.name(),
-                    parent.name(),
-                    symbol_ref.borrow().name(),
-                    sym_manager.lookup(symbol_ref.borrow().name()).unwrap().borrow().name()
-                );
-            };
+                    let is_new = sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
+                    assert!(
+                        is_new,
+                        "Unable to insert {} in symbol table of {}: symbol {} is already \
+                         registered to another operation {}.",
+                        this.name(),
+                        parent.name(),
+                        symbol_ref.borrow().name(),
+                        sym_manager.lookup(symbol_ref.borrow().name()).unwrap().borrow().name()
+                    );
+                }
+            }
         }
-
         let order_offset = core::mem::offset_of!(Operation, order);
         unsafe {
             let ptr = UnsafeIntrusiveEntityRef::as_ptr(&this);
@@ -223,20 +222,21 @@ impl EntityListItem for Operation {
     }
 
     fn on_removed(this: OperationRef, _list: &mut EntityCursorMut<'_, Self>) {
-        let parent = this.nearest_symbol_table();
-        if let Some(mut parent) = parent {
-            // NOTE: We use OperationName, instead of the Operation itself, to avoid borrowing.
-            if this.name().implements::<dyn Symbol>()
-                && parent.name().implements::<dyn SymbolTable>()
-            {
-                let mut symbol_table = parent.borrow_mut();
-                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
-                let mut sym_manager = sym_manager.symbol_manager_mut();
+        // NOTE: We use OperationName, instead of the Operation itself, to avoid borrowing.
+        if this.name().implements::<dyn Symbol>() {
+            let parent = this.nearest_symbol_table();
+            if let Some(mut parent) = parent {
+                // NOTE: We use OperationName, instead of the Operation itself, to avoid borrowing.
+                if parent.name().implements::<dyn SymbolTable>() {
+                    let mut symbol_table = parent.borrow_mut();
+                    let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
+                    let mut sym_manager = sym_manager.symbol_manager_mut();
 
-                let symbol_ref = this.borrow().as_symbol_ref().unwrap();
+                    let symbol_ref = this.borrow().as_symbol_ref().unwrap();
 
-                sym_manager.remove(symbol_ref);
-            };
+                    sym_manager.remove(symbol_ref);
+                };
+            }
         }
     }
 }

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -1125,6 +1125,14 @@ impl Operation {
 
 /// Insertion
 impl Operation {
+    pub fn insert_at_start(&mut self, block: BlockRef) {
+        self.as_operation_ref().insert_at_start(block);
+    }
+
+    pub fn insert_at_end(&mut self, block: BlockRef) {
+        self.as_operation_ref().insert_at_end(block);
+    }
+
     pub fn insert_before(&mut self, before: OperationRef) {
         assert!(
             self.parent().is_none(),

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -301,12 +301,10 @@ impl OperationRef {
     pub fn nearest_symbol_table(&self) -> Option<OperationRef> {
         let mut parent = self.parent_op();
         while let Some(parent_op) = parent.take() {
-            let op = parent_op.borrow();
-            if op.implements::<dyn SymbolTable>() {
-                drop(op);
+            if parent_op.name().implements::<dyn SymbolTable>() {
                 return Some(parent_op);
             }
-            parent = op.parent_op();
+            parent = parent_op.parent_op();
         }
         None
     }

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -189,10 +189,16 @@ impl EntityListItem for Operation {
                 && parent.name().implements::<dyn SymbolTable>()
             {
                 let mut symbol_table = parent.borrow_mut();
-                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
+                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().expect(
+                    "Could not cast parent operation {parent.name()} as SymbolTable, even though \
+                     it implements said trait",
+                );
                 let mut sym_manager = sym_manager.symbol_manager_mut();
 
-                let symbol_ref = this.borrow().as_symbol_ref().unwrap();
+                let symbol_ref = this.borrow().as_symbol_ref().expect(
+                    "Could not cast operation {this.name()} as Symbol, even though it implements \
+                     said trait",
+                );
 
                 sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
             };

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -319,7 +319,6 @@ impl OperationRef {
         self.parent().and_then(|block| block.parent())
     }
 
-    /// TODO(fabrio): maybe remove later?
     /// Returns the nearest [SymbolTable] from this operation.
     ///
     /// Returns `None` if no parent of this operation is a valid symbol table.
@@ -602,13 +601,13 @@ impl Operation {
         self.as_operation_ref().parent()
     }
 
-    /// TODO(fabrio): maybe remove later?
+    /// NOTE: this is a duplicate of OperationRef::parent_region
     /// Returns a handle to the containing [Region] of this operation, if it is attached to one
     pub fn parent_region(&self) -> Option<RegionRef> {
         self.parent().and_then(|block| block.parent())
     }
 
-    /// TODO(fabrio): maybe remove later?
+    /// NOTE: this is a duplicate of OperationRef::parent_region
     /// Returns a handle to the nearest containing [Operation] of this operation, if it is attached
     /// to one
     pub fn parent_op(&self) -> Option<OperationRef> {

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -344,7 +344,7 @@ impl OperationRef {
 
     /// Returns a handle to the containing [Region] of this operation, if it is attached to one
     pub fn parent_region(&self) -> Option<RegionRef> {
-        self.parent().and_then(|block| block.parent())
+        self.grandparent()
     }
 
     /// Returns the nearest [SymbolTable] from this operation.

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -187,17 +187,13 @@ impl EntityListItem for Operation {
             if this.name().implements::<dyn Symbol>()
                 && parent.name().implements::<dyn SymbolTable>()
             {
+                // NOTE: We call `unwrap()` here because we are confident that these function calls
+                // are valid thanks to the `implements` check above.
                 let mut symbol_table = parent.borrow_mut();
-                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().expect(
-                    "Could not cast parent operation {parent.name()} as SymbolTable, even though \
-                     it implements said trait",
-                );
+                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
                 let mut sym_manager = sym_manager.symbol_manager_mut();
 
-                let symbol_ref = this.borrow().as_symbol_ref().expect(
-                    "Could not cast operation {this.name()} as Symbol, even though it implements \
-                     said trait",
-                );
+                let symbol_ref = this.borrow().as_symbol_ref().unwrap();
 
                 let is_new = sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
                 assert!(is_new, "{} already exists in {}", this.name(), parent.name());

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -188,10 +188,6 @@ impl EntityListItem for Operation {
             if this.name().implements::<dyn Symbol>()
                 && parent.name().implements::<dyn SymbolTable>()
             {
-                std::dbg!("Here is where the SymbolTable should be modified");
-                std::println!("{} should be inserted in {}", this.name(), parent.name());
-
-                // There are no borrowing problem when it comes to the symbol_table.
                 let mut symbol_table = parent.borrow_mut();
                 let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
                 let mut sym_manager = sym_manager.symbol_manager_mut();

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -199,7 +199,8 @@ impl EntityListItem for Operation {
                      said trait",
                 );
 
-                sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
+                let is_new = sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
+                assert!(is_new, "{} already exists in {}", this.name(), parent.name());
             };
         }
 

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -278,6 +278,28 @@ impl OperationRef {
             OperationName::clone(&*name_ptr)
         }
     }
+
+    pub fn insert_at_start(&self, mut block: BlockRef) {
+        assert!(
+            self.parent().is_none(),
+            "cannot insert operation that is already attached to another block"
+        );
+        {
+            let mut block = block.borrow_mut();
+            block.body_mut().push_front(*self);
+        }
+    }
+
+    pub fn insert_at_end(&self, mut block: BlockRef) {
+        assert!(
+            self.parent().is_none(),
+            "cannot insert operation that is already attached to another block"
+        );
+        {
+            let mut block = block.borrow_mut();
+            block.body_mut().push_back(*self);
+        }
+    }
 }
 
 /// Metadata

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -270,29 +270,29 @@ impl Operation {
 
 /// Insertion
 impl OperationRef {
-    pub fn insert_at_start(&self, mut block: BlockRef) {
+    pub fn insert_at_start(self, mut block: BlockRef) {
         assert!(
             self.parent().is_none(),
             "cannot insert operation that is already attached to another block"
         );
         {
             let mut block = block.borrow_mut();
-            block.body_mut().push_front(*self);
+            block.body_mut().push_front(self);
         }
     }
 
-    pub fn insert_at_end(&self, mut block: BlockRef) {
+    pub fn insert_at_end(self, mut block: BlockRef) {
         assert!(
             self.parent().is_none(),
             "cannot insert operation that is already attached to another block"
         );
         {
             let mut block = block.borrow_mut();
-            block.body_mut().push_back(*self);
+            block.body_mut().push_back(self);
         }
     }
 
-    pub fn insert_before(&mut self, before: OperationRef) {
+    pub fn insert_before(self, before: OperationRef) {
         assert!(
             self.parent().is_none(),
             "cannot insert operation that is already attached to another block"
@@ -302,11 +302,11 @@ impl OperationRef {
             let mut block = block.borrow_mut();
             let block_body = block.body_mut();
             let mut cursor = unsafe { block_body.cursor_mut_from_ptr(before) };
-            cursor.insert_before(*self);
+            cursor.insert_before(self);
         }
     }
 
-    pub fn insert_after(&mut self, after: OperationRef) {
+    pub fn insert_after(self, after: OperationRef) {
         assert!(
             self.parent().is_none(),
             "cannot insert operation that is already attached to another block"
@@ -316,7 +316,7 @@ impl OperationRef {
             let mut block = block.borrow_mut();
             let block_body = block.body_mut();
             let mut cursor = unsafe { block_body.cursor_mut_from_ptr(after) };
-            cursor.insert_after(*self);
+            cursor.insert_after(self);
         }
     }
 }

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -180,7 +180,7 @@ impl EntityWithParent for Operation {
     type Parent = Block;
 }
 impl EntityListItem for Operation {
-    fn on_inserted(this: UnsafeIntrusiveEntityRef<Self>, _cursor: &mut EntityCursorMut<'_, Self>) {
+    fn on_inserted(this: OperationRef, _cursor: &mut EntityCursorMut<'_, Self>) {
         let order_offset = core::mem::offset_of!(Operation, order);
         unsafe {
             let ptr = UnsafeIntrusiveEntityRef::as_ptr(&this);
@@ -189,17 +189,13 @@ impl EntityListItem for Operation {
         }
     }
 
-    fn on_transfer(
-        _this: UnsafeIntrusiveEntityRef<Self>,
-        _from: &mut EntityList<Self>,
-        to: &mut EntityList<Self>,
-    ) {
+    fn on_transfer(_this: OperationRef, _from: &mut EntityList<Self>, to: &mut EntityList<Self>) {
         // Invalidate the ordering of the new parent block
         let mut to = to.parent();
         to.borrow_mut().invalidate_op_order();
     }
 
-    fn on_removed(_this: UnsafeIntrusiveEntityRef<Self>, _list: &mut EntityCursorMut<'_, Self>) {
+    fn on_removed(_this: OperationRef, _list: &mut EntityCursorMut<'_, Self>) {
     }
 }
 

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -1150,25 +1150,6 @@ impl Operation {
     }
 }
 
-/// Insertion
-impl Operation {
-    pub fn insert_at_start(&mut self, block: BlockRef) {
-        self.as_operation_ref().insert_at_start(block);
-    }
-
-    pub fn insert_at_end(&mut self, block: BlockRef) {
-        self.as_operation_ref().insert_at_end(block);
-    }
-
-    pub fn insert_before(&mut self, before: OperationRef) {
-        self.as_operation_ref().insert_before(before);
-    }
-
-    pub fn insert_after(&mut self, after: OperationRef) {
-        self.as_operation_ref().insert_after(after);
-    }
-}
-
 /// Movement
 impl Operation {
     /// Remove this operation (and its descendants) from its containing block, and delete them

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -181,6 +181,16 @@ impl EntityWithParent for Operation {
 }
 impl EntityListItem for Operation {
     fn on_inserted(this: OperationRef, _cursor: &mut EntityCursorMut<'_, Self>) {
+        let op = this;
+        let parent = this.grandparent().unwrap().parent().unwrap();
+
+        // NOTE: We are using OperationName here to check if the Operation implements symbol since
+        // the actual Operation is already being borrowed
+        if op.name().implements::<dyn Symbol>() && parent.name().implements::<dyn SymbolTable>() {
+            std::dbg!("Here is where the SymbolTable should be modified");
+            std::println!("{} should be inserted in {}", op.name(), parent.name());
+        };
+
         let order_offset = core::mem::offset_of!(Operation, order);
         unsafe {
             let ptr = UnsafeIntrusiveEntityRef::as_ptr(&this);

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -198,6 +198,9 @@ impl EntityListItem for Operation {
         let mut to = to.parent();
         to.borrow_mut().invalidate_op_order();
     }
+
+    fn on_removed(_this: UnsafeIntrusiveEntityRef<Self>, _list: &mut EntityCursorMut<'_, Self>) {
+    }
 }
 
 impl EntityParent<Region> for Operation {

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -182,13 +182,14 @@ impl EntityWithParent for Operation {
 impl EntityListItem for Operation {
     fn on_inserted(this: OperationRef, _cursor: &mut EntityCursorMut<'_, Self>) {
         let op = this;
-        let parent = this.grandparent().unwrap().parent().unwrap();
+        let mut parent = this.grandparent().unwrap().parent().unwrap();
 
         // NOTE: We are using OperationName here to check if the Operation implements symbol since
         // the actual Operation is already being borrowed
         if op.name().implements::<dyn Symbol>() && parent.name().implements::<dyn SymbolTable>() {
             std::dbg!("Here is where the SymbolTable should be modified");
             std::println!("{} should be inserted in {}", op.name(), parent.name());
+            let mut _parent = parent.borrow_mut();
         };
 
         let order_offset = core::mem::offset_of!(Operation, order);

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -1092,28 +1092,6 @@ impl Operation {
 
 /// Insertion
 impl Operation {
-    pub fn insert_at_start(&mut self, mut block: BlockRef) {
-        assert!(
-            self.parent().is_none(),
-            "cannot insert operation that is already attached to another block"
-        );
-        {
-            let mut block = block.borrow_mut();
-            block.body_mut().push_front(self.as_operation_ref());
-        }
-    }
-
-    pub fn insert_at_end(&mut self, mut block: BlockRef) {
-        assert!(
-            self.parent().is_none(),
-            "cannot insert operation that is already attached to another block"
-        );
-        {
-            let mut block = block.borrow_mut();
-            block.body_mut().push_back(self.as_operation_ref());
-        }
-    }
-
     pub fn insert_before(&mut self, before: OperationRef) {
         assert!(
             self.parent().is_none(),

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -196,7 +196,14 @@ impl EntityListItem for Operation {
                 let symbol_ref = this.borrow().as_symbol_ref().unwrap();
 
                 let is_new = sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
-                assert!(is_new, "{} already exists in {}", this.name(), parent.name());
+                assert!(
+                    is_new,
+                    "Unable to insert {} in symbol table of {}: symbol {} is already registered \
+                     to another operation",
+                    this.name(),
+                    parent.name(),
+                    symbol_ref.borrow().name(),
+                );
             };
         }
 

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -230,16 +230,10 @@ impl EntityListItem for Operation {
                 && parent.name().implements::<dyn SymbolTable>()
             {
                 let mut symbol_table = parent.borrow_mut();
-                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().expect(
-                    "Could not cast parent operation {parent.name()} as SymbolTable, even though \
-                     it implements said trait",
-                );
+                let sym_manager = symbol_table.as_trait_mut::<dyn SymbolTable>().unwrap();
                 let mut sym_manager = sym_manager.symbol_manager_mut();
 
-                let symbol_ref = this.borrow().as_symbol_ref().expect(
-                    "Could not cast operation {this.name()} as Symbol, even though it implements \
-                     said trait",
-                );
+                let symbol_ref = this.borrow().as_symbol_ref().unwrap();
 
                 sym_manager.remove(symbol_ref);
             };

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -186,8 +186,8 @@ impl EntityListItem for Operation {
         // however they are accesible via Operation rather than OperationRefs.
         let mut parent = this.grandparent().unwrap().parent().unwrap();
 
-        // NOTE: We are using OperationName here to check if the Operation implements symbol since
-        // the actual Operation is already being borrowed in hir/src/ir/builder.rs:136
+        // NOTE: We are using OperationName here to check if the Operation implements symbol to
+        // avoid borrowing if possible
         if op.name().implements::<dyn Symbol>() && parent.name().implements::<dyn SymbolTable>() {
             std::dbg!("Here is where the SymbolTable should be modified");
             std::println!("{} should be inserted in {}", op.name(), parent.name());
@@ -197,27 +197,9 @@ impl EntityListItem for Operation {
             let sym_manager = parent.as_trait_mut::<dyn SymbolTable>().unwrap();
             let mut sym_manager = sym_manager.symbol_manager_mut();
 
-            // The problem arises when I try to obtain a SymbolRef.
-            unsafe {
-                // I am not able to obtain a symbol reference from the operation.
-                // I tried with this approach here.
-                // However, as soon as I borrow the operation to get its symbol reference, a panic
-                // is raised stating that the operation is already borrowed in
-                // hir/src/ir/builder.rs:136
-                let symbol_ref = op.borrow().as_symbol_ref().unwrap();
+            let symbol_ref = op.borrow().as_symbol_ref().unwrap();
 
-                sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
-
-                //// I even tried this pointer approach, however, the insert_new function tries to
-                //// borrow the symbol, so the same error is raised, only a couple of functions
-                //// after.
-                // let raw = OperationRef::as_ptr(&this);
-                // let op = raw.as_ref().unwrap();
-                // let symbol = op.as_symbol_ref().unwrap();
-                // let symbol_ref = symbol.as_symbol_ref();
-                //
-                // sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
-            }
+            sym_manager.insert_new(symbol_ref, ProgramPoint::Invalid);
         };
 
         let order_offset = core::mem::offset_of!(Operation, order);

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -199,10 +199,11 @@ impl EntityListItem for Operation {
                 assert!(
                     is_new,
                     "Unable to insert {} in symbol table of {}: symbol {} is already registered \
-                     to another operation",
+                     to another operation {}.",
                     this.name(),
                     parent.name(),
                     symbol_ref.borrow().name(),
+                    sym_manager.lookup(symbol_ref.borrow().name()).unwrap().borrow().name()
                 );
             };
         }

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -600,17 +600,15 @@ impl Operation {
         self.as_operation_ref().parent()
     }
 
-    /// NOTE: this is a duplicate of OperationRef::parent_region
     /// Returns a handle to the containing [Region] of this operation, if it is attached to one
     pub fn parent_region(&self) -> Option<RegionRef> {
-        self.parent().and_then(|block| block.parent())
+        self.as_operation_ref().parent_region()
     }
 
-    /// NOTE: this is a duplicate of OperationRef::parent_region
     /// Returns a handle to the nearest containing [Operation] of this operation, if it is attached
     /// to one
     pub fn parent_op(&self) -> Option<OperationRef> {
-        self.parent_region().and_then(|region| region.parent())
+        self.as_operation_ref().parent_op()
     }
 
     /// Returns a handle to the nearest containing [Operation] of type `T` for this operation, if it

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -270,21 +270,8 @@ impl Operation {
     }
 }
 
-/// Read-only Metadata
+/// Insertion
 impl OperationRef {
-    pub fn name(&self) -> OperationName {
-        let ptr = OperationRef::as_ptr(self);
-        // SAFETY: The `name` field of Operation is read-only after an op is allocated, and the
-        // safety guarantees of OperationRef require that the allocation never moves for the
-        // lifetime of the ref. So it is always safe to read this field via direct pointer, even
-        // if a mutable borrow of the containing op exists, because the field is never written to
-        // after allocation.
-        unsafe {
-            let name_ptr = core::ptr::addr_of!((*ptr).name);
-            OperationName::clone(&*name_ptr)
-        }
-    }
-
     pub fn insert_at_start(&self, mut block: BlockRef) {
         assert!(
             self.parent().is_none(),
@@ -304,6 +291,22 @@ impl OperationRef {
         {
             let mut block = block.borrow_mut();
             block.body_mut().push_back(*self);
+        }
+    }
+}
+
+/// Read-only Metadata
+impl OperationRef {
+    pub fn name(&self) -> OperationName {
+        let ptr = OperationRef::as_ptr(self);
+        // SAFETY: The `name` field of Operation is read-only after an op is allocated, and the
+        // safety guarantees of OperationRef require that the allocation never moves for the
+        // lifetime of the ref. So it is always safe to read this field via direct pointer, even
+        // if a mutable borrow of the containing op exists, because the field is never written to
+        // after allocation.
+        unsafe {
+            let name_ptr = core::ptr::addr_of!((*ptr).name);
+            OperationName::clone(&*name_ptr)
         }
     }
 

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -183,8 +183,7 @@ impl EntityListItem for Operation {
     fn on_inserted(this: OperationRef, _cursor: &mut EntityCursorMut<'_, Self>) {
         let parent = this.nearest_symbol_table();
         if let Some(mut parent) = parent {
-            // NOTE: We are using OperationName here to check if the Operation implements symbol to
-            // avoid borrowing if possible
+            // NOTE: We use OperationName, instead of the Operation itself, to avoid borrowing.
             if this.name().implements::<dyn Symbol>()
                 && parent.name().implements::<dyn SymbolTable>()
             {
@@ -221,8 +220,7 @@ impl EntityListItem for Operation {
     fn on_removed(this: OperationRef, _list: &mut EntityCursorMut<'_, Self>) {
         let parent = this.nearest_symbol_table();
         if let Some(mut parent) = parent {
-            // NOTE: We are using OperationName here to check if the Operation implements symbol to
-            // avoid borrowing if possible
+            // NOTE: We use OperationName, instead of the Operation itself, to avoid borrowing.
             if this.name().implements::<dyn Symbol>()
                 && parent.name().implements::<dyn SymbolTable>()
             {

--- a/hir/src/ir/operation.rs
+++ b/hir/src/ir/operation.rs
@@ -293,6 +293,34 @@ impl OperationRef {
             block.body_mut().push_back(*self);
         }
     }
+
+    pub fn insert_before(&mut self, before: OperationRef) {
+        assert!(
+            self.parent().is_none(),
+            "cannot insert operation that is already attached to another block"
+        );
+        let mut block = before.parent().expect("'before' block is not attached to a block");
+        {
+            let mut block = block.borrow_mut();
+            let block_body = block.body_mut();
+            let mut cursor = unsafe { block_body.cursor_mut_from_ptr(before) };
+            cursor.insert_before(*self);
+        }
+    }
+
+    pub fn insert_after(&mut self, after: OperationRef) {
+        assert!(
+            self.parent().is_none(),
+            "cannot insert operation that is already attached to another block"
+        );
+        let mut block = after.parent().expect("'after' block is not attached to a block");
+        {
+            let mut block = block.borrow_mut();
+            let block_body = block.body_mut();
+            let mut cursor = unsafe { block_body.cursor_mut_from_ptr(after) };
+            cursor.insert_after(*self);
+        }
+    }
 }
 
 /// Read-only Metadata
@@ -1135,31 +1163,11 @@ impl Operation {
     }
 
     pub fn insert_before(&mut self, before: OperationRef) {
-        assert!(
-            self.parent().is_none(),
-            "cannot insert operation that is already attached to another block"
-        );
-        let mut block = before.parent().expect("'before' block is not attached to a block");
-        {
-            let mut block = block.borrow_mut();
-            let block_body = block.body_mut();
-            let mut cursor = unsafe { block_body.cursor_mut_from_ptr(before) };
-            cursor.insert_before(self.as_operation_ref());
-        }
+        self.as_operation_ref().insert_before(before);
     }
 
     pub fn insert_after(&mut self, after: OperationRef) {
-        assert!(
-            self.parent().is_none(),
-            "cannot insert operation that is already attached to another block"
-        );
-        let mut block = after.parent().expect("'after' block is not attached to a block");
-        {
-            let mut block = block.borrow_mut();
-            let block_body = block.body_mut();
-            let mut cursor = unsafe { block_body.cursor_mut_from_ptr(after) };
-            cursor.insert_after(self.as_operation_ref());
-        }
+        self.as_operation_ref().insert_after(after);
     }
 }
 

--- a/hir/src/ir/symbols.rs
+++ b/hir/src/ir/symbols.rs
@@ -147,7 +147,7 @@ impl Operation {
         parent
     }
 
-    /// TODO(fabrio): maybe remove later?
+    /// NOTE: this is a duplicate of OperationRef::nearest_symbol_table
     /// Returns the nearest [SymbolTable] from this operation.
     ///
     /// Returns `None` if no parent of this operation is a valid symbol table.

--- a/hir/src/ir/symbols.rs
+++ b/hir/src/ir/symbols.rs
@@ -147,6 +147,7 @@ impl Operation {
         parent
     }
 
+    /// TODO(fabrio): maybe remove later?
     /// Returns the nearest [SymbolTable] from this operation.
     ///
     /// Returns `None` if no parent of this operation is a valid symbol table.

--- a/hir/src/ir/symbols.rs
+++ b/hir/src/ir/symbols.rs
@@ -147,21 +147,11 @@ impl Operation {
         parent
     }
 
-    /// NOTE: this is a duplicate of OperationRef::nearest_symbol_table
     /// Returns the nearest [SymbolTable] from this operation.
     ///
     /// Returns `None` if no parent of this operation is a valid symbol table.
     pub fn nearest_symbol_table(&self) -> Option<OperationRef> {
-        let mut parent = self.parent_op();
-        while let Some(parent_op) = parent.take() {
-            let op = parent_op.borrow();
-            if op.implements::<dyn SymbolTable>() {
-                drop(op);
-                return Some(parent_op);
-            }
-            parent = op.parent_op();
-        }
-        None
+        self.as_operation_ref().nearest_symbol_table()
     }
 
     /// Returns the operation registered with the given symbol name within the closest symbol table

--- a/hir/src/lib.rs
+++ b/hir/src/lib.rs
@@ -41,7 +41,7 @@
 // Some of the above features require us to disable these warnings
 #![allow(incomplete_features)]
 #![allow(internal_features)]
-// #![deny(warnings)]
+#![deny(warnings)]
 
 extern crate alloc;
 

--- a/hir/src/lib.rs
+++ b/hir/src/lib.rs
@@ -41,7 +41,7 @@
 // Some of the above features require us to disable these warnings
 #![allow(incomplete_features)]
 #![allow(internal_features)]
-#![deny(warnings)]
+// #![deny(warnings)]
 
 extern crate alloc;
 

--- a/hir/src/patterns/rewriter.rs
+++ b/hir/src/patterns/rewriter.rs
@@ -358,7 +358,7 @@ pub trait Rewriter: Builder + RewriterListener {
     /// Insert an unlinked operation at the end of `ip`
     fn insert_op_at_end(&mut self, mut op: OperationRef, ip: BlockRef) {
         let prev = ProgramPoint::before(op);
-        op.borrow_mut().insert_at_end(ip);
+        op.insert_at_end(ip);
         self.notify_operation_inserted(op, prev);
     }
 

--- a/hir/src/patterns/rewriter.rs
+++ b/hir/src/patterns/rewriter.rs
@@ -356,7 +356,7 @@ pub trait Rewriter: Builder + RewriterListener {
     }
 
     /// Insert an unlinked operation at the end of `ip`
-    fn insert_op_at_end(&mut self, mut op: OperationRef, ip: BlockRef) {
+    fn insert_op_at_end(&mut self, op: OperationRef, ip: BlockRef) {
         let prev = ProgramPoint::before(op);
         op.insert_at_end(ip);
         self.notify_operation_inserted(op, prev);

--- a/hir/src/patterns/rewriter.rs
+++ b/hir/src/patterns/rewriter.rs
@@ -344,14 +344,14 @@ pub trait Rewriter: Builder + RewriterListener {
     /// Insert an unlinked operation right before `ip`
     fn insert_op_before(&mut self, mut op: OperationRef, ip: OperationRef) {
         let prev = ProgramPoint::before(op);
-        op.borrow_mut().insert_before(ip);
+        op.borrow_mut().as_operation_ref().insert_before(ip);
         self.notify_operation_inserted(op, prev);
     }
 
     /// Insert an unlinked operation right after `ip`
     fn insert_op_after(&mut self, mut op: OperationRef, ip: OperationRef) {
         let prev = ProgramPoint::before(op);
-        op.borrow_mut().insert_after(ip);
+        op.borrow_mut().as_operation_ref().insert_after(ip);
         self.notify_operation_inserted(op, prev);
     }
 


### PR DESCRIPTION
Closes: #404

This PR implements logic to add an Operation which implements the `Symbol` trait to its parent `SymbolTable`, after the Operation is built.

This is done via the `EntityListItem::on_inserted` and `EntityListItem::on_removed` hooks, which are run after an `Operation` is added or removed removed from an `EntityList` respectively. This executed shortly after `Operation` creation, during the final stages of the `OperationBuilder::build` function.

Originally, `Operation`s were borrowed before entering this function, which caused errors when trying to add them to their parent's `SymbolTable`. To prevent this, some functions related to `Operation` insertion were moved to `OperationRef` and now avoid borrowing the underlying `Operation`.
