### PR TITLE
fix: `BumpAlloc` to make all allocations minimally VM word-aligned (16 bytes)

### DIFF
--- a/sdk/alloc/src/lib.rs
+++ b/sdk/alloc/src/lib.rs
@@ -13,8 +13,8 @@ use core::{
 #[cfg(target_family = "wasm")]
 const PAGE_SIZE: usize = 2usize.pow(16);
 
-/// We require all allocations to be minimally word-aligned, i.e. 32 byte alignment
-const MIN_ALIGN: usize = 32;
+/// We require all allocations to be minimally word-aligned, i.e. 16 byte alignment
+const MIN_ALIGN: usize = 16;
 
 /// The linear memory heap must not spill over into the region reserved for procedure
 /// locals, which begins at 2^30 in Miden's address space.

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
@@ -206,20 +206,20 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v130: i32, v131: i32, v132: i32) -> i32 {
         ^block26(v130: i32, v131: i32, v132: i32):
-            v135 = arith.constant 32 : i32;
+            v135 = arith.constant 16 : i32;
             v134 = arith.constant 0 : i32;
-            v707 = arith.constant 32 : u32;
+            v707 = arith.constant 16 : u32;
             v137 = hir.bitcast v131 : u32;
             v139 = arith.gt v137, v707 : i1;
             v140 = arith.zext v139 : u32;
             v141 = hir.bitcast v140 : i32;
             v143 = arith.neq v141, v134 : i1;
             v144 = cf.select v143, v131, v135 : i32;
-            v745 = arith.constant 0 : i32;
+            v746 = arith.constant 0 : i32;
             v145 = arith.constant -1 : i32;
             v146 = arith.add v144, v145 : i32 #[overflow = wrapping];
             v147 = arith.band v144, v146 : i32;
-            v149 = arith.neq v147, v745 : i1;
+            v149 = arith.neq v147, v746 : i1;
             v716, v717 = scf.if v149 : i32, u32 {
             ^block95:
                 v708 = arith.constant 0 : u32;
@@ -228,7 +228,7 @@ builtin.component root_ns:root@1.0.0 {
             } else {
             ^block29:
                 v151 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/core::ptr::alignment::Alignment::max(v131, v144) : i32
-                v744 = arith.constant 0 : i32;
+                v745 = arith.constant 0 : i32;
                 v150 = arith.constant -2147483648 : i32;
                 v152 = arith.sub v150, v151 : i32 #[overflow = wrapping];
                 v154 = hir.bitcast v152 : u32;
@@ -236,18 +236,18 @@ builtin.component root_ns:root@1.0.0 {
                 v155 = arith.gt v153, v154 : i1;
                 v156 = arith.zext v155 : u32;
                 v157 = hir.bitcast v156 : i32;
-                v159 = arith.neq v157, v744 : i1;
+                v159 = arith.neq v157, v745 : i1;
                 v731 = scf.if v159 : i32 {
                 ^block94:
-                    v743 = ub.poison i32 : i32;
-                    scf.yield v743;
+                    v744 = ub.poison i32 : i32;
+                    scf.yield v744;
                 } else {
                 ^block30:
-                    v741 = arith.constant 0 : i32;
-                    v165 = arith.sub v741, v151 : i32 #[overflow = wrapping];
-                    v742 = arith.constant -1 : i32;
+                    v742 = arith.constant 0 : i32;
+                    v165 = arith.sub v742, v151 : i32 #[overflow = wrapping];
+                    v743 = arith.constant -1 : i32;
                     v161 = arith.add v132, v151 : i32 #[overflow = wrapping];
-                    v163 = arith.add v161, v742 : i32 #[overflow = wrapping];
+                    v163 = arith.add v161, v743 : i32 #[overflow = wrapping];
                     v166 = arith.band v163, v165 : i32;
                     v167 = hir.bitcast v130 : u32;
                     v168 = arith.constant 4 : u32;
@@ -255,8 +255,8 @@ builtin.component root_ns:root@1.0.0 {
                     hir.assertz v169 #[code = 250];
                     v170 = hir.int_to_ptr v167 : ptr<byte, i32>;
                     v171 = hir.load v170 : i32;
-                    v740 = arith.constant 0 : i32;
-                    v173 = arith.neq v171, v740 : i1;
+                    v741 = arith.constant 0 : i32;
+                    v173 = arith.neq v171, v741 : i1;
                     scf.if v173{
                     ^block93:
                         scf.yield ;
@@ -265,12 +265,12 @@ builtin.component root_ns:root@1.0.0 {
                         v174 = hir.exec @intrinsics/mem/heap_base() : i32
                         v175 = hir.mem_size  : u32;
                         v181 = hir.bitcast v130 : u32;
-                        v739 = arith.constant 4 : u32;
-                        v183 = arith.mod v181, v739 : u32;
+                        v740 = arith.constant 4 : u32;
+                        v183 = arith.mod v181, v740 : u32;
                         hir.assertz v183 #[code = 250];
-                        v706 = arith.constant 16 : u32;
+                        v739 = arith.constant 16 : u32;
                         v176 = hir.bitcast v175 : i32;
-                        v179 = arith.shl v176, v706 : i32;
+                        v179 = arith.shl v176, v739 : i32;
                         v180 = arith.add v174, v179 : i32 #[overflow = wrapping];
                         v184 = hir.int_to_ptr v181 : ptr<byte, i32>;
                         hir.store v184, v180;
@@ -346,56 +346,56 @@ builtin.component root_ns:root@1.0.0 {
             hir.assertz v230 #[code = 250];
             v231 = hir.int_to_ptr v228 : ptr<byte, i32>;
             v232 = hir.load v231 : i32;
-            v756 = arith.constant 4 : u32;
+            v757 = arith.constant 4 : u32;
             v233 = hir.bitcast v219 : u32;
-            v235 = arith.add v233, v756 : u32 #[overflow = checked];
-            v755 = arith.constant 4 : u32;
-            v237 = arith.mod v235, v755 : u32;
+            v235 = arith.add v233, v757 : u32 #[overflow = checked];
+            v756 = arith.constant 4 : u32;
+            v237 = arith.mod v235, v756 : u32;
             hir.assertz v237 #[code = 250];
             v238 = hir.int_to_ptr v235 : ptr<byte, i32>;
             v239 = hir.load v238 : i32;
-            v754 = arith.constant 0 : i32;
+            v755 = arith.constant 0 : i32;
             v240 = arith.constant 1 : i32;
             v241 = arith.neq v239, v240 : i1;
             v242 = arith.zext v241 : u32;
             v243 = hir.bitcast v242 : i32;
-            v245 = arith.neq v243, v754 : i1;
+            v245 = arith.neq v243, v755 : i1;
             cf.cond_br v245 ^block37, ^block38;
         ^block37:
             v254 = arith.constant 12 : u32;
             v253 = hir.bitcast v219 : u32;
             v255 = arith.add v253, v254 : u32 #[overflow = checked];
-            v753 = arith.constant 4 : u32;
-            v257 = arith.mod v255, v753 : u32;
+            v754 = arith.constant 4 : u32;
+            v257 = arith.mod v255, v754 : u32;
             hir.assertz v257 #[code = 250];
             v258 = hir.int_to_ptr v255 : ptr<byte, i32>;
             v259 = hir.load v258 : i32;
-            v752 = arith.constant 4 : u32;
+            v753 = arith.constant 4 : u32;
             v260 = hir.bitcast v210 : u32;
-            v262 = arith.add v260, v752 : u32 #[overflow = checked];
-            v751 = arith.constant 4 : u32;
-            v264 = arith.mod v262, v751 : u32;
+            v262 = arith.add v260, v753 : u32 #[overflow = checked];
+            v752 = arith.constant 4 : u32;
+            v264 = arith.mod v262, v752 : u32;
             hir.assertz v264 #[code = 250];
             v265 = hir.int_to_ptr v262 : ptr<byte, i32>;
             hir.store v265, v259;
             v266 = hir.bitcast v210 : u32;
-            v750 = arith.constant 4 : u32;
-            v268 = arith.mod v266, v750 : u32;
+            v751 = arith.constant 4 : u32;
+            v268 = arith.mod v266, v751 : u32;
             hir.assertz v268 #[code = 250];
             v269 = hir.int_to_ptr v266 : ptr<byte, i32>;
             hir.store v269, v232;
-            v749 = arith.constant 16 : i32;
-            v271 = arith.add v219, v749 : i32 #[overflow = wrapping];
+            v750 = arith.constant 16 : i32;
+            v271 = arith.add v219, v750 : i32 #[overflow = wrapping];
             v272 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v273 = hir.bitcast v272 : ptr<byte, i32>;
             hir.store v273, v271;
             builtin.ret ;
         ^block38:
-            v748 = arith.constant 12 : u32;
+            v749 = arith.constant 12 : u32;
             v246 = hir.bitcast v219 : u32;
-            v248 = arith.add v246, v748 : u32 #[overflow = checked];
-            v747 = arith.constant 4 : u32;
-            v250 = arith.mod v248, v747 : u32;
+            v248 = arith.add v246, v749 : u32 #[overflow = checked];
+            v748 = arith.constant 4 : u32;
+            v250 = arith.mod v248, v748 : u32;
             hir.assertz v250 #[code = 250];
             v251 = hir.int_to_ptr v248 : ptr<byte, i32>;
             v252 = hir.load v251 : i32;
@@ -429,40 +429,40 @@ builtin.component root_ns:root@1.0.0 {
             v296 = arith.constant 12 : u32;
             v295 = hir.bitcast v280 : u32;
             v297 = arith.add v295, v296 : u32 #[overflow = checked];
-            v764 = arith.constant 4 : u32;
-            v299 = arith.mod v297, v764 : u32;
+            v765 = arith.constant 4 : u32;
+            v299 = arith.mod v297, v765 : u32;
             hir.assertz v299 #[code = 250];
             v300 = hir.int_to_ptr v297 : ptr<byte, i32>;
             v301 = hir.load v300 : i32;
-            v757 = arith.constant 2 : u32;
+            v758 = arith.constant 2 : u32;
             v303 = hir.bitcast v301 : u32;
-            v305 = arith.shr v303, v757 : u32;
+            v305 = arith.shr v303, v758 : u32;
             v306 = hir.bitcast v305 : i32;
             v307 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::extern_note_get_inputs(v306) : i32
-            v763 = arith.constant 8 : u32;
+            v764 = arith.constant 8 : u32;
             v308 = hir.bitcast v274 : u32;
-            v310 = arith.add v308, v763 : u32 #[overflow = checked];
-            v762 = arith.constant 4 : u32;
-            v312 = arith.mod v310, v762 : u32;
+            v310 = arith.add v308, v764 : u32 #[overflow = checked];
+            v763 = arith.constant 4 : u32;
+            v312 = arith.mod v310, v763 : u32;
             hir.assertz v312 #[code = 250];
             v313 = hir.int_to_ptr v310 : ptr<byte, i32>;
             hir.store v313, v307;
-            v761 = arith.constant 4 : u32;
+            v762 = arith.constant 4 : u32;
             v314 = hir.bitcast v274 : u32;
-            v316 = arith.add v314, v761 : u32 #[overflow = checked];
-            v760 = arith.constant 4 : u32;
-            v318 = arith.mod v316, v760 : u32;
+            v316 = arith.add v314, v762 : u32 #[overflow = checked];
+            v761 = arith.constant 4 : u32;
+            v318 = arith.mod v316, v761 : u32;
             hir.assertz v318 #[code = 250];
             v319 = hir.int_to_ptr v316 : ptr<byte, i32>;
             hir.store v319, v301;
             v320 = hir.bitcast v274 : u32;
-            v759 = arith.constant 4 : u32;
-            v322 = arith.mod v320, v759 : u32;
+            v760 = arith.constant 4 : u32;
+            v322 = arith.mod v320, v760 : u32;
             hir.assertz v322 #[code = 250];
             v323 = hir.int_to_ptr v320 : ptr<byte, i32>;
             hir.store v323, v294;
-            v758 = arith.constant 16 : i32;
-            v325 = arith.add v280, v758 : i32 #[overflow = wrapping];
+            v759 = arith.constant 16 : i32;
+            v325 = arith.add v280, v759 : i32 #[overflow = wrapping];
             v326 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v327 = hir.bitcast v326 : ptr<byte, i32>;
             hir.store v327, v325;
@@ -490,38 +490,38 @@ builtin.component root_ns:root@1.0.0 {
             hir.assertz v345 #[code = 250];
             v346 = hir.int_to_ptr v343 : ptr<byte, i32>;
             v347 = hir.load v346 : i32;
-            v771 = arith.constant 0 : i32;
+            v772 = arith.constant 0 : i32;
             v331 = arith.constant 0 : i32;
             v349 = arith.eq v347, v331 : i1;
             v350 = arith.zext v349 : u32;
             v351 = hir.bitcast v350 : i32;
-            v353 = arith.neq v351, v771 : i1;
+            v353 = arith.neq v351, v772 : i1;
             scf.if v353{
             ^block103:
                 scf.yield ;
             } else {
             ^block44:
-                v770 = arith.constant 4 : u32;
+                v771 = arith.constant 4 : u32;
                 v354 = hir.bitcast v336 : u32;
-                v356 = arith.add v354, v770 : u32 #[overflow = checked];
-                v769 = arith.constant 4 : u32;
-                v358 = arith.mod v356, v769 : u32;
+                v356 = arith.add v354, v771 : u32 #[overflow = checked];
+                v770 = arith.constant 4 : u32;
+                v358 = arith.mod v356, v770 : u32;
                 hir.assertz v358 #[code = 250];
                 v359 = hir.int_to_ptr v356 : ptr<byte, i32>;
                 v360 = hir.load v359 : i32;
                 v362 = arith.constant 12 : u32;
                 v361 = hir.bitcast v336 : u32;
                 v363 = arith.add v361, v362 : u32 #[overflow = checked];
-                v768 = arith.constant 4 : u32;
-                v365 = arith.mod v363, v768 : u32;
+                v769 = arith.constant 4 : u32;
+                v365 = arith.mod v363, v769 : u32;
                 hir.assertz v365 #[code = 250];
                 v366 = hir.int_to_ptr v363 : ptr<byte, i32>;
                 v367 = hir.load v366 : i32;
                 hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v360, v347, v367)
                 scf.yield ;
             };
-            v767 = arith.constant 16 : i32;
-            v370 = arith.add v336, v767 : i32 #[overflow = wrapping];
+            v768 = arith.constant 16 : i32;
+            v370 = arith.add v336, v768 : i32 #[overflow = wrapping];
             v371 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v372 = hir.bitcast v371 : ptr<byte, i32>;
             hir.store v372, v370;
@@ -551,23 +551,23 @@ builtin.component root_ns:root@1.0.0 {
             v394 = arith.zext v393 : u64;
             v395 = hir.bitcast v394 : i64;
             v399 = arith.mul v395, v398 : i64 #[overflow = wrapping];
-            v875 = arith.constant 0 : i32;
+            v876 = arith.constant 0 : i32;
             v400 = arith.constant 32 : i64;
             v402 = hir.cast v400 : u32;
             v401 = hir.bitcast v399 : u64;
             v403 = arith.shr v401, v402 : u64;
             v404 = hir.bitcast v403 : i64;
             v405 = arith.trunc v404 : i32;
-            v407 = arith.neq v405, v875 : i1;
-            v787, v788, v789, v790, v791, v792 = scf.if v407 : i32, i32, i32, i32, i32, u32 {
+            v407 = arith.neq v405, v876 : i1;
+            v788, v789, v790, v791, v792, v793 = scf.if v407 : i32, i32, i32, i32, i32, u32 {
             ^block105:
-                v772 = arith.constant 0 : u32;
-                v779 = ub.poison i32 : i32;
-                scf.yield v373, v384, v779, v779, v779, v772;
+                v773 = arith.constant 0 : u32;
+                v780 = ub.poison i32 : i32;
+                scf.yield v373, v384, v780, v780, v780, v773;
             } else {
             ^block50:
                 v408 = arith.trunc v399 : i32;
-                v874 = arith.constant 0 : i32;
+                v875 = arith.constant 0 : i32;
                 v409 = arith.constant -2147483648 : i32;
                 v410 = arith.sub v409, v376 : i32 #[overflow = wrapping];
                 v412 = hir.bitcast v410 : u32;
@@ -575,16 +575,16 @@ builtin.component root_ns:root@1.0.0 {
                 v413 = arith.lte v411, v412 : i1;
                 v414 = arith.zext v413 : u32;
                 v415 = hir.bitcast v414 : i32;
-                v417 = arith.neq v415, v874 : i1;
-                v835 = scf.if v417 : i32 {
+                v417 = arith.neq v415, v875 : i1;
+                v836 = scf.if v417 : i32 {
                 ^block48:
-                    v873 = arith.constant 0 : i32;
-                    v428 = arith.neq v408, v873 : i1;
-                    v834 = scf.if v428 : i32 {
+                    v874 = arith.constant 0 : i32;
+                    v428 = arith.neq v408, v874 : i1;
+                    v835 = scf.if v428 : i32 {
                     ^block52:
-                        v872 = arith.constant 0 : i32;
-                        v444 = arith.neq v375, v872 : i1;
-                        v833 = scf.if v444 : i32 {
+                        v873 = arith.constant 0 : i32;
+                        v444 = arith.neq v375, v873 : i1;
+                        v834 = scf.if v444 : i32 {
                         ^block55:
                             v426 = arith.constant 1 : i32;
                             hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl(v384, v376, v408, v426)
@@ -603,130 +603,130 @@ builtin.component root_ns:root@1.0.0 {
                             v430 = arith.constant 8 : u32;
                             v447 = hir.bitcast v384 : u32;
                             v449 = arith.add v447, v430 : u32 #[overflow = checked];
-                            v871 = arith.constant 4 : u32;
-                            v451 = arith.mod v449, v871 : u32;
+                            v872 = arith.constant 4 : u32;
+                            v451 = arith.mod v449, v872 : u32;
                             hir.assertz v451 #[code = 250];
                             v452 = hir.int_to_ptr v449 : ptr<byte, i32>;
                             v453 = hir.load v452 : i32;
                             scf.yield v453;
                         };
-                        v869 = arith.constant 0 : i32;
                         v870 = arith.constant 0 : i32;
-                        v462 = arith.eq v833, v870 : i1;
+                        v871 = arith.constant 0 : i32;
+                        v462 = arith.eq v834, v871 : i1;
                         v463 = arith.zext v462 : u32;
                         v464 = hir.bitcast v463 : i32;
-                        v466 = arith.neq v464, v869 : i1;
+                        v466 = arith.neq v464, v870 : i1;
                         scf.if v466{
                         ^block57:
-                            v868 = arith.constant 8 : u32;
+                            v869 = arith.constant 8 : u32;
                             v483 = hir.bitcast v373 : u32;
-                            v485 = arith.add v483, v868 : u32 #[overflow = checked];
-                            v867 = arith.constant 4 : u32;
-                            v487 = arith.mod v485, v867 : u32;
+                            v485 = arith.add v483, v869 : u32 #[overflow = checked];
+                            v868 = arith.constant 4 : u32;
+                            v487 = arith.mod v485, v868 : u32;
                             hir.assertz v487 #[code = 250];
                             v488 = hir.int_to_ptr v485 : ptr<byte, i32>;
                             hir.store v488, v408;
-                            v866 = arith.constant 4 : u32;
+                            v867 = arith.constant 4 : u32;
                             v490 = hir.bitcast v373 : u32;
-                            v492 = arith.add v490, v866 : u32 #[overflow = checked];
-                            v865 = arith.constant 4 : u32;
-                            v494 = arith.mod v492, v865 : u32;
+                            v492 = arith.add v490, v867 : u32 #[overflow = checked];
+                            v866 = arith.constant 4 : u32;
+                            v494 = arith.mod v492, v866 : u32;
                             hir.assertz v494 #[code = 250];
                             v495 = hir.int_to_ptr v492 : ptr<byte, i32>;
                             hir.store v495, v376;
                             scf.yield ;
                         } else {
                         ^block58:
-                            v864 = arith.constant 8 : u32;
+                            v865 = arith.constant 8 : u32;
                             v468 = hir.bitcast v373 : u32;
-                            v470 = arith.add v468, v864 : u32 #[overflow = checked];
-                            v863 = arith.constant 4 : u32;
-                            v472 = arith.mod v470, v863 : u32;
+                            v470 = arith.add v468, v865 : u32 #[overflow = checked];
+                            v864 = arith.constant 4 : u32;
+                            v472 = arith.mod v470, v864 : u32;
                             hir.assertz v472 #[code = 250];
                             v473 = hir.int_to_ptr v470 : ptr<byte, i32>;
-                            hir.store v473, v833;
-                            v862 = arith.constant 4 : u32;
+                            hir.store v473, v834;
+                            v863 = arith.constant 4 : u32;
                             v475 = hir.bitcast v373 : u32;
-                            v477 = arith.add v475, v862 : u32 #[overflow = checked];
-                            v861 = arith.constant 4 : u32;
-                            v479 = arith.mod v477, v861 : u32;
+                            v477 = arith.add v475, v863 : u32 #[overflow = checked];
+                            v862 = arith.constant 4 : u32;
+                            v479 = arith.mod v477, v862 : u32;
                             hir.assertz v479 #[code = 250];
                             v480 = hir.int_to_ptr v477 : ptr<byte, i32>;
                             hir.store v480, v374;
                             scf.yield ;
                         };
-                        v859 = arith.constant 0 : i32;
-                        v860 = arith.constant 1 : i32;
-                        v832 = cf.select v466, v860, v859 : i32;
-                        scf.yield v832;
+                        v860 = arith.constant 0 : i32;
+                        v861 = arith.constant 1 : i32;
+                        v833 = cf.select v466, v861, v860 : i32;
+                        scf.yield v833;
                     } else {
                     ^block53:
-                        v858 = arith.constant 8 : u32;
+                        v859 = arith.constant 8 : u32;
                         v429 = hir.bitcast v373 : u32;
-                        v431 = arith.add v429, v858 : u32 #[overflow = checked];
-                        v857 = arith.constant 4 : u32;
-                        v433 = arith.mod v431, v857 : u32;
+                        v431 = arith.add v429, v859 : u32 #[overflow = checked];
+                        v858 = arith.constant 4 : u32;
+                        v433 = arith.mod v431, v858 : u32;
                         hir.assertz v433 #[code = 250];
                         v434 = hir.int_to_ptr v431 : ptr<byte, i32>;
                         hir.store v434, v376;
-                        v856 = arith.constant 4 : u32;
+                        v857 = arith.constant 4 : u32;
                         v437 = hir.bitcast v373 : u32;
-                        v439 = arith.add v437, v856 : u32 #[overflow = checked];
-                        v855 = arith.constant 4 : u32;
-                        v441 = arith.mod v439, v855 : u32;
+                        v439 = arith.add v437, v857 : u32 #[overflow = checked];
+                        v856 = arith.constant 4 : u32;
+                        v441 = arith.mod v439, v856 : u32;
                         hir.assertz v441 #[code = 250];
-                        v854 = arith.constant 0 : i32;
+                        v855 = arith.constant 0 : i32;
                         v442 = hir.int_to_ptr v439 : ptr<byte, i32>;
-                        hir.store v442, v854;
-                        v853 = arith.constant 0 : i32;
-                        scf.yield v853;
+                        hir.store v442, v855;
+                        v854 = arith.constant 0 : i32;
+                        scf.yield v854;
                     };
-                    scf.yield v834;
+                    scf.yield v835;
                 } else {
                 ^block51:
-                    v852 = ub.poison i32 : i32;
-                    scf.yield v852;
+                    v853 = ub.poison i32 : i32;
+                    scf.yield v853;
                 };
-                v847 = arith.constant 0 : u32;
-                v780 = arith.constant 1 : u32;
-                v840 = cf.select v417, v780, v847 : u32;
-                v848 = ub.poison i32 : i32;
-                v839 = cf.select v417, v384, v848 : i32;
+                v848 = arith.constant 0 : u32;
+                v781 = arith.constant 1 : u32;
+                v841 = cf.select v417, v781, v848 : u32;
                 v849 = ub.poison i32 : i32;
-                v838 = cf.select v417, v373, v849 : i32;
+                v840 = cf.select v417, v384, v849 : i32;
                 v850 = ub.poison i32 : i32;
-                v837 = cf.select v417, v850, v384 : i32;
+                v839 = cf.select v417, v373, v850 : i32;
                 v851 = ub.poison i32 : i32;
-                v836 = cf.select v417, v851, v373 : i32;
-                scf.yield v836, v837, v838, v835, v839, v840;
+                v838 = cf.select v417, v851, v384 : i32;
+                v852 = ub.poison i32 : i32;
+                v837 = cf.select v417, v852, v373 : i32;
+                scf.yield v837, v838, v839, v836, v840, v841;
             };
-            v793, v794, v795 = scf.index_switch v792 : i32, i32, i32 
+            v794, v795, v796 = scf.index_switch v793 : i32, i32, i32 
             case 0 {
             ^block49:
+                v847 = arith.constant 4 : u32;
+                v420 = hir.bitcast v788 : u32;
+                v422 = arith.add v420, v847 : u32 #[overflow = checked];
                 v846 = arith.constant 4 : u32;
-                v420 = hir.bitcast v787 : u32;
-                v422 = arith.add v420, v846 : u32 #[overflow = checked];
-                v845 = arith.constant 4 : u32;
-                v424 = arith.mod v422, v845 : u32;
+                v424 = arith.mod v422, v846 : u32;
                 hir.assertz v424 #[code = 250];
-                v844 = arith.constant 0 : i32;
+                v845 = arith.constant 0 : i32;
                 v425 = hir.int_to_ptr v422 : ptr<byte, i32>;
-                hir.store v425, v844;
-                v843 = arith.constant 1 : i32;
-                scf.yield v787, v843, v788;
+                hir.store v425, v845;
+                v844 = arith.constant 1 : i32;
+                scf.yield v788, v844, v789;
             }
             default {
             ^block109:
-                scf.yield v789, v790, v791;
+                scf.yield v790, v791, v792;
             };
-            v499 = hir.bitcast v793 : u32;
-            v842 = arith.constant 4 : u32;
-            v501 = arith.mod v499, v842 : u32;
+            v499 = hir.bitcast v794 : u32;
+            v843 = arith.constant 4 : u32;
+            v501 = arith.mod v499, v843 : u32;
             hir.assertz v501 #[code = 250];
             v502 = hir.int_to_ptr v499 : ptr<byte, i32>;
-            hir.store v502, v794;
-            v841 = arith.constant 16 : i32;
-            v507 = arith.add v795, v841 : i32 #[overflow = wrapping];
+            hir.store v502, v795;
+            v842 = arith.constant 16 : i32;
+            v507 = arith.add v796, v842 : i32 #[overflow = wrapping];
             v508 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v509 = hir.bitcast v508 : ptr<byte, i32>;
             hir.store v509, v507;
@@ -758,27 +758,27 @@ builtin.component root_ns:root@1.0.0 {
             v532 = arith.constant 8 : u32;
             v531 = hir.bitcast v518 : u32;
             v533 = arith.add v531, v532 : u32 #[overflow = checked];
-            v880 = arith.constant 4 : u32;
-            v535 = arith.mod v533, v880 : u32;
+            v881 = arith.constant 4 : u32;
+            v535 = arith.mod v533, v881 : u32;
             hir.assertz v535 #[code = 250];
             v536 = hir.int_to_ptr v533 : ptr<byte, i32>;
             v537 = hir.load v536 : i32;
             v538 = hir.bitcast v510 : u32;
-            v879 = arith.constant 4 : u32;
-            v540 = arith.mod v538, v879 : u32;
+            v880 = arith.constant 4 : u32;
+            v540 = arith.mod v538, v880 : u32;
             hir.assertz v540 #[code = 250];
             v541 = hir.int_to_ptr v538 : ptr<byte, i32>;
             hir.store v541, v537;
-            v878 = arith.constant 4 : u32;
+            v879 = arith.constant 4 : u32;
             v542 = hir.bitcast v510 : u32;
-            v544 = arith.add v542, v878 : u32 #[overflow = checked];
-            v877 = arith.constant 4 : u32;
-            v546 = arith.mod v544, v877 : u32;
+            v544 = arith.add v542, v879 : u32 #[overflow = checked];
+            v878 = arith.constant 4 : u32;
+            v546 = arith.mod v544, v878 : u32;
             hir.assertz v546 #[code = 250];
             v547 = hir.int_to_ptr v544 : ptr<byte, i32>;
             hir.store v547, v530;
-            v876 = arith.constant 16 : i32;
-            v549 = arith.add v518, v876 : i32 #[overflow = wrapping];
+            v877 = arith.constant 16 : i32;
+            v549 = arith.add v518, v877 : i32 #[overflow = wrapping];
             v550 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v551 = hir.bitcast v550 : ptr<byte, i32>;
             hir.store v551, v549;
@@ -787,20 +787,20 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @alloc::alloc::Global::alloc_impl(v552: i32, v553: i32, v554: i32, v555: i32) {
         ^block61(v552: i32, v553: i32, v554: i32, v555: i32):
-            v896 = arith.constant 0 : i32;
+            v897 = arith.constant 0 : i32;
             v556 = arith.constant 0 : i32;
             v557 = arith.eq v554, v556 : i1;
             v558 = arith.zext v557 : u32;
             v559 = hir.bitcast v558 : i32;
-            v561 = arith.neq v559, v896 : i1;
-            v892 = scf.if v561 : i32 {
+            v561 = arith.neq v559, v897 : i1;
+            v893 = scf.if v561 : i32 {
             ^block112:
                 scf.yield v553;
             } else {
             ^block64:
-                v895 = arith.constant 0 : i32;
-                v570 = arith.neq v555, v895 : i1;
-                v891 = scf.if v570 : i32 {
+                v896 = arith.constant 0 : i32;
+                v570 = arith.neq v555, v896 : i1;
+                v892 = scf.if v570 : i32 {
                 ^block65:
                     v572 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc_zeroed(v554, v553) : i32
                     scf.yield v572;
@@ -809,38 +809,38 @@ builtin.component root_ns:root@1.0.0 {
                     v571 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc(v554, v553) : i32
                     scf.yield v571;
                 };
-                scf.yield v891;
+                scf.yield v892;
             };
             v576 = arith.constant 4 : u32;
             v575 = hir.bitcast v552 : u32;
             v577 = arith.add v575, v576 : u32 #[overflow = checked];
-            v894 = arith.constant 4 : u32;
-            v579 = arith.mod v577, v894 : u32;
+            v895 = arith.constant 4 : u32;
+            v579 = arith.mod v577, v895 : u32;
             hir.assertz v579 #[code = 250];
             v580 = hir.int_to_ptr v577 : ptr<byte, i32>;
             hir.store v580, v554;
             v582 = hir.bitcast v552 : u32;
-            v893 = arith.constant 4 : u32;
-            v584 = arith.mod v582, v893 : u32;
+            v894 = arith.constant 4 : u32;
+            v584 = arith.mod v582, v894 : u32;
             hir.assertz v584 #[code = 250];
             v585 = hir.int_to_ptr v582 : ptr<byte, i32>;
-            hir.store v585, v892;
+            hir.store v585, v893;
             builtin.ret ;
         };
 
         private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v586: i32, v587: i32, v588: i32, v589: i32) {
         ^block67(v586: i32, v587: i32, v588: i32, v589: i32):
-            v922 = arith.constant 0 : i32;
+            v923 = arith.constant 0 : i32;
             v590 = arith.constant 0 : i32;
             v594 = arith.eq v589, v590 : i1;
             v595 = arith.zext v594 : u32;
             v596 = hir.bitcast v595 : i32;
-            v598 = arith.neq v596, v922 : i1;
-            v909, v910 = scf.if v598 : i32, i32 {
+            v598 = arith.neq v596, v923 : i1;
+            v910, v911 = scf.if v598 : i32, i32 {
             ^block116:
-                v921 = arith.constant 0 : i32;
+                v922 = arith.constant 0 : i32;
                 v592 = arith.constant 4 : i32;
-                scf.yield v592, v921;
+                scf.yield v592, v922;
             } else {
             ^block70:
                 v599 = hir.bitcast v587 : u32;
@@ -849,37 +849,37 @@ builtin.component root_ns:root@1.0.0 {
                 hir.assertz v601 #[code = 250];
                 v602 = hir.int_to_ptr v599 : ptr<byte, i32>;
                 v603 = hir.load v602 : i32;
-                v919 = arith.constant 0 : i32;
                 v920 = arith.constant 0 : i32;
-                v605 = arith.eq v603, v920 : i1;
+                v921 = arith.constant 0 : i32;
+                v605 = arith.eq v603, v921 : i1;
                 v606 = arith.zext v605 : u32;
                 v607 = hir.bitcast v606 : i32;
-                v609 = arith.neq v607, v919 : i1;
-                v907 = scf.if v609 : i32 {
+                v609 = arith.neq v607, v920 : i1;
+                v908 = scf.if v609 : i32 {
                 ^block115:
-                    v918 = arith.constant 0 : i32;
-                    scf.yield v918;
+                    v919 = arith.constant 0 : i32;
+                    scf.yield v919;
                 } else {
                 ^block71:
-                    v917 = arith.constant 4 : u32;
+                    v918 = arith.constant 4 : u32;
                     v610 = hir.bitcast v586 : u32;
-                    v612 = arith.add v610, v917 : u32 #[overflow = checked];
-                    v916 = arith.constant 4 : u32;
-                    v614 = arith.mod v612, v916 : u32;
+                    v612 = arith.add v610, v918 : u32 #[overflow = checked];
+                    v917 = arith.constant 4 : u32;
+                    v614 = arith.mod v612, v917 : u32;
                     hir.assertz v614 #[code = 250];
                     v615 = hir.int_to_ptr v612 : ptr<byte, i32>;
                     hir.store v615, v588;
-                    v915 = arith.constant 4 : u32;
+                    v916 = arith.constant 4 : u32;
                     v616 = hir.bitcast v587 : u32;
-                    v618 = arith.add v616, v915 : u32 #[overflow = checked];
-                    v914 = arith.constant 4 : u32;
-                    v620 = arith.mod v618, v914 : u32;
+                    v618 = arith.add v616, v916 : u32 #[overflow = checked];
+                    v915 = arith.constant 4 : u32;
+                    v620 = arith.mod v618, v915 : u32;
                     hir.assertz v620 #[code = 250];
                     v621 = hir.int_to_ptr v618 : ptr<byte, i32>;
                     v622 = hir.load v621 : i32;
                     v623 = hir.bitcast v586 : u32;
-                    v913 = arith.constant 4 : u32;
-                    v625 = arith.mod v623, v913 : u32;
+                    v914 = arith.constant 4 : u32;
+                    v625 = arith.mod v623, v914 : u32;
                     hir.assertz v625 #[code = 250];
                     v626 = hir.int_to_ptr v623 : ptr<byte, i32>;
                     hir.store v626, v622;
@@ -887,28 +887,28 @@ builtin.component root_ns:root@1.0.0 {
                     scf.yield v627;
                 };
                 v628 = arith.constant 8 : i32;
-                v912 = arith.constant 4 : i32;
-                v908 = cf.select v609, v912, v628 : i32;
-                scf.yield v908, v907;
+                v913 = arith.constant 4 : i32;
+                v909 = cf.select v609, v913, v628 : i32;
+                scf.yield v909, v908;
             };
-            v631 = arith.add v586, v909 : i32 #[overflow = wrapping];
+            v631 = arith.add v586, v910 : i32 #[overflow = wrapping];
             v633 = hir.bitcast v631 : u32;
-            v911 = arith.constant 4 : u32;
-            v635 = arith.mod v633, v911 : u32;
+            v912 = arith.constant 4 : u32;
+            v635 = arith.mod v633, v912 : u32;
             hir.assertz v635 #[code = 250];
             v636 = hir.int_to_ptr v633 : ptr<byte, i32>;
-            hir.store v636, v910;
+            hir.store v636, v911;
             builtin.ret ;
         };
 
         private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v637: i32, v638: i32, v639: i32) {
         ^block72(v637: i32, v638: i32, v639: i32):
-            v924 = arith.constant 0 : i32;
+            v925 = arith.constant 0 : i32;
             v640 = arith.constant 0 : i32;
             v641 = arith.eq v639, v640 : i1;
             v642 = arith.zext v641 : u32;
             v643 = hir.bitcast v642 : i32;
-            v645 = arith.neq v643, v924 : i1;
+            v645 = arith.neq v643, v925 : i1;
             scf.if v645{
             ^block74:
                 scf.yield ;

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -356,9 +356,9 @@ proc.__rustc::__rust_alloc_zeroed
 end
 
 proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
-    push.32
+    push.16
     push.0
-    push.32
+    push.16
     dup.4
     swap.1
     u32gt

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
@@ -119,9 +119,9 @@
     (local i32 i32)
     block ;; label = @1
       local.get 1
-      i32.const 32
+      i32.const 16
       local.get 1
-      i32.const 32
+      i32.const 16
       i32.gt_u
       select
       local.tee 3

--- a/tests/integration/expected/examples/p2id.hir
+++ b/tests/integration/expected/examples/p2id.hir
@@ -299,20 +299,20 @@ builtin.component miden:base/note-script@1.0.0 {
 
         private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v201: i32, v202: i32, v203: i32) -> i32 {
         ^block45(v201: i32, v202: i32, v203: i32):
-            v206 = arith.constant 32 : i32;
+            v206 = arith.constant 16 : i32;
             v205 = arith.constant 0 : i32;
-            v923 = arith.constant 32 : u32;
+            v923 = arith.constant 16 : u32;
             v208 = hir.bitcast v202 : u32;
             v210 = arith.gt v208, v923 : i1;
             v211 = arith.zext v210 : u32;
             v212 = hir.bitcast v211 : i32;
             v214 = arith.neq v212, v205 : i1;
             v215 = cf.select v214, v202, v206 : i32;
-            v961 = arith.constant 0 : i32;
+            v962 = arith.constant 0 : i32;
             v216 = arith.constant -1 : i32;
             v217 = arith.add v215, v216 : i32 #[overflow = wrapping];
             v218 = arith.band v215, v217 : i32;
-            v220 = arith.neq v218, v961 : i1;
+            v220 = arith.neq v218, v962 : i1;
             v932, v933 = scf.if v220 : i32, u32 {
             ^block121:
                 v924 = arith.constant 0 : u32;
@@ -321,7 +321,7 @@ builtin.component miden:base/note-script@1.0.0 {
             } else {
             ^block48:
                 v222 = hir.exec @miden:base/note-script@1.0.0/p2id/core::ptr::alignment::Alignment::max(v202, v215) : i32
-                v960 = arith.constant 0 : i32;
+                v961 = arith.constant 0 : i32;
                 v221 = arith.constant -2147483648 : i32;
                 v223 = arith.sub v221, v222 : i32 #[overflow = wrapping];
                 v225 = hir.bitcast v223 : u32;
@@ -329,18 +329,18 @@ builtin.component miden:base/note-script@1.0.0 {
                 v226 = arith.gt v224, v225 : i1;
                 v227 = arith.zext v226 : u32;
                 v228 = hir.bitcast v227 : i32;
-                v230 = arith.neq v228, v960 : i1;
+                v230 = arith.neq v228, v961 : i1;
                 v947 = scf.if v230 : i32 {
                 ^block120:
-                    v959 = ub.poison i32 : i32;
-                    scf.yield v959;
+                    v960 = ub.poison i32 : i32;
+                    scf.yield v960;
                 } else {
                 ^block49:
-                    v957 = arith.constant 0 : i32;
-                    v236 = arith.sub v957, v222 : i32 #[overflow = wrapping];
-                    v958 = arith.constant -1 : i32;
+                    v958 = arith.constant 0 : i32;
+                    v236 = arith.sub v958, v222 : i32 #[overflow = wrapping];
+                    v959 = arith.constant -1 : i32;
                     v232 = arith.add v203, v222 : i32 #[overflow = wrapping];
-                    v234 = arith.add v232, v958 : i32 #[overflow = wrapping];
+                    v234 = arith.add v232, v959 : i32 #[overflow = wrapping];
                     v237 = arith.band v234, v236 : i32;
                     v238 = hir.bitcast v201 : u32;
                     v239 = arith.constant 4 : u32;
@@ -348,8 +348,8 @@ builtin.component miden:base/note-script@1.0.0 {
                     hir.assertz v240 #[code = 250];
                     v241 = hir.int_to_ptr v238 : ptr<byte, i32>;
                     v242 = hir.load v241 : i32;
-                    v956 = arith.constant 0 : i32;
-                    v244 = arith.neq v242, v956 : i1;
+                    v957 = arith.constant 0 : i32;
+                    v244 = arith.neq v242, v957 : i1;
                     scf.if v244{
                     ^block119:
                         scf.yield ;
@@ -358,12 +358,12 @@ builtin.component miden:base/note-script@1.0.0 {
                         v245 = hir.exec @intrinsics/mem/heap_base() : i32
                         v246 = hir.mem_size  : u32;
                         v252 = hir.bitcast v201 : u32;
-                        v955 = arith.constant 4 : u32;
-                        v254 = arith.mod v252, v955 : u32;
+                        v956 = arith.constant 4 : u32;
+                        v254 = arith.mod v252, v956 : u32;
                         hir.assertz v254 #[code = 250];
-                        v922 = arith.constant 16 : u32;
+                        v955 = arith.constant 16 : u32;
                         v247 = hir.bitcast v246 : i32;
-                        v250 = arith.shl v247, v922 : i32;
+                        v250 = arith.shl v247, v955 : i32;
                         v251 = arith.add v245, v250 : i32 #[overflow = wrapping];
                         v255 = hir.int_to_ptr v252 : ptr<byte, i32>;
                         hir.store v255, v251;
@@ -439,56 +439,56 @@ builtin.component miden:base/note-script@1.0.0 {
             hir.assertz v301 #[code = 250];
             v302 = hir.int_to_ptr v299 : ptr<byte, i32>;
             v303 = hir.load v302 : i32;
-            v972 = arith.constant 4 : u32;
+            v973 = arith.constant 4 : u32;
             v304 = hir.bitcast v290 : u32;
-            v306 = arith.add v304, v972 : u32 #[overflow = checked];
-            v971 = arith.constant 4 : u32;
-            v308 = arith.mod v306, v971 : u32;
+            v306 = arith.add v304, v973 : u32 #[overflow = checked];
+            v972 = arith.constant 4 : u32;
+            v308 = arith.mod v306, v972 : u32;
             hir.assertz v308 #[code = 250];
             v309 = hir.int_to_ptr v306 : ptr<byte, i32>;
             v310 = hir.load v309 : i32;
-            v970 = arith.constant 0 : i32;
+            v971 = arith.constant 0 : i32;
             v311 = arith.constant 1 : i32;
             v312 = arith.neq v310, v311 : i1;
             v313 = arith.zext v312 : u32;
             v314 = hir.bitcast v313 : i32;
-            v316 = arith.neq v314, v970 : i1;
+            v316 = arith.neq v314, v971 : i1;
             cf.cond_br v316 ^block56, ^block57;
         ^block56:
             v325 = arith.constant 12 : u32;
             v324 = hir.bitcast v290 : u32;
             v326 = arith.add v324, v325 : u32 #[overflow = checked];
-            v969 = arith.constant 4 : u32;
-            v328 = arith.mod v326, v969 : u32;
+            v970 = arith.constant 4 : u32;
+            v328 = arith.mod v326, v970 : u32;
             hir.assertz v328 #[code = 250];
             v329 = hir.int_to_ptr v326 : ptr<byte, i32>;
             v330 = hir.load v329 : i32;
-            v968 = arith.constant 4 : u32;
+            v969 = arith.constant 4 : u32;
             v331 = hir.bitcast v281 : u32;
-            v333 = arith.add v331, v968 : u32 #[overflow = checked];
-            v967 = arith.constant 4 : u32;
-            v335 = arith.mod v333, v967 : u32;
+            v333 = arith.add v331, v969 : u32 #[overflow = checked];
+            v968 = arith.constant 4 : u32;
+            v335 = arith.mod v333, v968 : u32;
             hir.assertz v335 #[code = 250];
             v336 = hir.int_to_ptr v333 : ptr<byte, i32>;
             hir.store v336, v330;
             v337 = hir.bitcast v281 : u32;
-            v966 = arith.constant 4 : u32;
-            v339 = arith.mod v337, v966 : u32;
+            v967 = arith.constant 4 : u32;
+            v339 = arith.mod v337, v967 : u32;
             hir.assertz v339 #[code = 250];
             v340 = hir.int_to_ptr v337 : ptr<byte, i32>;
             hir.store v340, v303;
-            v965 = arith.constant 16 : i32;
-            v342 = arith.add v290, v965 : i32 #[overflow = wrapping];
+            v966 = arith.constant 16 : i32;
+            v342 = arith.add v290, v966 : i32 #[overflow = wrapping];
             v343 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v344 = hir.bitcast v343 : ptr<byte, i32>;
             hir.store v344, v342;
             builtin.ret ;
         ^block57:
-            v964 = arith.constant 12 : u32;
+            v965 = arith.constant 12 : u32;
             v317 = hir.bitcast v290 : u32;
-            v319 = arith.add v317, v964 : u32 #[overflow = checked];
-            v963 = arith.constant 4 : u32;
-            v321 = arith.mod v319, v963 : u32;
+            v319 = arith.add v317, v965 : u32 #[overflow = checked];
+            v964 = arith.constant 4 : u32;
+            v321 = arith.mod v319, v964 : u32;
             hir.assertz v321 #[code = 250];
             v322 = hir.int_to_ptr v319 : ptr<byte, i32>;
             v323 = hir.load v322 : i32;
@@ -532,40 +532,40 @@ builtin.component miden:base/note-script@1.0.0 {
             v373 = arith.constant 12 : u32;
             v372 = hir.bitcast v353 : u32;
             v374 = arith.add v372, v373 : u32 #[overflow = checked];
-            v980 = arith.constant 4 : u32;
-            v376 = arith.mod v374, v980 : u32;
+            v981 = arith.constant 4 : u32;
+            v376 = arith.mod v374, v981 : u32;
             hir.assertz v376 #[code = 250];
             v377 = hir.int_to_ptr v374 : ptr<byte, i32>;
             v378 = hir.load v377 : i32;
-            v973 = arith.constant 2 : u32;
+            v974 = arith.constant 2 : u32;
             v380 = hir.bitcast v378 : u32;
-            v382 = arith.shr v380, v973 : u32;
+            v382 = arith.shr v380, v974 : u32;
             v383 = hir.bitcast v382 : i32;
             v384 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_inputs(v383) : i32
-            v979 = arith.constant 8 : u32;
+            v980 = arith.constant 8 : u32;
             v385 = hir.bitcast v347 : u32;
-            v387 = arith.add v385, v979 : u32 #[overflow = checked];
-            v978 = arith.constant 4 : u32;
-            v389 = arith.mod v387, v978 : u32;
+            v387 = arith.add v385, v980 : u32 #[overflow = checked];
+            v979 = arith.constant 4 : u32;
+            v389 = arith.mod v387, v979 : u32;
             hir.assertz v389 #[code = 250];
             v390 = hir.int_to_ptr v387 : ptr<byte, i32>;
             hir.store v390, v384;
-            v977 = arith.constant 4 : u32;
+            v978 = arith.constant 4 : u32;
             v391 = hir.bitcast v347 : u32;
-            v393 = arith.add v391, v977 : u32 #[overflow = checked];
-            v976 = arith.constant 4 : u32;
-            v395 = arith.mod v393, v976 : u32;
+            v393 = arith.add v391, v978 : u32 #[overflow = checked];
+            v977 = arith.constant 4 : u32;
+            v395 = arith.mod v393, v977 : u32;
             hir.assertz v395 #[code = 250];
             v396 = hir.int_to_ptr v393 : ptr<byte, i32>;
             hir.store v396, v378;
             v397 = hir.bitcast v347 : u32;
-            v975 = arith.constant 4 : u32;
-            v399 = arith.mod v397, v975 : u32;
+            v976 = arith.constant 4 : u32;
+            v399 = arith.mod v397, v976 : u32;
             hir.assertz v399 #[code = 250];
             v400 = hir.int_to_ptr v397 : ptr<byte, i32>;
             hir.store v400, v371;
-            v974 = arith.constant 16 : i32;
-            v402 = arith.add v353, v974 : i32 #[overflow = wrapping];
+            v975 = arith.constant 16 : i32;
+            v402 = arith.add v353, v975 : i32 #[overflow = wrapping];
             v403 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v404 = hir.bitcast v403 : ptr<byte, i32>;
             hir.store v404, v402;
@@ -602,40 +602,40 @@ builtin.component miden:base/note-script@1.0.0 {
             v431 = arith.constant 12 : u32;
             v430 = hir.bitcast v411 : u32;
             v432 = arith.add v430, v431 : u32 #[overflow = checked];
-            v988 = arith.constant 4 : u32;
-            v434 = arith.mod v432, v988 : u32;
+            v989 = arith.constant 4 : u32;
+            v434 = arith.mod v432, v989 : u32;
             hir.assertz v434 #[code = 250];
             v435 = hir.int_to_ptr v432 : ptr<byte, i32>;
             v436 = hir.load v435 : i32;
-            v981 = arith.constant 2 : u32;
+            v982 = arith.constant 2 : u32;
             v438 = hir.bitcast v436 : u32;
-            v440 = arith.shr v438, v981 : u32;
+            v440 = arith.shr v438, v982 : u32;
             v441 = hir.bitcast v440 : i32;
             v442 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_assets(v441) : i32
-            v987 = arith.constant 8 : u32;
+            v988 = arith.constant 8 : u32;
             v443 = hir.bitcast v405 : u32;
-            v445 = arith.add v443, v987 : u32 #[overflow = checked];
-            v986 = arith.constant 4 : u32;
-            v447 = arith.mod v445, v986 : u32;
+            v445 = arith.add v443, v988 : u32 #[overflow = checked];
+            v987 = arith.constant 4 : u32;
+            v447 = arith.mod v445, v987 : u32;
             hir.assertz v447 #[code = 250];
             v448 = hir.int_to_ptr v445 : ptr<byte, i32>;
             hir.store v448, v442;
-            v985 = arith.constant 4 : u32;
+            v986 = arith.constant 4 : u32;
             v449 = hir.bitcast v405 : u32;
-            v451 = arith.add v449, v985 : u32 #[overflow = checked];
-            v984 = arith.constant 4 : u32;
-            v453 = arith.mod v451, v984 : u32;
+            v451 = arith.add v449, v986 : u32 #[overflow = checked];
+            v985 = arith.constant 4 : u32;
+            v453 = arith.mod v451, v985 : u32;
             hir.assertz v453 #[code = 250];
             v454 = hir.int_to_ptr v451 : ptr<byte, i32>;
             hir.store v454, v436;
             v455 = hir.bitcast v405 : u32;
-            v983 = arith.constant 4 : u32;
-            v457 = arith.mod v455, v983 : u32;
+            v984 = arith.constant 4 : u32;
+            v457 = arith.mod v455, v984 : u32;
             hir.assertz v457 #[code = 250];
             v458 = hir.int_to_ptr v455 : ptr<byte, i32>;
             hir.store v458, v429;
-            v982 = arith.constant 16 : i32;
-            v460 = arith.add v411, v982 : i32 #[overflow = wrapping];
+            v983 = arith.constant 16 : i32;
+            v460 = arith.add v411, v983 : i32 #[overflow = wrapping];
             v461 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v462 = hir.bitcast v461 : ptr<byte, i32>;
             hir.store v462, v460;
@@ -663,38 +663,38 @@ builtin.component miden:base/note-script@1.0.0 {
             hir.assertz v480 #[code = 250];
             v481 = hir.int_to_ptr v478 : ptr<byte, i32>;
             v482 = hir.load v481 : i32;
-            v995 = arith.constant 0 : i32;
+            v996 = arith.constant 0 : i32;
             v466 = arith.constant 0 : i32;
             v484 = arith.eq v482, v466 : i1;
             v485 = arith.zext v484 : u32;
             v486 = hir.bitcast v485 : i32;
-            v488 = arith.neq v486, v995 : i1;
+            v488 = arith.neq v486, v996 : i1;
             scf.if v488{
             ^block129:
                 scf.yield ;
             } else {
             ^block67:
-                v994 = arith.constant 4 : u32;
+                v995 = arith.constant 4 : u32;
                 v489 = hir.bitcast v471 : u32;
-                v491 = arith.add v489, v994 : u32 #[overflow = checked];
-                v993 = arith.constant 4 : u32;
-                v493 = arith.mod v491, v993 : u32;
+                v491 = arith.add v489, v995 : u32 #[overflow = checked];
+                v994 = arith.constant 4 : u32;
+                v493 = arith.mod v491, v994 : u32;
                 hir.assertz v493 #[code = 250];
                 v494 = hir.int_to_ptr v491 : ptr<byte, i32>;
                 v495 = hir.load v494 : i32;
                 v497 = arith.constant 12 : u32;
                 v496 = hir.bitcast v471 : u32;
                 v498 = arith.add v496, v497 : u32 #[overflow = checked];
-                v992 = arith.constant 4 : u32;
-                v500 = arith.mod v498, v992 : u32;
+                v993 = arith.constant 4 : u32;
+                v500 = arith.mod v498, v993 : u32;
                 hir.assertz v500 #[code = 250];
                 v501 = hir.int_to_ptr v498 : ptr<byte, i32>;
                 v502 = hir.load v501 : i32;
                 hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v495, v482, v502)
                 scf.yield ;
             };
-            v991 = arith.constant 16 : i32;
-            v505 = arith.add v471, v991 : i32 #[overflow = wrapping];
+            v992 = arith.constant 16 : i32;
+            v505 = arith.add v471, v992 : i32 #[overflow = wrapping];
             v506 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v507 = hir.bitcast v506 : ptr<byte, i32>;
             hir.store v507, v505;
@@ -724,23 +724,23 @@ builtin.component miden:base/note-script@1.0.0 {
             v529 = arith.zext v528 : u64;
             v530 = hir.bitcast v529 : i64;
             v534 = arith.mul v530, v533 : i64 #[overflow = wrapping];
-            v1099 = arith.constant 0 : i32;
+            v1100 = arith.constant 0 : i32;
             v535 = arith.constant 32 : i64;
             v537 = hir.cast v535 : u32;
             v536 = hir.bitcast v534 : u64;
             v538 = arith.shr v536, v537 : u64;
             v539 = hir.bitcast v538 : i64;
             v540 = arith.trunc v539 : i32;
-            v542 = arith.neq v540, v1099 : i1;
-            v1011, v1012, v1013, v1014, v1015, v1016 = scf.if v542 : i32, i32, i32, i32, i32, u32 {
+            v542 = arith.neq v540, v1100 : i1;
+            v1012, v1013, v1014, v1015, v1016, v1017 = scf.if v542 : i32, i32, i32, i32, i32, u32 {
             ^block131:
-                v996 = arith.constant 0 : u32;
-                v1003 = ub.poison i32 : i32;
-                scf.yield v508, v519, v1003, v1003, v1003, v996;
+                v997 = arith.constant 0 : u32;
+                v1004 = ub.poison i32 : i32;
+                scf.yield v508, v519, v1004, v1004, v1004, v997;
             } else {
             ^block73:
                 v543 = arith.trunc v534 : i32;
-                v1098 = arith.constant 0 : i32;
+                v1099 = arith.constant 0 : i32;
                 v544 = arith.constant -2147483648 : i32;
                 v545 = arith.sub v544, v511 : i32 #[overflow = wrapping];
                 v547 = hir.bitcast v545 : u32;
@@ -748,16 +748,16 @@ builtin.component miden:base/note-script@1.0.0 {
                 v548 = arith.lte v546, v547 : i1;
                 v549 = arith.zext v548 : u32;
                 v550 = hir.bitcast v549 : i32;
-                v552 = arith.neq v550, v1098 : i1;
-                v1059 = scf.if v552 : i32 {
+                v552 = arith.neq v550, v1099 : i1;
+                v1060 = scf.if v552 : i32 {
                 ^block71:
-                    v1097 = arith.constant 0 : i32;
-                    v563 = arith.neq v543, v1097 : i1;
-                    v1058 = scf.if v563 : i32 {
+                    v1098 = arith.constant 0 : i32;
+                    v563 = arith.neq v543, v1098 : i1;
+                    v1059 = scf.if v563 : i32 {
                     ^block75:
-                        v1096 = arith.constant 0 : i32;
-                        v579 = arith.neq v510, v1096 : i1;
-                        v1057 = scf.if v579 : i32 {
+                        v1097 = arith.constant 0 : i32;
+                        v579 = arith.neq v510, v1097 : i1;
+                        v1058 = scf.if v579 : i32 {
                         ^block78:
                             v561 = arith.constant 1 : i32;
                             hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v519, v511, v543, v561)
@@ -776,130 +776,130 @@ builtin.component miden:base/note-script@1.0.0 {
                             v565 = arith.constant 8 : u32;
                             v582 = hir.bitcast v519 : u32;
                             v584 = arith.add v582, v565 : u32 #[overflow = checked];
-                            v1095 = arith.constant 4 : u32;
-                            v586 = arith.mod v584, v1095 : u32;
+                            v1096 = arith.constant 4 : u32;
+                            v586 = arith.mod v584, v1096 : u32;
                             hir.assertz v586 #[code = 250];
                             v587 = hir.int_to_ptr v584 : ptr<byte, i32>;
                             v588 = hir.load v587 : i32;
                             scf.yield v588;
                         };
-                        v1093 = arith.constant 0 : i32;
                         v1094 = arith.constant 0 : i32;
-                        v597 = arith.eq v1057, v1094 : i1;
+                        v1095 = arith.constant 0 : i32;
+                        v597 = arith.eq v1058, v1095 : i1;
                         v598 = arith.zext v597 : u32;
                         v599 = hir.bitcast v598 : i32;
-                        v601 = arith.neq v599, v1093 : i1;
+                        v601 = arith.neq v599, v1094 : i1;
                         scf.if v601{
                         ^block80:
-                            v1092 = arith.constant 8 : u32;
+                            v1093 = arith.constant 8 : u32;
                             v618 = hir.bitcast v508 : u32;
-                            v620 = arith.add v618, v1092 : u32 #[overflow = checked];
-                            v1091 = arith.constant 4 : u32;
-                            v622 = arith.mod v620, v1091 : u32;
+                            v620 = arith.add v618, v1093 : u32 #[overflow = checked];
+                            v1092 = arith.constant 4 : u32;
+                            v622 = arith.mod v620, v1092 : u32;
                             hir.assertz v622 #[code = 250];
                             v623 = hir.int_to_ptr v620 : ptr<byte, i32>;
                             hir.store v623, v543;
-                            v1090 = arith.constant 4 : u32;
+                            v1091 = arith.constant 4 : u32;
                             v625 = hir.bitcast v508 : u32;
-                            v627 = arith.add v625, v1090 : u32 #[overflow = checked];
-                            v1089 = arith.constant 4 : u32;
-                            v629 = arith.mod v627, v1089 : u32;
+                            v627 = arith.add v625, v1091 : u32 #[overflow = checked];
+                            v1090 = arith.constant 4 : u32;
+                            v629 = arith.mod v627, v1090 : u32;
                             hir.assertz v629 #[code = 250];
                             v630 = hir.int_to_ptr v627 : ptr<byte, i32>;
                             hir.store v630, v511;
                             scf.yield ;
                         } else {
                         ^block81:
-                            v1088 = arith.constant 8 : u32;
+                            v1089 = arith.constant 8 : u32;
                             v603 = hir.bitcast v508 : u32;
-                            v605 = arith.add v603, v1088 : u32 #[overflow = checked];
-                            v1087 = arith.constant 4 : u32;
-                            v607 = arith.mod v605, v1087 : u32;
+                            v605 = arith.add v603, v1089 : u32 #[overflow = checked];
+                            v1088 = arith.constant 4 : u32;
+                            v607 = arith.mod v605, v1088 : u32;
                             hir.assertz v607 #[code = 250];
                             v608 = hir.int_to_ptr v605 : ptr<byte, i32>;
-                            hir.store v608, v1057;
-                            v1086 = arith.constant 4 : u32;
+                            hir.store v608, v1058;
+                            v1087 = arith.constant 4 : u32;
                             v610 = hir.bitcast v508 : u32;
-                            v612 = arith.add v610, v1086 : u32 #[overflow = checked];
-                            v1085 = arith.constant 4 : u32;
-                            v614 = arith.mod v612, v1085 : u32;
+                            v612 = arith.add v610, v1087 : u32 #[overflow = checked];
+                            v1086 = arith.constant 4 : u32;
+                            v614 = arith.mod v612, v1086 : u32;
                             hir.assertz v614 #[code = 250];
                             v615 = hir.int_to_ptr v612 : ptr<byte, i32>;
                             hir.store v615, v509;
                             scf.yield ;
                         };
-                        v1083 = arith.constant 0 : i32;
-                        v1084 = arith.constant 1 : i32;
-                        v1056 = cf.select v601, v1084, v1083 : i32;
-                        scf.yield v1056;
+                        v1084 = arith.constant 0 : i32;
+                        v1085 = arith.constant 1 : i32;
+                        v1057 = cf.select v601, v1085, v1084 : i32;
+                        scf.yield v1057;
                     } else {
                     ^block76:
-                        v1082 = arith.constant 8 : u32;
+                        v1083 = arith.constant 8 : u32;
                         v564 = hir.bitcast v508 : u32;
-                        v566 = arith.add v564, v1082 : u32 #[overflow = checked];
-                        v1081 = arith.constant 4 : u32;
-                        v568 = arith.mod v566, v1081 : u32;
+                        v566 = arith.add v564, v1083 : u32 #[overflow = checked];
+                        v1082 = arith.constant 4 : u32;
+                        v568 = arith.mod v566, v1082 : u32;
                         hir.assertz v568 #[code = 250];
                         v569 = hir.int_to_ptr v566 : ptr<byte, i32>;
                         hir.store v569, v511;
-                        v1080 = arith.constant 4 : u32;
+                        v1081 = arith.constant 4 : u32;
                         v572 = hir.bitcast v508 : u32;
-                        v574 = arith.add v572, v1080 : u32 #[overflow = checked];
-                        v1079 = arith.constant 4 : u32;
-                        v576 = arith.mod v574, v1079 : u32;
+                        v574 = arith.add v572, v1081 : u32 #[overflow = checked];
+                        v1080 = arith.constant 4 : u32;
+                        v576 = arith.mod v574, v1080 : u32;
                         hir.assertz v576 #[code = 250];
-                        v1078 = arith.constant 0 : i32;
+                        v1079 = arith.constant 0 : i32;
                         v577 = hir.int_to_ptr v574 : ptr<byte, i32>;
-                        hir.store v577, v1078;
-                        v1077 = arith.constant 0 : i32;
-                        scf.yield v1077;
+                        hir.store v577, v1079;
+                        v1078 = arith.constant 0 : i32;
+                        scf.yield v1078;
                     };
-                    scf.yield v1058;
+                    scf.yield v1059;
                 } else {
                 ^block74:
-                    v1076 = ub.poison i32 : i32;
-                    scf.yield v1076;
+                    v1077 = ub.poison i32 : i32;
+                    scf.yield v1077;
                 };
-                v1071 = arith.constant 0 : u32;
-                v1004 = arith.constant 1 : u32;
-                v1064 = cf.select v552, v1004, v1071 : u32;
-                v1072 = ub.poison i32 : i32;
-                v1063 = cf.select v552, v519, v1072 : i32;
+                v1072 = arith.constant 0 : u32;
+                v1005 = arith.constant 1 : u32;
+                v1065 = cf.select v552, v1005, v1072 : u32;
                 v1073 = ub.poison i32 : i32;
-                v1062 = cf.select v552, v508, v1073 : i32;
+                v1064 = cf.select v552, v519, v1073 : i32;
                 v1074 = ub.poison i32 : i32;
-                v1061 = cf.select v552, v1074, v519 : i32;
+                v1063 = cf.select v552, v508, v1074 : i32;
                 v1075 = ub.poison i32 : i32;
-                v1060 = cf.select v552, v1075, v508 : i32;
-                scf.yield v1060, v1061, v1062, v1059, v1063, v1064;
+                v1062 = cf.select v552, v1075, v519 : i32;
+                v1076 = ub.poison i32 : i32;
+                v1061 = cf.select v552, v1076, v508 : i32;
+                scf.yield v1061, v1062, v1063, v1060, v1064, v1065;
             };
-            v1017, v1018, v1019 = scf.index_switch v1016 : i32, i32, i32 
+            v1018, v1019, v1020 = scf.index_switch v1017 : i32, i32, i32 
             case 0 {
             ^block72:
+                v1071 = arith.constant 4 : u32;
+                v555 = hir.bitcast v1012 : u32;
+                v557 = arith.add v555, v1071 : u32 #[overflow = checked];
                 v1070 = arith.constant 4 : u32;
-                v555 = hir.bitcast v1011 : u32;
-                v557 = arith.add v555, v1070 : u32 #[overflow = checked];
-                v1069 = arith.constant 4 : u32;
-                v559 = arith.mod v557, v1069 : u32;
+                v559 = arith.mod v557, v1070 : u32;
                 hir.assertz v559 #[code = 250];
-                v1068 = arith.constant 0 : i32;
+                v1069 = arith.constant 0 : i32;
                 v560 = hir.int_to_ptr v557 : ptr<byte, i32>;
-                hir.store v560, v1068;
-                v1067 = arith.constant 1 : i32;
-                scf.yield v1011, v1067, v1012;
+                hir.store v560, v1069;
+                v1068 = arith.constant 1 : i32;
+                scf.yield v1012, v1068, v1013;
             }
             default {
             ^block135:
-                scf.yield v1013, v1014, v1015;
+                scf.yield v1014, v1015, v1016;
             };
-            v634 = hir.bitcast v1017 : u32;
-            v1066 = arith.constant 4 : u32;
-            v636 = arith.mod v634, v1066 : u32;
+            v634 = hir.bitcast v1018 : u32;
+            v1067 = arith.constant 4 : u32;
+            v636 = arith.mod v634, v1067 : u32;
             hir.assertz v636 #[code = 250];
             v637 = hir.int_to_ptr v634 : ptr<byte, i32>;
-            hir.store v637, v1018;
-            v1065 = arith.constant 16 : i32;
-            v642 = arith.add v1019, v1065 : i32 #[overflow = wrapping];
+            hir.store v637, v1019;
+            v1066 = arith.constant 16 : i32;
+            v642 = arith.add v1020, v1066 : i32 #[overflow = wrapping];
             v643 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v644 = hir.bitcast v643 : ptr<byte, i32>;
             hir.store v644, v642;
@@ -931,27 +931,27 @@ builtin.component miden:base/note-script@1.0.0 {
             v667 = arith.constant 8 : u32;
             v666 = hir.bitcast v653 : u32;
             v668 = arith.add v666, v667 : u32 #[overflow = checked];
-            v1104 = arith.constant 4 : u32;
-            v670 = arith.mod v668, v1104 : u32;
+            v1105 = arith.constant 4 : u32;
+            v670 = arith.mod v668, v1105 : u32;
             hir.assertz v670 #[code = 250];
             v671 = hir.int_to_ptr v668 : ptr<byte, i32>;
             v672 = hir.load v671 : i32;
             v673 = hir.bitcast v645 : u32;
-            v1103 = arith.constant 4 : u32;
-            v675 = arith.mod v673, v1103 : u32;
+            v1104 = arith.constant 4 : u32;
+            v675 = arith.mod v673, v1104 : u32;
             hir.assertz v675 #[code = 250];
             v676 = hir.int_to_ptr v673 : ptr<byte, i32>;
             hir.store v676, v672;
-            v1102 = arith.constant 4 : u32;
+            v1103 = arith.constant 4 : u32;
             v677 = hir.bitcast v645 : u32;
-            v679 = arith.add v677, v1102 : u32 #[overflow = checked];
-            v1101 = arith.constant 4 : u32;
-            v681 = arith.mod v679, v1101 : u32;
+            v679 = arith.add v677, v1103 : u32 #[overflow = checked];
+            v1102 = arith.constant 4 : u32;
+            v681 = arith.mod v679, v1102 : u32;
             hir.assertz v681 #[code = 250];
             v682 = hir.int_to_ptr v679 : ptr<byte, i32>;
             hir.store v682, v665;
-            v1100 = arith.constant 16 : i32;
-            v684 = arith.add v653, v1100 : i32 #[overflow = wrapping];
+            v1101 = arith.constant 16 : i32;
+            v684 = arith.add v653, v1101 : i32 #[overflow = wrapping];
             v685 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v686 = hir.bitcast v685 : ptr<byte, i32>;
             hir.store v686, v684;
@@ -960,20 +960,20 @@ builtin.component miden:base/note-script@1.0.0 {
 
         private builtin.function @alloc::alloc::Global::alloc_impl(v687: i32, v688: i32, v689: i32, v690: i32) {
         ^block84(v687: i32, v688: i32, v689: i32, v690: i32):
-            v1120 = arith.constant 0 : i32;
+            v1121 = arith.constant 0 : i32;
             v691 = arith.constant 0 : i32;
             v692 = arith.eq v689, v691 : i1;
             v693 = arith.zext v692 : u32;
             v694 = hir.bitcast v693 : i32;
-            v696 = arith.neq v694, v1120 : i1;
-            v1116 = scf.if v696 : i32 {
+            v696 = arith.neq v694, v1121 : i1;
+            v1117 = scf.if v696 : i32 {
             ^block138:
                 scf.yield v688;
             } else {
             ^block87:
-                v1119 = arith.constant 0 : i32;
-                v705 = arith.neq v690, v1119 : i1;
-                v1115 = scf.if v705 : i32 {
+                v1120 = arith.constant 0 : i32;
+                v705 = arith.neq v690, v1120 : i1;
+                v1116 = scf.if v705 : i32 {
                 ^block88:
                     v707 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v689, v688) : i32
                     scf.yield v707;
@@ -982,38 +982,38 @@ builtin.component miden:base/note-script@1.0.0 {
                     v706 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v689, v688) : i32
                     scf.yield v706;
                 };
-                scf.yield v1115;
+                scf.yield v1116;
             };
             v711 = arith.constant 4 : u32;
             v710 = hir.bitcast v687 : u32;
             v712 = arith.add v710, v711 : u32 #[overflow = checked];
-            v1118 = arith.constant 4 : u32;
-            v714 = arith.mod v712, v1118 : u32;
+            v1119 = arith.constant 4 : u32;
+            v714 = arith.mod v712, v1119 : u32;
             hir.assertz v714 #[code = 250];
             v715 = hir.int_to_ptr v712 : ptr<byte, i32>;
             hir.store v715, v689;
             v717 = hir.bitcast v687 : u32;
-            v1117 = arith.constant 4 : u32;
-            v719 = arith.mod v717, v1117 : u32;
+            v1118 = arith.constant 4 : u32;
+            v719 = arith.mod v717, v1118 : u32;
             hir.assertz v719 #[code = 250];
             v720 = hir.int_to_ptr v717 : ptr<byte, i32>;
-            hir.store v720, v1116;
+            hir.store v720, v1117;
             builtin.ret ;
         };
 
         private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v721: i32, v722: i32, v723: i32, v724: i32) {
         ^block90(v721: i32, v722: i32, v723: i32, v724: i32):
-            v1146 = arith.constant 0 : i32;
+            v1147 = arith.constant 0 : i32;
             v725 = arith.constant 0 : i32;
             v729 = arith.eq v724, v725 : i1;
             v730 = arith.zext v729 : u32;
             v731 = hir.bitcast v730 : i32;
-            v733 = arith.neq v731, v1146 : i1;
-            v1133, v1134 = scf.if v733 : i32, i32 {
+            v733 = arith.neq v731, v1147 : i1;
+            v1134, v1135 = scf.if v733 : i32, i32 {
             ^block142:
-                v1145 = arith.constant 0 : i32;
+                v1146 = arith.constant 0 : i32;
                 v727 = arith.constant 4 : i32;
-                scf.yield v727, v1145;
+                scf.yield v727, v1146;
             } else {
             ^block93:
                 v734 = hir.bitcast v722 : u32;
@@ -1022,37 +1022,37 @@ builtin.component miden:base/note-script@1.0.0 {
                 hir.assertz v736 #[code = 250];
                 v737 = hir.int_to_ptr v734 : ptr<byte, i32>;
                 v738 = hir.load v737 : i32;
-                v1143 = arith.constant 0 : i32;
                 v1144 = arith.constant 0 : i32;
-                v740 = arith.eq v738, v1144 : i1;
+                v1145 = arith.constant 0 : i32;
+                v740 = arith.eq v738, v1145 : i1;
                 v741 = arith.zext v740 : u32;
                 v742 = hir.bitcast v741 : i32;
-                v744 = arith.neq v742, v1143 : i1;
-                v1131 = scf.if v744 : i32 {
+                v744 = arith.neq v742, v1144 : i1;
+                v1132 = scf.if v744 : i32 {
                 ^block141:
-                    v1142 = arith.constant 0 : i32;
-                    scf.yield v1142;
+                    v1143 = arith.constant 0 : i32;
+                    scf.yield v1143;
                 } else {
                 ^block94:
-                    v1141 = arith.constant 4 : u32;
+                    v1142 = arith.constant 4 : u32;
                     v745 = hir.bitcast v721 : u32;
-                    v747 = arith.add v745, v1141 : u32 #[overflow = checked];
-                    v1140 = arith.constant 4 : u32;
-                    v749 = arith.mod v747, v1140 : u32;
+                    v747 = arith.add v745, v1142 : u32 #[overflow = checked];
+                    v1141 = arith.constant 4 : u32;
+                    v749 = arith.mod v747, v1141 : u32;
                     hir.assertz v749 #[code = 250];
                     v750 = hir.int_to_ptr v747 : ptr<byte, i32>;
                     hir.store v750, v723;
-                    v1139 = arith.constant 4 : u32;
+                    v1140 = arith.constant 4 : u32;
                     v751 = hir.bitcast v722 : u32;
-                    v753 = arith.add v751, v1139 : u32 #[overflow = checked];
-                    v1138 = arith.constant 4 : u32;
-                    v755 = arith.mod v753, v1138 : u32;
+                    v753 = arith.add v751, v1140 : u32 #[overflow = checked];
+                    v1139 = arith.constant 4 : u32;
+                    v755 = arith.mod v753, v1139 : u32;
                     hir.assertz v755 #[code = 250];
                     v756 = hir.int_to_ptr v753 : ptr<byte, i32>;
                     v757 = hir.load v756 : i32;
                     v758 = hir.bitcast v721 : u32;
-                    v1137 = arith.constant 4 : u32;
-                    v760 = arith.mod v758, v1137 : u32;
+                    v1138 = arith.constant 4 : u32;
+                    v760 = arith.mod v758, v1138 : u32;
                     hir.assertz v760 #[code = 250];
                     v761 = hir.int_to_ptr v758 : ptr<byte, i32>;
                     hir.store v761, v757;
@@ -1060,28 +1060,28 @@ builtin.component miden:base/note-script@1.0.0 {
                     scf.yield v762;
                 };
                 v763 = arith.constant 8 : i32;
-                v1136 = arith.constant 4 : i32;
-                v1132 = cf.select v744, v1136, v763 : i32;
-                scf.yield v1132, v1131;
+                v1137 = arith.constant 4 : i32;
+                v1133 = cf.select v744, v1137, v763 : i32;
+                scf.yield v1133, v1132;
             };
-            v766 = arith.add v721, v1133 : i32 #[overflow = wrapping];
+            v766 = arith.add v721, v1134 : i32 #[overflow = wrapping];
             v768 = hir.bitcast v766 : u32;
-            v1135 = arith.constant 4 : u32;
-            v770 = arith.mod v768, v1135 : u32;
+            v1136 = arith.constant 4 : u32;
+            v770 = arith.mod v768, v1136 : u32;
             hir.assertz v770 #[code = 250];
             v771 = hir.int_to_ptr v768 : ptr<byte, i32>;
-            hir.store v771, v1134;
+            hir.store v771, v1135;
             builtin.ret ;
         };
 
         private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v772: i32, v773: i32, v774: i32) {
         ^block95(v772: i32, v773: i32, v774: i32):
-            v1148 = arith.constant 0 : i32;
+            v1149 = arith.constant 0 : i32;
             v775 = arith.constant 0 : i32;
             v776 = arith.eq v774, v775 : i1;
             v777 = arith.zext v776 : u32;
             v778 = hir.bitcast v777 : i32;
-            v780 = arith.neq v778, v1148 : i1;
+            v780 = arith.neq v778, v1149 : i1;
             scf.if v780{
             ^block97:
                 scf.yield ;

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -642,9 +642,9 @@ proc.wit_bindgen_rt::run_ctors_once
 end
 
 proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
-    push.32
+    push.16
     push.0
-    push.32
+    push.16
     dup.4
     swap.1
     u32gt

--- a/tests/integration/expected/examples/p2id.wat
+++ b/tests/integration/expected/examples/p2id.wat
@@ -218,9 +218,9 @@
       (local i32 i32)
       block ;; label = @1
         local.get 1
-        i32.const 32
+        i32.const 16
         local.get 1
-        i32.const 32
+        i32.const 16
         i32.gt_u
         select
         local.tee 3

--- a/tests/integration/expected/mem_intrinsics_heap_base.hir
+++ b/tests/integration/expected/mem_intrinsics_heap_base.hir
@@ -56,20 +56,20 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v47: i32, v48: i32, v49: i32) -> i32 {
         ^block12(v47: i32, v48: i32, v49: i32):
-            v52 = arith.constant 32 : i32;
+            v52 = arith.constant 16 : i32;
             v51 = arith.constant 0 : i32;
-            v149 = arith.constant 32 : u32;
+            v149 = arith.constant 16 : u32;
             v54 = hir.bitcast v48 : u32;
             v56 = arith.gt v54, v149 : i1;
             v57 = arith.zext v56 : u32;
             v58 = hir.bitcast v57 : i32;
             v60 = arith.neq v58, v51 : i1;
             v61 = cf.select v60, v48, v52 : i32;
-            v187 = arith.constant 0 : i32;
+            v188 = arith.constant 0 : i32;
             v62 = arith.constant -1 : i32;
             v63 = arith.add v61, v62 : i32 #[overflow = wrapping];
             v64 = arith.band v61, v63 : i32;
-            v66 = arith.neq v64, v187 : i1;
+            v66 = arith.neq v64, v188 : i1;
             v158, v159 = scf.if v66 : i32, u32 {
             ^block29:
                 v150 = arith.constant 0 : u32;
@@ -78,7 +78,7 @@ builtin.component root_ns:root@1.0.0 {
             } else {
             ^block15:
                 v68 = hir.exec @root_ns:root@1.0.0/mem_intrinsics_heap_base/core::ptr::alignment::Alignment::max(v48, v61) : i32
-                v186 = arith.constant 0 : i32;
+                v187 = arith.constant 0 : i32;
                 v67 = arith.constant -2147483648 : i32;
                 v69 = arith.sub v67, v68 : i32 #[overflow = wrapping];
                 v71 = hir.bitcast v69 : u32;
@@ -86,18 +86,18 @@ builtin.component root_ns:root@1.0.0 {
                 v72 = arith.gt v70, v71 : i1;
                 v73 = arith.zext v72 : u32;
                 v74 = hir.bitcast v73 : i32;
-                v76 = arith.neq v74, v186 : i1;
+                v76 = arith.neq v74, v187 : i1;
                 v173 = scf.if v76 : i32 {
                 ^block28:
-                    v185 = ub.poison i32 : i32;
-                    scf.yield v185;
+                    v186 = ub.poison i32 : i32;
+                    scf.yield v186;
                 } else {
                 ^block16:
-                    v183 = arith.constant 0 : i32;
-                    v82 = arith.sub v183, v68 : i32 #[overflow = wrapping];
-                    v184 = arith.constant -1 : i32;
+                    v184 = arith.constant 0 : i32;
+                    v82 = arith.sub v184, v68 : i32 #[overflow = wrapping];
+                    v185 = arith.constant -1 : i32;
                     v78 = arith.add v49, v68 : i32 #[overflow = wrapping];
-                    v80 = arith.add v78, v184 : i32 #[overflow = wrapping];
+                    v80 = arith.add v78, v185 : i32 #[overflow = wrapping];
                     v83 = arith.band v80, v82 : i32;
                     v84 = hir.bitcast v47 : u32;
                     v85 = arith.constant 4 : u32;
@@ -105,8 +105,8 @@ builtin.component root_ns:root@1.0.0 {
                     hir.assertz v86 #[code = 250];
                     v87 = hir.int_to_ptr v84 : ptr<byte, i32>;
                     v88 = hir.load v87 : i32;
-                    v182 = arith.constant 0 : i32;
-                    v90 = arith.neq v88, v182 : i1;
+                    v183 = arith.constant 0 : i32;
+                    v90 = arith.neq v88, v183 : i1;
                     scf.if v90{
                     ^block27:
                         scf.yield ;
@@ -115,12 +115,12 @@ builtin.component root_ns:root@1.0.0 {
                         v91 = hir.exec @intrinsics/mem/heap_base() : i32
                         v92 = hir.mem_size  : u32;
                         v98 = hir.bitcast v47 : u32;
-                        v181 = arith.constant 4 : u32;
-                        v100 = arith.mod v98, v181 : u32;
+                        v182 = arith.constant 4 : u32;
+                        v100 = arith.mod v98, v182 : u32;
                         hir.assertz v100 #[code = 250];
-                        v148 = arith.constant 16 : u32;
+                        v181 = arith.constant 16 : u32;
                         v93 = hir.bitcast v92 : i32;
-                        v96 = arith.shl v93, v148 : i32;
+                        v96 = arith.shl v93, v181 : i32;
                         v97 = arith.add v91, v96 : i32 #[overflow = wrapping];
                         v101 = hir.int_to_ptr v98 : ptr<byte, i32>;
                         hir.store v101, v97;

--- a/tests/integration/expected/mem_intrinsics_heap_base.wat
+++ b/tests/integration/expected/mem_intrinsics_heap_base.wat
@@ -50,9 +50,9 @@
     (local i32 i32)
     block ;; label = @1
       local.get 1
-      i32.const 32
+      i32.const 16
       local.get 1
-      i32.const 32
+      i32.const 16
       i32.gt_u
       select
       local.tee 3


### PR DESCRIPTION
Close #550 