### PR TITLE
chore: remove lto = "thin" from release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ codegen-units = 1
 opt-level = 2
 debug = true
 codegen-units = 1
+lto = "fat"
 
 # The following crates are always built with optimizations
 [profile.test.package.proptest]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,6 @@ codegen-units = 1
 opt-level = 2
 debug = true
 codegen-units = 1
-lto = "thin"
 
 # The following crates are always built with optimizations
 [profile.test.package.proptest]


### PR DESCRIPTION
Issue raised in this conversation: https://github.com/0xMiden/midenup/pull/5#discussion_r2141001835