### PR TITLE
Fix mask in `trunc_int32` and add memory intrinsics tests for `bool`, `u8`, `u16` values

### DIFF
--- a/codegen/masm/src/emit/int32.rs
+++ b/codegen/masm/src/emit/int32.rs
@@ -353,7 +353,7 @@ impl OpEmitter<'_> {
         // Mask out any bits between N and 32.
         let unused_bits = 32 - n;
         if unused_bits > 0 {
-            self.const_mask_u32(1 << ((32 - unused_bits) - 1), span);
+            self.const_mask_u32((1 << (32 - unused_bits)) - 1, span);
         }
     }
 

--- a/tests/integration/expected/examples/basic_wallet.masm
+++ b/tests/integration/expected/examples/basic_wallet.masm
@@ -532,7 +532,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/examples/counter.masm
+++ b/tests/integration/expected/examples/counter.masm
@@ -858,7 +858,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/examples/counter_note.masm
+++ b/tests/integration/expected/examples/counter_note.masm
@@ -105,7 +105,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -589,7 +589,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/examples/storage_example.masm
+++ b/tests/integration/expected/examples/storage_example.masm
@@ -717,7 +717,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.masm
@@ -70,7 +70,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/rust_sdk/cross_ctx_account_word_arg.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account_word_arg.masm
@@ -152,7 +152,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.masm
@@ -84,7 +84,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/rust_sdk/cross_ctx_note_word_arg.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note_word_arg.masm
@@ -106,7 +106,7 @@ proc.wit_bindgen_rt::run_ctors_once
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.0
     swap.1

--- a/tests/integration/expected/types/static_mut.masm
+++ b/tests/integration/expected/types/static_mut.masm
@@ -41,12 +41,12 @@ export.global_var_update
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.128
+    push.255
     u32and
     push.1
     swap.1
     u32wrapping_add
-    push.128
+    push.255
     u32and
     push.1048576
     push.0
@@ -97,7 +97,7 @@ export.__main
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        push.128
+        push.255
         u32and
         movup.2
         swap.1

--- a/tests/integration/src/codegen/intrinsics/mem.rs
+++ b/tests/integration/src/codegen/intrinsics/mem.rs
@@ -113,7 +113,7 @@ fn load_dw() {
             felts: Cow::Borrowed(value_felts.as_slice()),
         }];
 
-        // Generate a `test` module with `main` function that invokes `load_sw` when lowered to MASM
+        // Generate a `test` module with `main` function that invokes `load_dw` when lowered to MASM
         let signature = Signature::new(
             [AbiParam::new(Type::from(PointerType::new(Type::U64)))],
             [AbiParam::new(Type::U64)],
@@ -144,6 +144,80 @@ fn load_dw() {
                 log::trace!(target: "executor", "hi = {hi} ({hi:0x})");
                 log::trace!(target: "executor", "lo = {lo} ({lo:0x})");
                 let stored = trace.read_from_rust_memory::<u64>(write_to).ok_or_else(|| {
+                    TestCaseError::fail(format!(
+                        "expected {value} to have been written to byte address {write_to}, but \
+                         read from that address failed"
+                    ))
+                })?;
+                prop_assert_eq!(
+                    stored,
+                    value,
+                    "expected {} to have been written to byte address {}, but found {} there \
+                     instead",
+                    value,
+                    write_to,
+                    stored
+                );
+                Ok(())
+            },
+        )?;
+
+        prop_assert_eq!(output, value);
+
+        Ok(())
+    });
+
+    match res {
+        Err(TestError::Fail(_, value)) => {
+            panic!("Found minimal(shrinked) failing case: {:?}", value);
+        }
+        Ok(_) => (),
+        _ => panic!("Unexpected test result: {:?}", res),
+    }
+}
+
+/// Tests the memory load intrinsic for loads of single-byte (i.e. 8-bit) values
+#[test]
+fn load_u8() {
+    setup::enable_compiler_instrumentation();
+
+    let config = proptest::test_runner::Config::with_cases(10);
+    let res = TestRunner::new(config).run(&any::<u8>(), move |value| {
+        let context = setup::dummy_context(&["--test-harness", "--entrypoint", "test::main"]);
+
+        // Construct the link outputs to be populated
+        let link_output = setup::build_empty_component_for_test(context.clone());
+        // Write `value` to the start of the 17th page (1 page after the 16 pages reserved for the
+        // Rust stack)
+        let write_to = 17 * 2u32.pow(16);
+        let value_bytes = [value];
+        let initializers = [Initializer::MemoryBytes {
+            addr: write_to,
+            bytes: &value_bytes,
+        }];
+
+        // Generate a `test` module with `main` function that invokes load for u8 when lowered to MASM
+        let signature = Signature::new(
+            [AbiParam::new(Type::from(PointerType::new(Type::U8)))],
+            [AbiParam::new(Type::U8)],
+        );
+        setup::build_entrypoint(link_output.component, &signature, |builder| {
+            let block = builder.current_block();
+            // Get the input pointer, and load the value at that address
+            let ptr = block.borrow().arguments()[0] as ValueRef;
+            let loaded = builder.load(ptr, SourceSpan::default()).unwrap();
+            // Return the value so we can assert that the output of execution matches
+            builder.ret(Some(loaded), SourceSpan::default()).unwrap();
+        });
+
+        let args = [Felt::new(write_to as u64)];
+        let output = eval_link_output::<u8, _, _>(
+            link_output,
+            initializers,
+            &args,
+            context.session(),
+            |trace| {
+                let stored = trace.read_from_rust_memory::<u8>(write_to).ok_or_else(|| {
                     TestCaseError::fail(format!(
                         "expected {value} to have been written to byte address {write_to}, but \
                          read from that address failed"

--- a/tests/integration/src/codegen/intrinsics/mem.rs
+++ b/tests/integration/src/codegen/intrinsics/mem.rs
@@ -323,3 +323,78 @@ fn load_u16() {
         _ => panic!("Unexpected test result: {:?}", res),
     }
 }
+
+/// Tests the memory load intrinsic for loads of boolean (i.e. 1-bit) values
+#[test]
+fn load_bool() {
+    setup::enable_compiler_instrumentation();
+
+    let config = proptest::test_runner::Config::with_cases(10);
+    let res = TestRunner::new(config).run(&any::<bool>(), move |value| {
+        let context = setup::dummy_context(&["--test-harness", "--entrypoint", "test::main"]);
+
+        // Construct the link outputs to be populated
+        let link_output = setup::build_empty_component_for_test(context.clone());
+        // Write `value` to the start of the 17th page (1 page after the 16 pages reserved for the
+        // Rust stack)
+        let write_to = 17 * 2u32.pow(16);
+        let value_bytes = [value as u8];
+        let initializers = [Initializer::MemoryBytes {
+            addr: write_to,
+            bytes: &value_bytes,
+        }];
+
+        // Generate a `test` module with `main` function that invokes load for bool when lowered to MASM
+        let signature = Signature::new(
+            [AbiParam::new(Type::from(PointerType::new(Type::I1)))],
+            [AbiParam::new(Type::I1)],
+        );
+        setup::build_entrypoint(link_output.component, &signature, |builder| {
+            let block = builder.current_block();
+            // Get the input pointer, and load the value at that address
+            let ptr = block.borrow().arguments()[0] as ValueRef;
+            let loaded = builder.load(ptr, SourceSpan::default()).unwrap();
+            // Return the value so we can assert that the output of execution matches
+            builder.ret(Some(loaded), SourceSpan::default()).unwrap();
+        });
+
+        let args = [Felt::new(write_to as u64)];
+        let output = eval_link_output::<bool, _, _>(
+            link_output,
+            initializers,
+            &args,
+            context.session(),
+            |trace| {
+                let stored = trace.read_from_rust_memory::<u8>(write_to).ok_or_else(|| {
+                    TestCaseError::fail(format!(
+                        "expected {value} to have been written to byte address {write_to}, but \
+                         read from that address failed"
+                    ))
+                })?;
+                let stored_bool = stored != 0;
+                prop_assert_eq!(
+                    stored_bool,
+                    value,
+                    "expected {} to have been written to byte address {}, but found {} there \
+                     instead",
+                    value,
+                    write_to,
+                    stored_bool
+                );
+                Ok(())
+            },
+        )?;
+
+        prop_assert_eq!(output, value);
+
+        Ok(())
+    });
+
+    match res {
+        Err(TestError::Fail(_, value)) => {
+            panic!("Found minimal(shrinked) failing case: {:?}", value);
+        }
+        Ok(_) => (),
+        _ => panic!("Unexpected test result: {:?}", res),
+    }
+}

--- a/tests/integration/src/codegen/intrinsics/mem.rs
+++ b/tests/integration/src/codegen/intrinsics/mem.rs
@@ -249,3 +249,77 @@ fn load_u8() {
         _ => panic!("Unexpected test result: {:?}", res),
     }
 }
+
+/// Tests the memory load intrinsic for loads of 16-bit (u16) values
+#[test]
+fn load_u16() {
+    setup::enable_compiler_instrumentation();
+
+    let config = proptest::test_runner::Config::with_cases(10);
+    let res = TestRunner::new(config).run(&any::<u16>(), move |value| {
+        let context = setup::dummy_context(&["--test-harness", "--entrypoint", "test::main"]);
+
+        // Construct the link outputs to be populated
+        let link_output = setup::build_empty_component_for_test(context.clone());
+        // Write `value` to the start of the 17th page (1 page after the 16 pages reserved for the
+        // Rust stack)
+        let write_to = 17 * 2u32.pow(16);
+        let value_bytes = value.to_ne_bytes();
+        let initializers = [Initializer::MemoryBytes {
+            addr: write_to,
+            bytes: &value_bytes,
+        }];
+
+        // Generate a `test` module with `main` function that invokes load for u16 when lowered to MASM
+        let signature = Signature::new(
+            [AbiParam::new(Type::from(PointerType::new(Type::U16)))],
+            [AbiParam::new(Type::U16)],
+        );
+        setup::build_entrypoint(link_output.component, &signature, |builder| {
+            let block = builder.current_block();
+            // Get the input pointer, and load the value at that address
+            let ptr = block.borrow().arguments()[0] as ValueRef;
+            let loaded = builder.load(ptr, SourceSpan::default()).unwrap();
+            // Return the value so we can assert that the output of execution matches
+            builder.ret(Some(loaded), SourceSpan::default()).unwrap();
+        });
+
+        let args = [Felt::new(write_to as u64)];
+        let output = eval_link_output::<u16, _, _>(
+            link_output,
+            initializers,
+            &args,
+            context.session(),
+            |trace| {
+                let stored = trace.read_from_rust_memory::<u16>(write_to).ok_or_else(|| {
+                    TestCaseError::fail(format!(
+                        "expected {value} to have been written to byte address {write_to}, but \
+                         read from that address failed"
+                    ))
+                })?;
+                prop_assert_eq!(
+                    stored,
+                    value,
+                    "expected {} to have been written to byte address {}, but found {} there \
+                     instead",
+                    value,
+                    write_to,
+                    stored
+                );
+                Ok(())
+            },
+        )?;
+
+        prop_assert_eq!(output, value);
+
+        Ok(())
+    });
+
+    match res {
+        Err(TestError::Fail(_, value)) => {
+            panic!("Found minimal(shrinked) failing case: {:?}", value);
+        }
+        Ok(_) => (),
+        _ => panic!("Unexpected test result: {:?}", res),
+    }
+}


### PR DESCRIPTION
Close #268 

Discovered while working on #533.

This PR fixes the mask in the `trunc_int32` function and adds loading tests for `bool`, `u8` and `u16` values.