### PR TITLE
Add a rewriter pass for folding redundant yields from SCF control flow.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3979,7 +3979,6 @@ dependencies = [
  "log",
  "midenc-dialect-arith",
  "midenc-dialect-cf",
- "midenc-dialect-hir",
  "midenc-dialect-ub",
  "midenc-expect-test",
  "midenc-hir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3979,6 +3979,7 @@ dependencies = [
  "log",
  "midenc-dialect-arith",
  "midenc-dialect-cf",
+ "midenc-dialect-hir",
  "midenc-dialect-ub",
  "midenc-expect-test",
  "midenc-hir",

--- a/dialects/scf/Cargo.toml
+++ b/dialects/scf/Cargo.toml
@@ -25,6 +25,5 @@ midenc-hir-transform.workspace = true
 bitvec.workspace = true
 
 [dev-dependencies]
-midenc-dialect-hir.workspace = true
 midenc-expect-test.workspace = true
 env_logger.workspace = true

--- a/dialects/scf/Cargo.toml
+++ b/dialects/scf/Cargo.toml
@@ -25,5 +25,6 @@ midenc-hir-transform.workspace = true
 bitvec.workspace = true
 
 [dev-dependencies]
+midenc-dialect-hir.workspace = true
 midenc-expect-test.workspace = true
 env_logger.workspace = true

--- a/dialects/scf/src/canonicalization.rs
+++ b/dialects/scf/src/canonicalization.rs
@@ -1,6 +1,7 @@
 //mod convert_do_while_to_while_true;
 mod convert_trivial_if_to_select;
 mod fold_constant_index_switch;
+mod fold_redundant_yields;
 mod if_remove_unused_results;
 mod remove_loop_invariant_args_from_before_block;
 //mod remove_loop_invariant_value_yielded;
@@ -13,6 +14,7 @@ pub use self::{
     //convert_do_while_to_while_true::ConvertDoWhileToWhileTrue,
     convert_trivial_if_to_select::ConvertTrivialIfToSelect,
     fold_constant_index_switch::FoldConstantIndexSwitch,
+    fold_redundant_yields::FoldRedundantYields,
     if_remove_unused_results::IfRemoveUnusedResults,
     remove_loop_invariant_args_from_before_block::RemoveLoopInvariantArgsFromBeforeBlock,
     while_condition_truth::WhileConditionTruth,

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_after.hir
@@ -1,0 +1,27 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v8 = arith.constant 44 : u32;
+    v5 = arith.constant 11 : u32;
+    v6 = arith.constant 22 : u32;
+    v7 = arith.constant 33 : u32;
+    v14 = scf.index_switch v0 : u32 
+    case 1 {
+    ^block1:
+        scf.yield v6;
+    }
+    case 2 {
+    ^block2:
+        scf.yield v6;
+    }
+    case 3 {
+    ^block3:
+        scf.yield v6;
+    }
+    default {
+    ^block4:
+        scf.yield v8;
+    };
+    v9 = arith.add v5, v14 : u32 #[overflow = checked];
+    v10 = arith.add v9, v7 : u32 #[overflow = checked];
+    builtin.ret v10;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_after.hir
@@ -1,9 +1,9 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v8 = arith.constant 44 : u32;
-    v5 = arith.constant 11 : u32;
-    v6 = arith.constant 22 : u32;
-    v7 = arith.constant 33 : u32;
+    v8 = test.constant 44 : u32;
+    v5 = test.constant 11 : u32;
+    v6 = test.constant 22 : u32;
+    v7 = test.constant 33 : u32;
     v14 = scf.index_switch v0 : u32 
     case 1 {
     ^block1:
@@ -21,7 +21,7 @@ public builtin.function @test(v0: u32) -> u32 {
     ^block4:
         scf.yield v8;
     };
-    v9 = arith.add v5, v14 : u32 #[overflow = checked];
-    v10 = arith.add v9, v7 : u32 #[overflow = checked];
+    v9 = test.add v5, v14 : u32 #[overflow = checked];
+    v10 = test.add v9, v7 : u32 #[overflow = checked];
     builtin.ret v10;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_before.hir
@@ -1,0 +1,27 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v5 = arith.constant 11 : u32;
+    v6 = arith.constant 22 : u32;
+    v7 = arith.constant 33 : u32;
+    v13, v14, v15 = scf.index_switch v0 : u32, u32, u32 
+    case 1 {
+    ^block1:
+        scf.yield v5, v6, v7;
+    }
+    case 2 {
+    ^block2:
+        scf.yield v5, v6, v7;
+    }
+    case 3 {
+    ^block3:
+        scf.yield v5, v6, v7;
+    }
+    default {
+    ^block4:
+        v8 = arith.constant 44 : u32;
+        scf.yield v5, v8, v7;
+    };
+    v9 = arith.add v13, v14 : u32 #[overflow = checked];
+    v10 = arith.add v9, v15 : u32 #[overflow = checked];
+    builtin.ret v10;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_but_one_switch_before.hir
@@ -1,8 +1,8 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v5 = arith.constant 11 : u32;
-    v6 = arith.constant 22 : u32;
-    v7 = arith.constant 33 : u32;
+    v5 = test.constant 11 : u32;
+    v6 = test.constant 22 : u32;
+    v7 = test.constant 33 : u32;
     v13, v14, v15 = scf.index_switch v0 : u32, u32, u32 
     case 1 {
     ^block1:
@@ -18,10 +18,10 @@ public builtin.function @test(v0: u32) -> u32 {
     }
     default {
     ^block4:
-        v8 = arith.constant 44 : u32;
+        v8 = test.constant 44 : u32;
         scf.yield v5, v8, v7;
     };
-    v9 = arith.add v13, v14 : u32 #[overflow = checked];
-    v10 = arith.add v9, v15 : u32 #[overflow = checked];
+    v9 = test.add v13, v14 : u32 #[overflow = checked];
+    v10 = test.add v9, v15 : u32 #[overflow = checked];
     builtin.ret v10;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_after.hir
@@ -1,7 +1,7 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 22 : u32;
-    v7 = arith.add v3, v4 : u32 #[overflow = checked];
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 22 : u32;
+    v7 = test.add v3, v4 : u32 #[overflow = checked];
     builtin.ret v7;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_after.hir
@@ -1,0 +1,7 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 22 : u32;
+    v7 = arith.add v3, v4 : u32 #[overflow = checked];
+    builtin.ret v7;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_before.hir
@@ -1,7 +1,7 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 22 : u32;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 22 : u32;
     v12, v13 = scf.index_switch v0 : u32, u32 
     case 1 {
     ^block1:
@@ -9,8 +9,8 @@ public builtin.function @test(v0: u32) -> u32 {
     }
     case 2 {
     ^block4:
-        v5 = arith.constant 0 : u32;
-        v6 = arith.eq v0, v5 : i1;
+        v5 = test.constant 0 : u32;
+        v6 = test.eq v0, v5 : i1;
         v14, v15 = scf.if v6 : u32, u32 {
         ^block2:
             scf.yield v3, v4;
@@ -24,6 +24,6 @@ public builtin.function @test(v0: u32) -> u32 {
     ^block5:
         scf.yield v3, v4;
     };
-    v7 = arith.add v12, v13 : u32 #[overflow = checked];
+    v7 = test.add v12, v13 : u32 #[overflow = checked];
     builtin.ret v7;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_if_switch_before.hir
@@ -1,0 +1,29 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 22 : u32;
+    v12, v13 = scf.index_switch v0 : u32, u32 
+    case 1 {
+    ^block1:
+        scf.yield v3, v4;
+    }
+    case 2 {
+    ^block4:
+        v5 = arith.constant 0 : u32;
+        v6 = arith.eq v0, v5 : i1;
+        v14, v15 = scf.if v6 : u32, u32 {
+        ^block2:
+            scf.yield v3, v4;
+        } else {
+        ^block3:
+            scf.yield v3, v4;
+        };
+        scf.yield v14, v15;
+    }
+    default {
+    ^block5:
+        scf.yield v3, v4;
+    };
+    v7 = arith.add v12, v13 : u32 #[overflow = checked];
+    builtin.ret v7;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_after.hir
@@ -1,7 +1,7 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 22 : u32;
-    v7 = arith.add v3, v4 : u32 #[overflow = checked];
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 22 : u32;
+    v7 = test.add v3, v4 : u32 #[overflow = checked];
     builtin.ret v7;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_after.hir
@@ -1,0 +1,7 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 22 : u32;
+    v7 = arith.add v3, v4 : u32 #[overflow = checked];
+    builtin.ret v7;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_before.hir
@@ -1,0 +1,29 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 22 : u32;
+    v5 = arith.constant 0 : u32;
+    v6 = arith.neq v0, v5 : i1;
+    v12, v13 = scf.if v6 : u32, u32 {
+    ^block1:
+        v14, v15 = scf.index_switch v0 : u32, u32 
+        case 1 {
+        ^block2:
+            scf.yield v3, v4;
+        }
+        case 2 {
+        ^block3:
+            scf.yield v3, v4;
+        }
+        default {
+        ^block4:
+            scf.yield v3, v4;
+        };
+        scf.yield v14, v15;
+    } else {
+    ^block5:
+        scf.yield v3, v4;
+    };
+    v7 = arith.add v12, v13 : u32 #[overflow = checked];
+    builtin.ret v7;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_all_switch_if_before.hir
@@ -1,9 +1,9 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 22 : u32;
-    v5 = arith.constant 0 : u32;
-    v6 = arith.neq v0, v5 : i1;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 22 : u32;
+    v5 = test.constant 0 : u32;
+    v6 = test.neq v0, v5 : i1;
     v12, v13 = scf.if v6 : u32, u32 {
     ^block1:
         v14, v15 = scf.index_switch v0 : u32, u32 
@@ -24,6 +24,6 @@ public builtin.function @test(v0: u32) -> u32 {
     ^block5:
         scf.yield v3, v4;
     };
-    v7 = arith.add v12, v13 : u32 #[overflow = checked];
+    v7 = test.add v12, v13 : u32 #[overflow = checked];
     builtin.ret v7;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_after.hir
@@ -1,0 +1,20 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 22 : u32;
+    v8, v9 = scf.index_switch v0 : u32, u32 
+    case 1 {
+    ^block1:
+        scf.yield v3, v4;
+    }
+    case 2 {
+    ^block2:
+        scf.yield v4, v3;
+    }
+    default {
+    ^block3:
+        scf.yield v3, v4;
+    };
+    v5 = arith.add v8, v9 : u32 #[overflow = checked];
+    builtin.ret v5;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_after.hir
@@ -1,7 +1,7 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 22 : u32;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 22 : u32;
     v8, v9 = scf.index_switch v0 : u32, u32 
     case 1 {
     ^block1:
@@ -15,6 +15,6 @@ public builtin.function @test(v0: u32) -> u32 {
     ^block3:
         scf.yield v3, v4;
     };
-    v5 = arith.add v8, v9 : u32 #[overflow = checked];
+    v5 = test.add v8, v9 : u32 #[overflow = checked];
     builtin.ret v5;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_before.hir
@@ -1,0 +1,20 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 22 : u32;
+    v8, v9 = scf.index_switch v0 : u32, u32 
+    case 1 {
+    ^block1:
+        scf.yield v3, v4;
+    }
+    case 2 {
+    ^block2:
+        scf.yield v4, v3;
+    }
+    default {
+    ^block3:
+        scf.yield v3, v4;
+    };
+    v5 = arith.add v8, v9 : u32 #[overflow = checked];
+    builtin.ret v5;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_different_pos_switch_before.hir
@@ -1,7 +1,7 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 22 : u32;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 22 : u32;
     v8, v9 = scf.index_switch v0 : u32, u32 
     case 1 {
     ^block1:
@@ -15,6 +15,6 @@ public builtin.function @test(v0: u32) -> u32 {
     ^block3:
         scf.yield v3, v4;
     };
-    v5 = arith.add v8, v9 : u32 #[overflow = checked];
+    v5 = test.add v8, v9 : u32 #[overflow = checked];
     builtin.ret v5;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_after.hir
@@ -1,14 +1,14 @@
 public builtin.function @test(v0: u32, v1: ptr<byte, u32>) -> u32 {
 ^block0(v0: u32, v1: ptr<byte, u32>):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 0 : u32;
-    v5 = arith.eq v0, v4 : i1;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 0 : u32;
+    v5 = test.eq v0, v4 : i1;
     scf.if v5{
     ^block1:
         scf.yield ;
     } else {
     ^block2:
-        hir.store v1, v3;
+        test.store v1, v3;
         scf.yield ;
     };
     builtin.ret v3;

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_after.hir
@@ -1,0 +1,15 @@
+public builtin.function @test(v0: u32, v1: ptr<byte, u32>) -> u32 {
+^block0(v0: u32, v1: ptr<byte, u32>):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 0 : u32;
+    v5 = arith.eq v0, v4 : i1;
+    scf.if v5{
+    ^block1:
+        scf.yield ;
+    } else {
+    ^block2:
+        hir.store v1, v3;
+        scf.yield ;
+    };
+    builtin.ret v3;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_before.hir
@@ -1,0 +1,15 @@
+public builtin.function @test(v0: u32, v1: ptr<byte, u32>) -> u32 {
+^block0(v0: u32, v1: ptr<byte, u32>):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 0 : u32;
+    v5 = arith.eq v0, v4 : i1;
+    v8 = scf.if v5 : u32 {
+    ^block1:
+        scf.yield v3;
+    } else {
+    ^block2:
+        hir.store v1, v3;
+        scf.yield v3;
+    };
+    builtin.ret v8;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_effects_if_before.hir
@@ -1,14 +1,14 @@
 public builtin.function @test(v0: u32, v1: ptr<byte, u32>) -> u32 {
 ^block0(v0: u32, v1: ptr<byte, u32>):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 0 : u32;
-    v5 = arith.eq v0, v4 : i1;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 0 : u32;
+    v5 = test.eq v0, v4 : i1;
     v8 = scf.if v5 : u32 {
     ^block1:
         scf.yield v3;
     } else {
     ^block2:
-        hir.store v1, v3;
+        test.store v1, v3;
         scf.yield v3;
     };
     builtin.ret v8;

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_after.hir
@@ -1,0 +1,36 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v15 = arith.constant 301 : u32;
+    v14 = arith.constant 300 : u32;
+    v13 = arith.constant 201 : u32;
+    v12 = arith.constant 200 : u32;
+    v11 = arith.constant 101 : u32;
+    v10 = arith.constant 100 : u32;
+    v17 = arith.constant 401 : u32;
+    v16 = arith.constant 400 : u32;
+    v7 = arith.constant 11 : u32;
+    v8 = arith.constant 22 : u32;
+    v9 = arith.constant 33 : u32;
+    v26, v28 = scf.index_switch v0 : u32, u32 
+    case 1 {
+    ^block1:
+        scf.yield v10, v11;
+    }
+    case 2 {
+    ^block2:
+        scf.yield v12, v13;
+    }
+    case 3 {
+    ^block3:
+        scf.yield v14, v15;
+    }
+    default {
+    ^block4:
+        scf.yield v16, v17;
+    };
+    v18 = arith.add v7, v8 : u32 #[overflow = checked];
+    v19 = arith.add v18, v26 : u32 #[overflow = checked];
+    v20 = arith.add v19, v9 : u32 #[overflow = checked];
+    v21 = arith.add v20, v28 : u32 #[overflow = checked];
+    builtin.ret v21;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_after.hir
@@ -1,16 +1,16 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v15 = arith.constant 301 : u32;
-    v14 = arith.constant 300 : u32;
-    v13 = arith.constant 201 : u32;
-    v12 = arith.constant 200 : u32;
-    v11 = arith.constant 101 : u32;
-    v10 = arith.constant 100 : u32;
-    v17 = arith.constant 401 : u32;
-    v16 = arith.constant 400 : u32;
-    v7 = arith.constant 11 : u32;
-    v8 = arith.constant 22 : u32;
-    v9 = arith.constant 33 : u32;
+    v15 = test.constant 301 : u32;
+    v14 = test.constant 300 : u32;
+    v13 = test.constant 201 : u32;
+    v12 = test.constant 200 : u32;
+    v11 = test.constant 101 : u32;
+    v10 = test.constant 100 : u32;
+    v17 = test.constant 401 : u32;
+    v16 = test.constant 400 : u32;
+    v7 = test.constant 11 : u32;
+    v8 = test.constant 22 : u32;
+    v9 = test.constant 33 : u32;
     v26, v28 = scf.index_switch v0 : u32, u32 
     case 1 {
     ^block1:
@@ -28,9 +28,9 @@ public builtin.function @test(v0: u32) -> u32 {
     ^block4:
         scf.yield v16, v17;
     };
-    v18 = arith.add v7, v8 : u32 #[overflow = checked];
-    v19 = arith.add v18, v26 : u32 #[overflow = checked];
-    v20 = arith.add v19, v9 : u32 #[overflow = checked];
-    v21 = arith.add v20, v28 : u32 #[overflow = checked];
+    v18 = test.add v7, v8 : u32 #[overflow = checked];
+    v19 = test.add v18, v26 : u32 #[overflow = checked];
+    v20 = test.add v19, v9 : u32 #[overflow = checked];
+    v21 = test.add v20, v28 : u32 #[overflow = checked];
     builtin.ret v21;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_before.hir
@@ -1,0 +1,36 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v7 = arith.constant 11 : u32;
+    v8 = arith.constant 22 : u32;
+    v9 = arith.constant 33 : u32;
+    v24, v25, v26, v27, v28 = scf.index_switch v0 : u32, u32, u32, u32, u32 
+    case 1 {
+    ^block1:
+        v10 = arith.constant 100 : u32;
+        v11 = arith.constant 101 : u32;
+        scf.yield v7, v8, v10, v9, v11;
+    }
+    case 2 {
+    ^block2:
+        v12 = arith.constant 200 : u32;
+        v13 = arith.constant 201 : u32;
+        scf.yield v7, v8, v12, v9, v13;
+    }
+    case 3 {
+    ^block3:
+        v14 = arith.constant 300 : u32;
+        v15 = arith.constant 301 : u32;
+        scf.yield v7, v8, v14, v9, v15;
+    }
+    default {
+    ^block4:
+        v16 = arith.constant 400 : u32;
+        v17 = arith.constant 401 : u32;
+        scf.yield v7, v8, v16, v9, v17;
+    };
+    v18 = arith.add v24, v25 : u32 #[overflow = checked];
+    v19 = arith.add v18, v26 : u32 #[overflow = checked];
+    v20 = arith.add v19, v27 : u32 #[overflow = checked];
+    v21 = arith.add v20, v28 : u32 #[overflow = checked];
+    builtin.ret v21;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_many_switch_before.hir
@@ -1,36 +1,36 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v7 = arith.constant 11 : u32;
-    v8 = arith.constant 22 : u32;
-    v9 = arith.constant 33 : u32;
+    v7 = test.constant 11 : u32;
+    v8 = test.constant 22 : u32;
+    v9 = test.constant 33 : u32;
     v24, v25, v26, v27, v28 = scf.index_switch v0 : u32, u32, u32, u32, u32 
     case 1 {
     ^block1:
-        v10 = arith.constant 100 : u32;
-        v11 = arith.constant 101 : u32;
+        v10 = test.constant 100 : u32;
+        v11 = test.constant 101 : u32;
         scf.yield v7, v8, v10, v9, v11;
     }
     case 2 {
     ^block2:
-        v12 = arith.constant 200 : u32;
-        v13 = arith.constant 201 : u32;
+        v12 = test.constant 200 : u32;
+        v13 = test.constant 201 : u32;
         scf.yield v7, v8, v12, v9, v13;
     }
     case 3 {
     ^block3:
-        v14 = arith.constant 300 : u32;
-        v15 = arith.constant 301 : u32;
+        v14 = test.constant 300 : u32;
+        v15 = test.constant 301 : u32;
         scf.yield v7, v8, v14, v9, v15;
     }
     default {
     ^block4:
-        v16 = arith.constant 400 : u32;
-        v17 = arith.constant 401 : u32;
+        v16 = test.constant 400 : u32;
+        v17 = test.constant 401 : u32;
         scf.yield v7, v8, v16, v9, v17;
     };
-    v18 = arith.add v24, v25 : u32 #[overflow = checked];
-    v19 = arith.add v18, v26 : u32 #[overflow = checked];
-    v20 = arith.add v19, v27 : u32 #[overflow = checked];
-    v21 = arith.add v20, v28 : u32 #[overflow = checked];
+    v18 = test.add v24, v25 : u32 #[overflow = checked];
+    v19 = test.add v18, v26 : u32 #[overflow = checked];
+    v20 = test.add v19, v27 : u32 #[overflow = checked];
+    v21 = test.add v20, v28 : u32 #[overflow = checked];
     builtin.ret v21;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_after.hir
@@ -1,0 +1,33 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v8 = arith.constant 44 : u32;
+    v7 = arith.constant 33 : u32;
+    v9 = arith.constant 55 : u32;
+    v6 = arith.constant 22 : u32;
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 0 : u32;
+    v5 = arith.eq v0, v4 : i1;
+    v17 = scf.if v5 : u32 {
+    ^block1:
+        scf.yield v6;
+    } else {
+    ^block2:
+        v19 = scf.index_switch v0 : u32 
+        case 1 {
+        ^block3:
+            scf.yield v7;
+        }
+        case 2 {
+        ^block4:
+            scf.yield v8;
+        }
+        default {
+        ^block5:
+            scf.yield v9;
+        };
+        scf.yield v19;
+    };
+    v10 = arith.add v3, v17 : u32 #[overflow = checked];
+    v11 = arith.add v10, v3 : u32 #[overflow = checked];
+    builtin.ret v11;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_after.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_after.hir
@@ -1,12 +1,12 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v8 = arith.constant 44 : u32;
-    v7 = arith.constant 33 : u32;
-    v9 = arith.constant 55 : u32;
-    v6 = arith.constant 22 : u32;
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 0 : u32;
-    v5 = arith.eq v0, v4 : i1;
+    v8 = test.constant 44 : u32;
+    v7 = test.constant 33 : u32;
+    v9 = test.constant 55 : u32;
+    v6 = test.constant 22 : u32;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 0 : u32;
+    v5 = test.eq v0, v4 : i1;
     v17 = scf.if v5 : u32 {
     ^block1:
         scf.yield v6;
@@ -27,7 +27,7 @@ public builtin.function @test(v0: u32) -> u32 {
         };
         scf.yield v19;
     };
-    v10 = arith.add v3, v17 : u32 #[overflow = checked];
-    v11 = arith.add v10, v3 : u32 #[overflow = checked];
+    v10 = test.add v3, v17 : u32 #[overflow = checked];
+    v11 = test.add v10, v3 : u32 #[overflow = checked];
     builtin.ret v11;
 };

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_before.hir
@@ -1,0 +1,33 @@
+public builtin.function @test(v0: u32) -> u32 {
+^block0(v0: u32):
+    v3 = arith.constant 11 : u32;
+    v4 = arith.constant 0 : u32;
+    v5 = arith.eq v0, v4 : i1;
+    v16, v17 = scf.if v5 : u32, u32 {
+    ^block1:
+        v6 = arith.constant 22 : u32;
+        scf.yield v3, v6;
+    } else {
+    ^block2:
+        v18, v19 = scf.index_switch v0 : u32, u32 
+        case 1 {
+        ^block3:
+            v7 = arith.constant 33 : u32;
+            scf.yield v3, v7;
+        }
+        case 2 {
+        ^block4:
+            v8 = arith.constant 44 : u32;
+            scf.yield v3, v8;
+        }
+        default {
+        ^block5:
+            v9 = arith.constant 55 : u32;
+            scf.yield v3, v9;
+        };
+        scf.yield v18, v19;
+    };
+    v10 = arith.add v16, v17 : u32 #[overflow = checked];
+    v11 = arith.add v10, v3 : u32 #[overflow = checked];
+    builtin.ret v11;
+};

--- a/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_before.hir
+++ b/dialects/scf/src/canonicalization/expected/fold_redundant_yields_subset_if_switch_before.hir
@@ -1,33 +1,33 @@
 public builtin.function @test(v0: u32) -> u32 {
 ^block0(v0: u32):
-    v3 = arith.constant 11 : u32;
-    v4 = arith.constant 0 : u32;
-    v5 = arith.eq v0, v4 : i1;
+    v3 = test.constant 11 : u32;
+    v4 = test.constant 0 : u32;
+    v5 = test.eq v0, v4 : i1;
     v16, v17 = scf.if v5 : u32, u32 {
     ^block1:
-        v6 = arith.constant 22 : u32;
+        v6 = test.constant 22 : u32;
         scf.yield v3, v6;
     } else {
     ^block2:
         v18, v19 = scf.index_switch v0 : u32, u32 
         case 1 {
         ^block3:
-            v7 = arith.constant 33 : u32;
+            v7 = test.constant 33 : u32;
             scf.yield v3, v7;
         }
         case 2 {
         ^block4:
-            v8 = arith.constant 44 : u32;
+            v8 = test.constant 44 : u32;
             scf.yield v3, v8;
         }
         default {
         ^block5:
-            v9 = arith.constant 55 : u32;
+            v9 = test.constant 55 : u32;
             scf.yield v3, v9;
         };
         scf.yield v18, v19;
     };
-    v10 = arith.add v16, v17 : u32 #[overflow = checked];
-    v11 = arith.add v10, v3 : u32 #[overflow = checked];
+    v10 = test.add v16, v17 : u32 #[overflow = checked];
+    v11 = test.add v10, v3 : u32 #[overflow = checked];
     builtin.ret v11;
 };

--- a/dialects/scf/src/canonicalization/fold_redundant_yields.rs
+++ b/dialects/scf/src/canonicalization/fold_redundant_yields.rs
@@ -140,7 +140,7 @@ impl RewritePattern for FoldRedundantYields {
                 let mut new_opands = SmallVec::<[ValueRef; 4]>::default();
 
                 // Make a copy of the old operands, except for the redundant value, except in the
-                // case where they're all redudant where we need no operands.
+                // case where they're all redundant where we need no operands.
                 if !all_results_are_redundant {
                     for old_opand in term_op.borrow().operands().iter() {
                         if !redundant_result_positions.contains(&old_opand.index()) {

--- a/dialects/scf/src/canonicalization/fold_redundant_yields.rs
+++ b/dialects/scf/src/canonicalization/fold_redundant_yields.rs
@@ -68,6 +68,13 @@ impl RewritePattern for FoldRedundantYields {
                 "All region block terminators must impl RegionBranchTerminatorOpInterface.",
             );
 
+            // For now we only support regions with a simple `yield` terminator.  This may change
+            // in the future if/when we support other RegionBranchOps (e.g., `while`).
+            let term_op_name = term_op.as_operation().name();
+            if term_op_name.dialect() != "scf" || term_op_name.name() != "yield" {
+                return Ok(false);
+            }
+
             // Save the terminator and each of its opands paired with their indices.
             term_ops.push(term_op_ref);
             region_yields.push(

--- a/dialects/scf/src/canonicalization/fold_redundant_yields.rs
+++ b/dialects/scf/src/canonicalization/fold_redundant_yields.rs
@@ -170,14 +170,13 @@ impl RewritePattern for FoldRedundantYields {
 mod tests {
     use alloc::{boxed::Box, format, rc::Rc, sync::Arc, vec::Vec};
 
-    use builtin::{BuiltinOpBuilder, FunctionBuilder};
-    use midenc_dialect_arith::ArithOpBuilder;
     use midenc_dialect_cf::{ControlFlowOpBuilder, SwitchCase};
-    use midenc_dialect_hir::HirOpBuilder;
     use midenc_expect_test::expect_file;
     use midenc_hir::{
-        dialects::builtin,
-        pass,
+        dialects::{
+            builtin::{self, BuiltinOpBuilder, FunctionBuilder},
+            test::TestOpBuilder,
+        },
         pass::{Pass, PassExecutionState},
         patterns::{
             FrozenRewritePatternSet, GreedyRewriteConfig, RewritePattern, RewritePatternSet,
@@ -316,14 +315,14 @@ mod tests {
         let if_sum_rhs = builder.append_block_param(if_final, Type::U32, span);
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
-        let redundant_val = builder.u32(11, span);
+        let redundant_val = builder.u32(11, span)?;
 
-        let zero = builder.u32(0, span);
+        let zero = builder.u32(0, span)?;
         let is_zero = builder.eq(input, zero, span)?;
         builder.cond_br(is_zero, if_then, [], if_else, [], span)?;
 
         builder.switch_to_block(if_then);
-        let then_non_redundant_val = builder.u32(22, span);
+        let then_non_redundant_val = builder.u32(22, span)?;
         builder.br(if_final, [redundant_val, then_non_redundant_val], span)?;
 
         let switch_on_one_case = SwitchCase {
@@ -348,15 +347,15 @@ mod tests {
         )?;
 
         builder.switch_to_block(switch_on_one_block);
-        let switch_on_one_non_redundant_val = builder.u32(33, span);
+        let switch_on_one_non_redundant_val = builder.u32(33, span)?;
         builder.br(if_final, [redundant_val, switch_on_one_non_redundant_val], span)?;
 
         builder.switch_to_block(switch_on_two_block);
-        let switch_on_two_non_redundant_val = builder.u32(44, span);
+        let switch_on_two_non_redundant_val = builder.u32(44, span)?;
         builder.br(if_final, [redundant_val, switch_on_two_non_redundant_val], span)?;
 
         builder.switch_to_block(switch_default_block);
-        let switch_default_non_redundant_val = builder.u32(55, span);
+        let switch_default_non_redundant_val = builder.u32(55, span)?;
         builder.br(if_final, [redundant_val, switch_default_non_redundant_val], span)?;
 
         // Add all the results together along with the redundant value to give them all users.
@@ -399,8 +398,8 @@ mod tests {
         let sum_rhs = builder.append_block_param(switch_final_block, Type::U32, span);
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
-        let redundant_val0 = builder.u32(11, span);
-        let redundant_val1 = builder.u32(22, span);
+        let redundant_val0 = builder.u32(11, span)?;
+        let redundant_val1 = builder.u32(22, span)?;
 
         let switch_on_one_case = SwitchCase {
             value: 1,
@@ -426,7 +425,7 @@ mod tests {
         builder.br(switch_final_block, [redundant_val0, redundant_val1], span)?;
 
         builder.switch_to_block(switch_on_two_block);
-        let zero = builder.u32(0, span);
+        let zero = builder.u32(0, span)?;
         let is_zero = builder.eq(input, zero, span)?;
         builder.cond_br(is_zero, if_then_block, [], if_else_block, [], span)?;
 
@@ -478,10 +477,10 @@ mod tests {
         let sum_rhs = builder.append_block_param(if_final_block, Type::U32, span);
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
-        let redundant_val0 = builder.u32(11, span);
-        let redundant_val1 = builder.u32(22, span);
+        let redundant_val0 = builder.u32(11, span)?;
+        let redundant_val1 = builder.u32(22, span)?;
 
-        let zero = builder.u32(0, span);
+        let zero = builder.u32(0, span)?;
         let is_not_zero = builder.neq(input, zero, span)?;
         builder.cond_br(is_not_zero, if_then_block, [], if_else_block, [], span)?;
 
@@ -562,9 +561,9 @@ mod tests {
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
 
-        let redundant_val11 = builder.u32(11, span);
-        let redundant_val22 = builder.u32(22, span);
-        let redundant_val33 = builder.u32(33, span);
+        let redundant_val11 = builder.u32(11, span)?;
+        let redundant_val22 = builder.u32(22, span)?;
+        let redundant_val33 = builder.u32(33, span)?;
 
         let switch_on_one_case = SwitchCase {
             value: 1,
@@ -593,8 +592,8 @@ mod tests {
         )?;
 
         builder.switch_to_block(switch_on_one_block);
-        let switch_on_one_non_redundant_val0 = builder.u32(100, span);
-        let switch_on_one_non_redundant_val1 = builder.u32(101, span);
+        let switch_on_one_non_redundant_val0 = builder.u32(100, span)?;
+        let switch_on_one_non_redundant_val1 = builder.u32(101, span)?;
         builder.br(
             switch_final_block,
             [
@@ -608,8 +607,8 @@ mod tests {
         )?;
 
         builder.switch_to_block(switch_on_two_block);
-        let switch_on_two_non_redundant_val0 = builder.u32(200, span);
-        let switch_on_two_non_redundant_val1 = builder.u32(201, span);
+        let switch_on_two_non_redundant_val0 = builder.u32(200, span)?;
+        let switch_on_two_non_redundant_val1 = builder.u32(201, span)?;
         builder.br(
             switch_final_block,
             [
@@ -623,8 +622,8 @@ mod tests {
         )?;
 
         builder.switch_to_block(switch_on_three_block);
-        let switch_on_three_non_redundant_val0 = builder.u32(300, span);
-        let switch_on_three_non_redundant_val1 = builder.u32(301, span);
+        let switch_on_three_non_redundant_val0 = builder.u32(300, span)?;
+        let switch_on_three_non_redundant_val1 = builder.u32(301, span)?;
         builder.br(
             switch_final_block,
             [
@@ -638,8 +637,8 @@ mod tests {
         )?;
 
         builder.switch_to_block(switch_on_default_block);
-        let switch_on_default_non_redundant_val0 = builder.u32(400, span);
-        let switch_on_default_non_redundant_val1 = builder.u32(401, span);
+        let switch_on_default_non_redundant_val0 = builder.u32(400, span)?;
+        let switch_on_default_non_redundant_val1 = builder.u32(401, span)?;
         builder.br(
             switch_final_block,
             [
@@ -696,8 +695,8 @@ mod tests {
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
 
-        let redundant_val11 = builder.u32(11, span);
-        let redundant_val22 = builder.u32(22, span);
+        let redundant_val11 = builder.u32(11, span)?;
+        let redundant_val22 = builder.u32(22, span)?;
 
         let switch_on_one_case = SwitchCase {
             value: 1,
@@ -772,9 +771,9 @@ mod tests {
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
 
-        let redundant_val11 = builder.u32(11, span);
-        let redundant_val22 = builder.u32(22, span);
-        let redundant_val33 = builder.u32(33, span);
+        let redundant_val11 = builder.u32(11, span)?;
+        let redundant_val22 = builder.u32(22, span)?;
+        let redundant_val33 = builder.u32(33, span)?;
 
         let switch_on_one_case = SwitchCase {
             value: 1,
@@ -824,7 +823,7 @@ mod tests {
         )?;
 
         builder.switch_to_block(switch_on_default_block);
-        let non_redundant_val44 = builder.u32(44, span);
+        let non_redundant_val44 = builder.u32(44, span)?;
         builder.br(
             switch_final_block,
             [redundant_val11, non_redundant_val44, redundant_val33],
@@ -877,9 +876,9 @@ mod tests {
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
         let input_ptr = builder.current_block().borrow().arguments()[1].upcast();
-        let redundant_val = builder.u32(11, span);
+        let redundant_val = builder.u32(11, span)?;
 
-        let zero = builder.u32(0, span);
+        let zero = builder.u32(0, span)?;
         let is_zero = builder.eq(input, zero, span)?;
         builder.cond_br(is_zero, if_then, [], if_else, [], span)?;
 
@@ -920,10 +919,10 @@ mod tests {
         let mut builder = FunctionBuilder::new(function, &mut builder);
 
         let input = builder.current_block().borrow().arguments()[0].upcast();
-        let redundant_val = builder.u32(11, span);
+        let redundant_val = builder.u32(11, span)?;
 
         // Create a while op, pass zero.
-        let zero = builder.u32(0, span);
+        let zero = builder.u32(0, span)?;
         let while_op = builder.r#while([zero], &[Type::U32], span)?;
         let while_before_block = while_op.borrow().before().entry().as_block_ref();
         let while_after_block = while_op.borrow().after().entry().as_block_ref();

--- a/dialects/scf/src/canonicalization/fold_redundant_yields.rs
+++ b/dialects/scf/src/canonicalization/fold_redundant_yields.rs
@@ -70,8 +70,7 @@ impl RewritePattern for FoldRedundantYields {
 
             // For now we only support regions with a simple `yield` terminator.  This may change
             // in the future if/when we support other RegionBranchOps (e.g., `while`).
-            let term_op_name = term_op.as_operation().name();
-            if term_op_name.dialect() != "scf" || term_op_name.name() != "yield" {
+            if !term_op.as_operation().is::<Yield>() {
                 return Ok(false);
             }
 

--- a/dialects/scf/src/canonicalization/fold_redundant_yields.rs
+++ b/dialects/scf/src/canonicalization/fold_redundant_yields.rs
@@ -1,0 +1,959 @@
+use alloc::rc::Rc;
+use core::{any::TypeId, ops::Index};
+
+use midenc_hir::{
+    patterns::{Pattern, PatternBenefit, PatternInfo, PatternKind, RewritePattern},
+    *,
+};
+
+use crate::*;
+
+/// Lift common yield results from their regions to their predecessors.
+pub struct FoldRedundantYields {
+    info: PatternInfo,
+}
+
+impl FoldRedundantYields {
+    pub fn new(context: Rc<Context>) -> Self {
+        Self {
+            info: PatternInfo::new(
+                context,
+                "fold-redundant-yields",
+                PatternKind::Trait(TypeId::of::<dyn RegionBranchOpInterface>()),
+                PatternBenefit::MAX,
+            ),
+        }
+    }
+}
+
+impl Pattern for FoldRedundantYields {
+    fn info(&self) -> &PatternInfo {
+        &self.info
+    }
+}
+
+impl RewritePattern for FoldRedundantYields {
+    fn match_and_rewrite(
+        &self,
+        mut op_ref: OperationRef,
+        rewriter: &mut dyn Rewriter,
+    ) -> Result<bool, Report> {
+        let mut op = op_ref.borrow_mut();
+
+        let Some(br_op) = op.as_trait::<dyn RegionBranchOpInterface>() else {
+            return Ok(false);
+        };
+
+        // For each successor gather its terminator and the terminator operands.
+        let mut term_ops: SmallVec<[_; 4]> = SmallVec::new();
+        let mut region_yields: SmallVec<[_; 4]> = SmallVec::new();
+
+        for succ_region in br_op.get_successor_regions(RegionBranchPoint::Parent) {
+            let Some(region_ref) = succ_region.successor() else {
+                return Ok(false);
+            };
+
+            // Several assertions follow: an SCF region always has a single block, that block must
+            // have a terminator which then implements RegionBranchTerminatorOpInterface.
+            let region = region_ref.borrow();
+            assert!(region.has_one_block());
+
+            let block = region.entry();
+            let term_op_ref =
+                block.terminator().expect("All region blocks must have a terminator.");
+
+            // Got the terminator.
+            let term_op = term_op_ref.borrow();
+            let term_op = term_op.as_trait::<dyn RegionBranchTerminatorOpInterface>().expect(
+                "All region block terminators must impl RegionBranchTerminatorOpInterface.",
+            );
+
+            // Save the terminator and each of its opands paired with their indices.
+            term_ops.push(term_op_ref);
+            region_yields.push(
+                term_op
+                    .get_successor_operands(RegionBranchPoint::Parent)
+                    .forwarded()
+                    .iter()
+                    .map(|opand_ref| {
+                        let opand = opand_ref.borrow();
+                        (opand.index(), opand.as_value_ref())
+                    })
+                    .collect::<adt::SmallSet<_, 4>>(),
+            );
+        }
+
+        if region_yields.len() < 2 {
+            return Ok(false);
+        }
+
+        // Fold the yield opand sets down via intersection to a final set which will contain the
+        // redundant values.
+        let redundant_yield_vals = region_yields
+            .into_iter()
+            .reduce(|acc, region_yield_vals| acc.intersection(&region_yield_vals))
+            .expect("Have already checked region_yields is non-empty.");
+
+        if redundant_yield_vals.is_empty() {
+            // No redundant values found.
+            return Ok(false);
+        }
+
+        // Save a copy of the redundant result positions.
+        let mut redundant_result_positions =
+            redundant_yield_vals.iter().map(|(pos, _)| *pos).collect::<SmallVec<[_; 4]>>();
+
+        let all_results_are_redundant = redundant_yield_vals.len() == op.num_results();
+
+        if all_results_are_redundant && op.is_memory_effect_free() {
+            // The entire operation is actually redundant; just remove it.  Make sure the yield
+            // vals are sorted first.
+            let mut sorted_vals = redundant_yield_vals.into_vec();
+            sorted_vals.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
+            // Wrap each of the values in Some.
+            let some_vals =
+                sorted_vals.into_iter().map(|(_, val)| Some(val)).collect::<SmallVec<[_; 4]>>();
+
+            // Replace the operation.
+            drop(op);
+            rewriter.replace_op_with_values(op_ref, &some_vals);
+        } else {
+            // Replace all uses of the redundant results.
+            for (redundant_opand_pos, redundant_yield_val) in redundant_yield_vals {
+                let result_val_ref =
+                    op.results().index(redundant_opand_pos).borrow().as_value_ref();
+                if result_val_ref.borrow().is_used() {
+                    rewriter.replace_all_uses_of_value_with(result_val_ref, redundant_yield_val);
+                }
+            }
+
+            // Next remove the redundant results.  Iterate for each position in reverse to avoid
+            // invalidating offsets as we go.
+            redundant_result_positions.sort_unstable_by(|a, b| b.cmp(a));
+            for idx in &redundant_result_positions {
+                op.results_mut().group_mut(0).erase(*idx);
+            }
+
+            // And remove the redundant terminator operands.
+            for mut term_op in term_ops {
+                let mut new_opands = SmallVec::<[ValueRef; 4]>::default();
+
+                // Make a copy of the old operands, except for the redundant value, except in the
+                // case where they're all redudant where we need no operands.
+                if !all_results_are_redundant {
+                    for old_opand in term_op.borrow().operands().iter() {
+                        if !redundant_result_positions.contains(&old_opand.index()) {
+                            new_opands.push(old_opand.borrow().as_value_ref());
+                        }
+                    }
+                }
+
+                // Update the terminator with the new operands.
+                let _guard = rewriter.modify_op_in_place(term_op);
+                let mut term_op_mut = term_op.borrow_mut();
+                term_op_mut.set_operands(new_opands);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, format, rc::Rc, sync::Arc, vec::Vec};
+
+    use builtin::{BuiltinOpBuilder, FunctionBuilder};
+    use midenc_dialect_arith::ArithOpBuilder;
+    use midenc_dialect_cf::{ControlFlowOpBuilder, SwitchCase};
+    use midenc_dialect_hir::HirOpBuilder;
+    use midenc_expect_test::expect_file;
+    use midenc_hir::{
+        dialects::builtin,
+        pass,
+        pass::{Pass, PassExecutionState},
+        patterns::{
+            FrozenRewritePatternSet, GreedyRewriteConfig, RewritePattern, RewritePatternSet,
+        },
+        AbiParam, BuilderExt, Context, Ident, OpBuilder, Report, Signature, SourceSpan, Type,
+    };
+
+    use super::*;
+
+    struct SingleCanonicalizerPass {
+        rewrites: Rc<FrozenRewritePatternSet>,
+        should_modify: bool,
+    }
+
+    impl SingleCanonicalizerPass {
+        fn new(
+            context: Rc<Context>,
+            pattern: Box<dyn RewritePattern>,
+            should_modify: bool,
+        ) -> Self {
+            let pattern_set = RewritePatternSet::from_iter(context, [pattern]);
+            let rewrites = Rc::new(FrozenRewritePatternSet::new(pattern_set));
+
+            Self {
+                rewrites,
+                should_modify,
+            }
+        }
+    }
+
+    impl Pass for SingleCanonicalizerPass {
+        type Target = Operation;
+
+        fn name(&self) -> &'static str {
+            "test-single-rewriter"
+        }
+
+        fn can_schedule_on(&self, _name: &OperationName) -> bool {
+            true
+        }
+
+        fn run_on_operation(
+            &mut self,
+            op: EntityMut<'_, Self::Target>,
+            state: &mut PassExecutionState,
+        ) -> Result<(), Report> {
+            let op_ref = op.as_operation_ref();
+            drop(op);
+
+            let converged = patterns::apply_patterns_and_fold_greedily(
+                op_ref,
+                self.rewrites.clone(),
+                GreedyRewriteConfig::default(),
+            );
+
+            let changed = match converged {
+                Ok(b) => b,
+                Err(e) => {
+                    panic!("Pass returned error: {e}");
+                }
+            };
+
+            match (changed, self.should_modify) {
+                (true, false) => panic!("Pass modified input unexpectedly."),
+                (false, true) => panic!("Pass did not modify input."),
+                _ => {}
+            }
+
+            state.set_post_pass_status(changed.into());
+
+            Ok(())
+        }
+    }
+
+    fn run_single_canonicalizer(
+        context: Rc<Context>,
+        operation: OperationRef,
+        name: &'static str,
+        should_modify: bool,
+    ) -> Result<(), Report> {
+        // UNCOMMENT TO DUMP (SHOW DIFF OF) CF INPUT.
+        // let input = format!("{}", &operation.borrow());
+        // expect_file!["non-existentent"].assert_eq(&input);
+
+        // Run the CF->SCF pass first, then the canonicalisation pass.  Need to register the SCF
+        // dialect to make sure the patterns are registered.
+        let _scf_dialect = context.get_or_register_dialect::<ScfDialect>();
+        let mut pm =
+            pass::PassManager::on::<builtin::Function>(context.clone(), pass::Nesting::Implicit);
+        pm.add_pass(Box::new(transforms::LiftControlFlowToSCF));
+        pm.run(operation)?;
+
+        // Confirm the CF->SCF transformed IR is correct.
+        let input = format!("{}", operation.borrow());
+        let before_file_path = format!("expected/{name}_before.hir");
+        expect_file![before_file_path.as_str()].assert_eq(&input);
+
+        pm.add_pass(Box::new(SingleCanonicalizerPass::new(
+            context.clone(),
+            Box::new(FoldRedundantYields::new(context.clone())),
+            should_modify,
+        )));
+        pm.run(operation)?;
+
+        // Confirm the canonicalised IR is correct.
+        let output = format!("{}", operation.borrow());
+        let after_file_path = format!("expected/{name}_after.hir");
+        expect_file![after_file_path.as_str()].assert_eq(&output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn fold_redundant_yields_subset_if_switch() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let if_then = builder.create_block();
+        let if_else = builder.create_block();
+        let switch_on_one_block = builder.create_block();
+        let switch_on_two_block = builder.create_block();
+        let switch_default_block = builder.create_block();
+        let if_final = builder.create_block();
+
+        let if_sum_lhs = builder.append_block_param(if_final, Type::U32, span);
+        let if_sum_rhs = builder.append_block_param(if_final, Type::U32, span);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+        let redundant_val = builder.u32(11, span);
+
+        let zero = builder.u32(0, span);
+        let is_zero = builder.eq(input, zero, span)?;
+        builder.cond_br(is_zero, if_then, [], if_else, [], span)?;
+
+        builder.switch_to_block(if_then);
+        let then_non_redundant_val = builder.u32(22, span);
+        builder.br(if_final, [redundant_val, then_non_redundant_val], span)?;
+
+        let switch_on_one_case = SwitchCase {
+            value: 1,
+            successor: switch_on_one_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_two_case = SwitchCase {
+            value: 2,
+            successor: switch_on_two_block,
+            arguments: Vec::default(),
+        };
+
+        builder.switch_to_block(if_else);
+        builder.switch(
+            input,
+            [switch_on_one_case, switch_on_two_case],
+            switch_default_block,
+            Vec::default(),
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_one_block);
+        let switch_on_one_non_redundant_val = builder.u32(33, span);
+        builder.br(if_final, [redundant_val, switch_on_one_non_redundant_val], span)?;
+
+        builder.switch_to_block(switch_on_two_block);
+        let switch_on_two_non_redundant_val = builder.u32(44, span);
+        builder.br(if_final, [redundant_val, switch_on_two_non_redundant_val], span)?;
+
+        builder.switch_to_block(switch_default_block);
+        let switch_default_non_redundant_val = builder.u32(55, span);
+        builder.br(if_final, [redundant_val, switch_default_non_redundant_val], span)?;
+
+        // Add all the results together along with the redundant value to give them all users.
+        builder.switch_to_block(if_final);
+        let if_sum0 = builder.add(if_sum_lhs, if_sum_rhs, span)?;
+        let if_sum1 = builder.add(if_sum0, redundant_val, span)?;
+        builder.ret(Some(if_sum1), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_subset_if_switch",
+            true,
+        )
+    }
+
+    #[test]
+    fn fold_redundant_yields_all_if_switch() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let switch_on_one_block = builder.create_block();
+        let if_then_block = builder.create_block();
+        let if_else_block = builder.create_block();
+        let switch_on_two_block = builder.create_block();
+        let switch_default_block = builder.create_block();
+        let switch_final_block = builder.create_block();
+
+        let sum_lhs = builder.append_block_param(switch_final_block, Type::U32, span);
+        let sum_rhs = builder.append_block_param(switch_final_block, Type::U32, span);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+        let redundant_val0 = builder.u32(11, span);
+        let redundant_val1 = builder.u32(22, span);
+
+        let switch_on_one_case = SwitchCase {
+            value: 1,
+            successor: switch_on_one_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_two_case = SwitchCase {
+            value: 2,
+            successor: switch_on_two_block,
+            arguments: Vec::default(),
+        };
+
+        builder.switch(
+            input,
+            [switch_on_one_case, switch_on_two_case],
+            switch_default_block,
+            Vec::default(),
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_one_block);
+        builder.br(switch_final_block, [redundant_val0, redundant_val1], span)?;
+
+        builder.switch_to_block(switch_on_two_block);
+        let zero = builder.u32(0, span);
+        let is_zero = builder.eq(input, zero, span)?;
+        builder.cond_br(is_zero, if_then_block, [], if_else_block, [], span)?;
+
+        builder.switch_to_block(if_then_block);
+        builder.br(switch_final_block, [redundant_val0, redundant_val1], span)?;
+
+        builder.switch_to_block(if_else_block);
+        builder.br(switch_final_block, [redundant_val0, redundant_val1], span)?;
+
+        builder.switch_to_block(switch_default_block);
+        builder.br(switch_final_block, [redundant_val0, redundant_val1], span)?;
+
+        // Add all the results together along with the redundant value to give them all users.
+        builder.switch_to_block(switch_final_block);
+        let sum = builder.add(sum_lhs, sum_rhs, span)?;
+        builder.ret(Some(sum), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_all_if_switch",
+            true,
+        )
+    }
+
+    #[test]
+    fn fold_redundant_yields_all_switch_if() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let if_then_block = builder.create_block();
+        let switch_on_one_block = builder.create_block();
+        let switch_on_two_block = builder.create_block();
+        let switch_default_block = builder.create_block();
+        let if_else_block = builder.create_block();
+        let if_final_block = builder.create_block();
+
+        let sum_lhs = builder.append_block_param(if_final_block, Type::U32, span);
+        let sum_rhs = builder.append_block_param(if_final_block, Type::U32, span);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+        let redundant_val0 = builder.u32(11, span);
+        let redundant_val1 = builder.u32(22, span);
+
+        let zero = builder.u32(0, span);
+        let is_not_zero = builder.neq(input, zero, span)?;
+        builder.cond_br(is_not_zero, if_then_block, [], if_else_block, [], span)?;
+
+        let switch_on_one_case = SwitchCase {
+            value: 1,
+            successor: switch_on_one_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_two_case = SwitchCase {
+            value: 2,
+            successor: switch_on_two_block,
+            arguments: Vec::default(),
+        };
+
+        builder.switch_to_block(if_then_block);
+        builder.switch(
+            input,
+            [switch_on_one_case, switch_on_two_case],
+            switch_default_block,
+            Vec::default(),
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_one_block);
+        builder.br(if_final_block, [redundant_val0, redundant_val1], span)?;
+
+        builder.switch_to_block(switch_on_two_block);
+        builder.br(if_final_block, [redundant_val0, redundant_val1], span)?;
+
+        builder.switch_to_block(switch_default_block);
+        builder.br(if_final_block, [redundant_val0, redundant_val1], span)?;
+
+        builder.switch_to_block(if_else_block);
+        builder.br(if_final_block, [redundant_val0, redundant_val1], span)?;
+
+        builder.switch_to_block(if_final_block);
+        let sum = builder.add(sum_lhs, sum_rhs, span)?;
+        builder.ret(Some(sum), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_all_switch_if",
+            true,
+        )
+    }
+
+    #[test]
+    fn fold_redundant_yields_many_switch() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let switch_on_one_block = builder.create_block();
+        let switch_on_two_block = builder.create_block();
+        let switch_on_three_block = builder.create_block();
+        let switch_on_default_block = builder.create_block();
+        let switch_final_block = builder.create_block();
+        let exit_block = builder.create_block();
+
+        let final_arg0 = builder.append_block_param(switch_final_block, Type::U32, span);
+        let final_arg1 = builder.append_block_param(switch_final_block, Type::U32, span);
+        let final_arg2 = builder.append_block_param(switch_final_block, Type::U32, span);
+        let final_arg3 = builder.append_block_param(switch_final_block, Type::U32, span);
+        let final_arg4 = builder.append_block_param(switch_final_block, Type::U32, span);
+
+        let ret_val = builder.append_block_param(exit_block, Type::U32, span);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+
+        let redundant_val11 = builder.u32(11, span);
+        let redundant_val22 = builder.u32(22, span);
+        let redundant_val33 = builder.u32(33, span);
+
+        let switch_on_one_case = SwitchCase {
+            value: 1,
+            successor: switch_on_one_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_two_case = SwitchCase {
+            value: 2,
+            successor: switch_on_two_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_three_case = SwitchCase {
+            value: 3,
+            successor: switch_on_three_block,
+            arguments: Vec::default(),
+        };
+
+        builder.switch(
+            input,
+            [switch_on_one_case, switch_on_two_case, switch_on_three_case],
+            switch_on_default_block,
+            Vec::default(),
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_one_block);
+        let switch_on_one_non_redundant_val0 = builder.u32(100, span);
+        let switch_on_one_non_redundant_val1 = builder.u32(101, span);
+        builder.br(
+            switch_final_block,
+            [
+                redundant_val11,
+                redundant_val22,
+                switch_on_one_non_redundant_val0,
+                redundant_val33,
+                switch_on_one_non_redundant_val1,
+            ],
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_two_block);
+        let switch_on_two_non_redundant_val0 = builder.u32(200, span);
+        let switch_on_two_non_redundant_val1 = builder.u32(201, span);
+        builder.br(
+            switch_final_block,
+            [
+                redundant_val11,
+                redundant_val22,
+                switch_on_two_non_redundant_val0,
+                redundant_val33,
+                switch_on_two_non_redundant_val1,
+            ],
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_three_block);
+        let switch_on_three_non_redundant_val0 = builder.u32(300, span);
+        let switch_on_three_non_redundant_val1 = builder.u32(301, span);
+        builder.br(
+            switch_final_block,
+            [
+                redundant_val11,
+                redundant_val22,
+                switch_on_three_non_redundant_val0,
+                redundant_val33,
+                switch_on_three_non_redundant_val1,
+            ],
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_default_block);
+        let switch_on_default_non_redundant_val0 = builder.u32(400, span);
+        let switch_on_default_non_redundant_val1 = builder.u32(401, span);
+        builder.br(
+            switch_final_block,
+            [
+                redundant_val11,
+                redundant_val22,
+                switch_on_default_non_redundant_val0,
+                redundant_val33,
+                switch_on_default_non_redundant_val1,
+            ],
+            span,
+        )?;
+
+        // Add all the results together.
+        builder.switch_to_block(switch_final_block);
+        let sum0 = builder.add(final_arg0, final_arg1, span)?;
+        let sum1 = builder.add(sum0, final_arg2, span)?;
+        let sum2 = builder.add(sum1, final_arg3, span)?;
+        let sum3 = builder.add(sum2, final_arg4, span)?;
+        builder.br(exit_block, [sum3], span)?;
+
+        builder.switch_to_block(exit_block);
+        builder.ret(Some(ret_val), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_many_switch",
+            true,
+        )
+    }
+
+    #[test]
+    fn fold_redundant_yields_different_pos_switch() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let switch_on_one_block = builder.create_block();
+        let switch_on_two_block = builder.create_block();
+        let switch_on_default_block = builder.create_block();
+        let switch_final_block = builder.create_block();
+
+        let final_arg0 = builder.append_block_param(switch_final_block, Type::U32, span);
+        let final_arg1 = builder.append_block_param(switch_final_block, Type::U32, span);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+
+        let redundant_val11 = builder.u32(11, span);
+        let redundant_val22 = builder.u32(22, span);
+
+        let switch_on_one_case = SwitchCase {
+            value: 1,
+            successor: switch_on_one_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_two_case = SwitchCase {
+            value: 2,
+            successor: switch_on_two_block,
+            arguments: Vec::default(),
+        };
+
+        builder.switch(
+            input,
+            [switch_on_one_case, switch_on_two_case],
+            switch_on_default_block,
+            Vec::default(),
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_one_block);
+        builder.br(switch_final_block, [redundant_val11, redundant_val22], span)?;
+
+        // 'yielding' args in reverse order.
+        builder.switch_to_block(switch_on_two_block);
+        builder.br(switch_final_block, [redundant_val22, redundant_val11], span)?;
+
+        builder.switch_to_block(switch_on_default_block);
+        builder.br(switch_final_block, [redundant_val11, redundant_val22], span)?;
+
+        // Add all the results together.
+        builder.switch_to_block(switch_final_block);
+        let sum = builder.add(final_arg0, final_arg1, span)?;
+        builder.ret(Some(sum), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_different_pos_switch",
+            false, // Should not modify input.
+        )
+    }
+
+    #[test]
+    fn fold_redundant_yields_all_but_one_switch() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let switch_on_one_block = builder.create_block();
+        let switch_on_two_block = builder.create_block();
+        let switch_on_three_block = builder.create_block();
+        let switch_on_default_block = builder.create_block();
+        let switch_final_block = builder.create_block();
+        let exit_block = builder.create_block();
+
+        let final_arg0 = builder.append_block_param(switch_final_block, Type::U32, span);
+        let final_arg1 = builder.append_block_param(switch_final_block, Type::U32, span);
+        let final_arg2 = builder.append_block_param(switch_final_block, Type::U32, span);
+
+        let ret_val = builder.append_block_param(exit_block, Type::U32, span);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+
+        let redundant_val11 = builder.u32(11, span);
+        let redundant_val22 = builder.u32(22, span);
+        let redundant_val33 = builder.u32(33, span);
+
+        let switch_on_one_case = SwitchCase {
+            value: 1,
+            successor: switch_on_one_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_two_case = SwitchCase {
+            value: 2,
+            successor: switch_on_two_block,
+            arguments: Vec::default(),
+        };
+
+        let switch_on_three_case = SwitchCase {
+            value: 3,
+            successor: switch_on_three_block,
+            arguments: Vec::default(),
+        };
+
+        builder.switch(
+            input,
+            [switch_on_one_case, switch_on_two_case, switch_on_three_case],
+            switch_on_default_block,
+            Vec::default(),
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_one_block);
+        builder.br(
+            switch_final_block,
+            [redundant_val11, redundant_val22, redundant_val33],
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_two_block);
+        builder.br(
+            switch_final_block,
+            [redundant_val11, redundant_val22, redundant_val33],
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_three_block);
+        builder.br(
+            switch_final_block,
+            [redundant_val11, redundant_val22, redundant_val33],
+            span,
+        )?;
+
+        builder.switch_to_block(switch_on_default_block);
+        let non_redundant_val44 = builder.u32(44, span);
+        builder.br(
+            switch_final_block,
+            [redundant_val11, non_redundant_val44, redundant_val33],
+            span,
+        )?;
+
+        // Add all the results together.
+        builder.switch_to_block(switch_final_block);
+        let sum0 = builder.add(final_arg0, final_arg1, span)?;
+        let sum1 = builder.add(sum0, final_arg2, span)?;
+        builder.br(exit_block, [sum1], span)?;
+
+        builder.switch_to_block(exit_block);
+        builder.ret(Some(ret_val), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_all_but_one_switch",
+            true,
+        )
+    }
+
+    #[test]
+    fn fold_redundant_yields_effects_if() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new(
+                [
+                    AbiParam::new(Type::U32),
+                    AbiParam::new(Type::Ptr(Arc::new(PointerType::new(Type::U32)))),
+                ],
+                [AbiParam::new(Type::U32)],
+            );
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let if_then = builder.create_block();
+        let if_else = builder.create_block();
+        let if_final = builder.create_block();
+
+        let ret_val = builder.append_block_param(if_final, Type::U32, span);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+        let input_ptr = builder.current_block().borrow().arguments()[1].upcast();
+        let redundant_val = builder.u32(11, span);
+
+        let zero = builder.u32(0, span);
+        let is_zero = builder.eq(input, zero, span)?;
+        builder.cond_br(is_zero, if_then, [], if_else, [], span)?;
+
+        builder.switch_to_block(if_then);
+        builder.br(if_final, [redundant_val], span)?;
+
+        builder.switch_to_block(if_else);
+        builder.store(input_ptr, redundant_val, span)?;
+        builder.br(if_final, [redundant_val], span)?;
+
+        // Add all the results together along with the redundant value to give them all users.
+        builder.switch_to_block(if_final);
+        builder.ret(Some(ret_val), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_effects_if",
+            true,
+        )
+    }
+
+    /* A `while` test which initially showed that this rewriter probably isn't suited for them. {{{
+
+    #[test]
+    fn fold_redundant_yields_subset_while() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let mut builder = OpBuilder::new(context.clone());
+
+        let span = SourceSpan::default();
+        let function = {
+            let builder = builder.create::<builtin::Function, (_, _)>(span);
+            let name = Ident::new("test".into(), span);
+            let signature = Signature::new([AbiParam::new(Type::U32)], [AbiParam::new(Type::U32)]);
+            builder(name, signature).unwrap()
+        };
+
+        let mut builder = FunctionBuilder::new(function, &mut builder);
+
+        let input = builder.current_block().borrow().arguments()[0].upcast();
+        let redundant_val = builder.u32(11, span);
+
+        // Create a while op, pass zero.
+        let zero = builder.u32(0, span);
+        let while_op = builder.r#while([zero], &[Type::U32], span)?;
+        let while_before_block = while_op.borrow().before().entry().as_block_ref();
+        let while_after_block = while_op.borrow().after().entry().as_block_ref();
+
+        // Check the passed arg against the function arg.
+        builder.switch_to_block(while_before_block);
+        let while_cond_arg = while_before_block.borrow().arguments()[0].upcast();
+        let finished = builder.eq(while_cond_arg, input, span)?;
+        let next_iter = builder.incr(while_cond_arg, span)?;
+        builder.condition(finished, [next_iter], span)?;
+
+        // Just yield the final results from the while op.
+        builder.switch_to_block(while_after_block);
+        let yield_values = while_after_block
+            .borrow()
+            .arguments()
+            .iter()
+            .map(|a| a.borrow().as_value_ref())
+            .collect::<SmallVec<[_; 4]>>();
+        builder.r#yield(yield_values, span)?;
+
+        // Add all the results together along with the redundant value to give them all users.
+        builder.switch_to_block(builder.entry_block());
+        let summed_while_results =
+            while_op.borrow().results().iter().try_fold(zero, |acc, res| {
+                let res_val_ref = res.borrow().as_value_ref();
+                builder.add(acc, res_val_ref, span)
+            })?;
+        let final_sum = builder.add(summed_while_results, redundant_val, span)?;
+        builder.ret(Some(final_sum), span)?;
+
+        run_single_canonicalizer(
+            context,
+            function.as_operation_ref(),
+            "fold_redundant_yields_subset_while",
+        )
+    }
+    }}} */
+}

--- a/dialects/scf/src/ops.rs
+++ b/dialects/scf/src/ops.rs
@@ -645,7 +645,7 @@ impl RegionBranchTerminatorOpInterface for Condition {
 /// regions must yield the same arity and types.
 #[operation(
     dialect = ScfDialect,
-    traits(Terminator, ReturnLike, Pure),
+    traits(Terminator, ReturnLike, Pure, AlwaysSpeculatable),
     implements(
         RegionBranchTerminatorOpInterface,
         MemoryEffectOpInterface,
@@ -704,8 +704,6 @@ impl EffectOpInterface<MemoryEffect> for Yield {
         EffectIterator::from_smallvec(::midenc_hir::smallvec![])
     }
 }
-
-impl AlwaysSpeculatable for Yield {}
 
 impl ConditionallySpeculatable for Yield {
     fn speculatability(&self) -> Speculatability {

--- a/dialects/scf/src/ops.rs
+++ b/dialects/scf/src/ops.rs
@@ -79,7 +79,8 @@ impl If {
 impl Canonicalizable for If {
     fn get_canonicalization_patterns(rewrites: &mut RewritePatternSet, context: Rc<Context>) {
         rewrites.push(crate::canonicalization::ConvertTrivialIfToSelect::new(context.clone()));
-        rewrites.push(crate::canonicalization::IfRemoveUnusedResults::new(context));
+        rewrites.push(crate::canonicalization::IfRemoveUnusedResults::new(context.clone()));
+        rewrites.push(crate::canonicalization::FoldRedundantYields::new(context));
     }
 }
 
@@ -547,7 +548,8 @@ impl RegionBranchOpInterface for IndexSwitch {
 
 impl Canonicalizable for IndexSwitch {
     fn get_canonicalization_patterns(rewrites: &mut RewritePatternSet, context: Rc<Context>) {
-        rewrites.push(crate::canonicalization::FoldConstantIndexSwitch::new(context));
+        rewrites.push(crate::canonicalization::FoldConstantIndexSwitch::new(context.clone()));
+        rewrites.push(crate::canonicalization::FoldRedundantYields::new(context));
     }
 }
 
@@ -643,8 +645,12 @@ impl RegionBranchTerminatorOpInterface for Condition {
 /// regions must yield the same arity and types.
 #[operation(
     dialect = ScfDialect,
-    traits(Terminator, ReturnLike),
-    implements(RegionBranchTerminatorOpInterface)
+    traits(Terminator, ReturnLike, Pure),
+    implements(
+        RegionBranchTerminatorOpInterface,
+        MemoryEffectOpInterface,
+        ConditionallySpeculatable
+    )
 )]
 pub struct Yield {
     #[operands]
@@ -686,5 +692,23 @@ impl RegionBranchTerminatorOpInterface for Yield {
         } else {
             panic!("unsupported parent operation for '{}': '{}'", self.name(), parent_op.name())
         }
+    }
+}
+
+impl EffectOpInterface<MemoryEffect> for Yield {
+    fn has_no_effect(&self) -> bool {
+        true
+    }
+
+    fn effects(&self) -> EffectIterator<::midenc_hir::effects::MemoryEffect> {
+        EffectIterator::from_smallvec(::midenc_hir::smallvec![])
+    }
+}
+
+impl AlwaysSpeculatable for Yield {}
+
+impl ConditionallySpeculatable for Yield {
+    fn speculatability(&self) -> Speculatability {
+        Speculatability::Speculatable
     }
 }

--- a/hir/src/dialects.rs
+++ b/hir/src/dialects.rs
@@ -1,3 +1,2 @@
 pub mod builtin;
-#[cfg(test)]
 pub mod test;

--- a/hir/src/dialects/test.rs
+++ b/hir/src/dialects/test.rs
@@ -119,5 +119,8 @@ impl DialectRegistration for TestDialect {
         info.register_operation::<ops::Shl>();
         info.register_operation::<ops::Ret>();
         info.register_operation::<ops::Constant>();
+        info.register_operation::<ops::Eq>();
+        info.register_operation::<ops::Neq>();
+        info.register_operation::<ops::Store>();
     }
 }

--- a/hir/src/dialects/test/builders.rs
+++ b/hir/src/dialects/test/builders.rs
@@ -10,6 +10,18 @@ pub trait TestOpBuilder<'f, B: ?Sized + Builder> {
         Ok(constant.borrow().result().as_value_ref())
     }
 
+    fn eq(&mut self, lhs: ValueRef, rhs: ValueRef, span: SourceSpan) -> Result<ValueRef, Report> {
+        let op_builder = self.builder_mut().create::<Eq, _>(span);
+        let op = op_builder(lhs, rhs)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
+    fn neq(&mut self, lhs: ValueRef, rhs: ValueRef, span: SourceSpan) -> Result<ValueRef, Report> {
+        let op_builder = self.builder_mut().create::<Neq, _>(span);
+        let op = op_builder(lhs, rhs)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
     /// Two's complement addition which traps on overflow
     fn add(&mut self, lhs: ValueRef, rhs: ValueRef, span: SourceSpan) -> Result<ValueRef, Report> {
         let op_builder = self.builder_mut().create::<Add, _>(span);


### PR DESCRIPTION
At this stage this is only `scf.if` and `scf.index_switch`.  It will try to replace the entire operation if all yields within are of the same values, or it will cull those yields down to only those which differ per region.

Something similar could be applied to `scf.while` but while I tried to get it going, it was both more complicated and felt like it was addressing a corner case.  Finding redundant values between the 'before' and 'after' blocks might be worthwhile, though it would be unlikely the compiler would generate such values.  And then lifting out redundant yields (of values which dominate the `while`) could also be done.

To test the output I've created a pass which runs a single rewriter.  It's handy to use a pass manager to run it because a) the `LiftControlFlowToSCF` transform can be run on `cf` input before calling the rewriter, and then b) it handles the greedy iteration nicely.

This pass and the helper functions to run it could be lifted into the parent `scf/lib.rs` or somewhere deeper if it were to be used for testing elsewhere.

Closes #440.