### PR TITLE
feature: add `cargo miden example`, clean up `new` project templates

### DIFF
--- a/docs/src/usage/cargo-miden.md
+++ b/docs/src/usage/cargo-miden.md
@@ -34,6 +34,32 @@ This will take a minute to compile, but once complete, you can run `cargo help m
 
 To get help for a specific command, use `cargo miden help <command>` or `cargo miden <command> --help`.
 
+## Creating an example project
+
+If you're new to Miden and want to explore some example projects, you can use the `cargo miden example` command to create a project from one of our templates:
+
+```bash
+cargo miden example <example-name>
+```
+
+To see the list of available examples, run:
+
+```bash
+cargo miden example --help
+```
+
+Available examples include:
+- **basic-wallet** - A basic wallet account implementation (creates both the wallet and a paired p2id-note)
+- **p2id-note** - A pay-to-ID note script (creates both the note and a paired basic-wallet)
+- **counter-contract** - A simple counter contract (creates both the contract and a paired counter-note)
+- **counter-note** - A note script for interacting with the counter contract (creates both the note and paired counter-contract)
+- **fibonacci** - A Fibonacci sequence calculator demonstrating basic computations
+- **collatz** - An implementation of the Collatz conjecture
+- **is-prime** - A prime number checker
+- **storage-example** - Demonstrates storage operations in Miden
+
+Note that some examples create paired projects. For instance, running `cargo miden example basic-wallet` will create a directory containing both the `basic-wallet` account and the `p2id-note` script that interacts with it.
+
 ## Creating a new project
 
 Your first step will be to create a new Rust project set up for compiling to Miden:

--- a/tools/cargo-miden/src/commands/example_project.rs
+++ b/tools/cargo-miden/src/commands/example_project.rs
@@ -14,8 +14,16 @@ pub const WIT_DEPS_PATH: &str = "wit-deps";
 #[derive(Args)]
 #[clap(disable_version_flag = true)]
 pub struct ExampleCommand {
-    /// The example name to use from the compiler repository (will also be used as project name)
-    #[clap()]
+    #[clap(help = r#"The example name to use from the compiler repository
+Available examples:
+basic-wallet      : Basic wallet account
+p2id-note         : Pay-to-ID note
+counter-contract  : Counter contract
+counter-note      : Counter note
+fibonacci         : Fibonacci sequence calculator
+collatz           : Collatz conjecture calculator
+is-prime          : Prime number checker
+storage-example   : Storage operations example"#)]
     pub example_name: String,
 }
 

--- a/tools/cargo-miden/src/commands/example_project.rs
+++ b/tools/cargo-miden/src/commands/example_project.rs
@@ -103,6 +103,7 @@ impl ExampleCommand {
         Ok(project_path)
     }
 
+    /// Create a pari (account and note script) projects in a sub-folder
     fn exec_paired_projects(
         &self,
         first_project: &str,
@@ -198,6 +199,9 @@ fn set_default_test_compiler(define: &mut Vec<String>) {
 }
 
 /// Process the generated Cargo.toml to update dependencies and WIT paths
+/// The projects in `example` folder set Miden SDK dependencies as local paths.
+/// After copying we need to change them to be git dependency (Miden SDK crate) and local WIT files
+/// (deployed from the Miden SDK crates by `deploy_wit_files()`)
 fn process_cargo_toml(project_path: &Path) -> anyhow::Result<()> {
     let cargo_toml_path = project_path.join("Cargo.toml");
     let content = fs::read_to_string(&cargo_toml_path)?;
@@ -283,6 +287,8 @@ fn process_cargo_toml(project_path: &Path) -> anyhow::Result<()> {
 }
 
 /// Update note project's dependencies to use local contract
+/// The note script projects in the `example` folder of the compiler repo use a local path to
+/// specify the account Miden package and WIT file dependency.
 fn update_note_dependencies(
     main_dir: &Path,
     note_dir: &str,

--- a/tools/cargo-miden/src/commands/example_project.rs
+++ b/tools/cargo-miden/src/commands/example_project.rs
@@ -23,7 +23,7 @@ pub struct ProjectTemplate {
     /// Rust program
     #[clap(long, group = "template", conflicts_with_all(["account", "note"]))]
     program: bool,
-    /// Miden rollup account
+    /// Miden rollup account (default)
     #[clap(long, group = "template", conflicts_with_all(["program", "note"]))]
     account: bool,
     /// Miden rollup note script
@@ -60,7 +60,7 @@ impl ProjectTemplate {
 
 impl Default for ProjectTemplate {
     fn default() -> Self {
-        Self::program()
+        Self::account()
     }
 }
 
@@ -78,10 +78,10 @@ impl fmt::Display for ProjectTemplate {
     }
 }
 
-/// Create a new clean slate Miden project at <path>
+/// Create a new Miden example project at <path>
 #[derive(Args)]
 #[clap(disable_version_flag = true)]
-pub struct NewCommand {
+pub struct ExampleCommand {
     /// The path for the generated package (the directory name is used for project name)
     #[clap()]
     pub path: PathBuf,
@@ -104,7 +104,7 @@ pub struct NewCommand {
 
 use std::{fs, io::Write};
 
-impl NewCommand {
+impl ExampleCommand {
     pub fn exec(self) -> anyhow::Result<PathBuf> {
         let name = self
             .path
@@ -158,7 +158,7 @@ impl NewCommand {
                 TemplatePath {
                     git: Some("https://github.com/0xMiden/rust-templates".into()),
                     tag: Some(TEMPLATES_REPO_TAG.into()),
-                    auto_path: Some(format!("new/{}", project_kind_str)),
+                    auto_path: Some(format!("example/{}", project_kind_str)),
                     ..Default::default()
                 }
             }

--- a/tools/cargo-miden/src/commands/example_project.rs
+++ b/tools/cargo-miden/src/commands/example_project.rs
@@ -10,7 +10,6 @@ use crate::commands::new_project::deploy_wit_files;
 /// The folder name to put Miden SDK WIT files in
 pub const WIT_DEPS_PATH: &str = "wit-deps";
 
-
 /// Create a new Miden example project
 #[derive(Args)]
 #[clap(disable_version_flag = true)]
@@ -24,10 +23,25 @@ use std::fs;
 
 impl ExampleCommand {
     pub fn exec(self) -> anyhow::Result<PathBuf> {
+        // Check if this is a paired project
+        let paired_projects = match self.example_name.as_str() {
+            "basic-wallet" | "p2id-note" => Some(("basic-wallet", "p2id-note")),
+            "counter-contract" | "counter-note" => Some(("counter-contract", "counter-note")),
+            _ => None,
+        };
+
+        if let Some((first, second)) = paired_projects {
+            self.exec_paired_projects(first, second)
+        } else {
+            self.exec_single_project()
+        }
+    }
+
+    fn exec_single_project(&self) -> anyhow::Result<PathBuf> {
         // Use example name as project name
         let project_name = self.example_name.clone();
         let project_path = PathBuf::from(&project_name);
-        
+
         // Check if directory already exists
         if project_path.exists() {
             return Err(anyhow::anyhow!(
@@ -51,11 +65,9 @@ impl ExampleCommand {
         // Generate in current directory
         let destination = {
             use path_absolutize::Absolutize;
-            std::env::current_dir()?
-                .absolutize()
-                .map(|p| p.to_path_buf())?
+            std::env::current_dir()?.absolutize().map(|p| p.to_path_buf())?
         };
-        
+
         let generate_args = GenerateArgs {
             template_path,
             destination: Some(destination),
@@ -74,25 +86,108 @@ impl ExampleCommand {
         let wit_dir = project_path.join("wit");
         if wit_dir.exists() && wit_dir.is_dir() {
             // Deploy core WIT files to the project
-            deploy_wit_files(&project_path)
-                .context("Failed to deploy WIT files")?;
+            deploy_wit_files(&project_path).context("Failed to deploy WIT files")?;
         }
 
         // Process the Cargo.toml to update dependencies and WIT paths
-        process_cargo_toml(&project_path)
-            .context("Failed to process Cargo.toml")?;
+        process_cargo_toml(&project_path).context("Failed to process Cargo.toml")?;
 
         Ok(project_path)
     }
-}
 
+    fn exec_paired_projects(
+        &self,
+        first_project: &str,
+        second_project: &str,
+    ) -> anyhow::Result<PathBuf> {
+        // Create main directory with the requested example name
+        let main_dir = PathBuf::from(&self.example_name);
+
+        if main_dir.exists() {
+            return Err(anyhow::anyhow!(
+                "Directory '{}' already exists. Please remove it or choose a different location.",
+                self.example_name
+            ));
+        }
+
+        // Create the main directory
+        fs::create_dir_all(&main_dir)?;
+
+        let mut define = vec![];
+        if cfg!(test) || std::env::var("TEST").is_ok() {
+            set_default_test_compiler(&mut define);
+        }
+
+        // Generate both projects
+        let examples = [first_project, second_project];
+        for example in &examples {
+            let template_path = TemplatePath {
+                git: Some("https://github.com/0xMiden/compiler".into()),
+                auto_path: Some(format!("examples/{}", example)),
+                ..Default::default()
+            };
+
+            let destination = {
+                use path_absolutize::Absolutize;
+                main_dir.absolutize().map(|p| p.to_path_buf())?
+            };
+
+            let generate_args = GenerateArgs {
+                template_path,
+                destination: Some(destination),
+                name: Some(example.to_string()),
+                force: true,
+                force_git_init: false, // Don't init git for subdirectories
+                verbose: true,
+                define: define.clone(),
+                ..Default::default()
+            };
+
+            cargo_generate::generate(generate_args)
+                .context(format!("Failed to scaffold {} project", example))?;
+
+            let project_path = main_dir.join(example);
+
+            // Check if the project has WIT files
+            let wit_dir = project_path.join("wit");
+            if wit_dir.exists() && wit_dir.is_dir() {
+                deploy_wit_files(&project_path)
+                    .context(format!("Failed to deploy WIT files for {}", example))?;
+            }
+
+            // Process the Cargo.toml
+            process_cargo_toml(&project_path)
+                .context(format!("Failed to process Cargo.toml for {}", example))?;
+        }
+
+        // Update dependencies for paired projects
+        match (first_project, second_project) {
+            ("basic-wallet", "p2id-note") => update_note_dependencies(
+                &main_dir,
+                "p2id-note",
+                "miden:basic-wallet",
+                "basic-wallet",
+                "basic-wallet.wit",
+            )?,
+            ("counter-contract", "counter-note") => update_note_dependencies(
+                &main_dir,
+                "counter-note",
+                "miden:counter-contract",
+                "counter-contract",
+                "counter.wit",
+            )?,
+            _ => {}
+        }
+
+        Ok(main_dir)
+    }
+}
 
 fn set_default_test_compiler(define: &mut Vec<String>) {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let compiler_path = Path::new(&manifest_dir).parent().unwrap().parent().unwrap();
     define.push(format!("compiler_path={}", compiler_path.display()));
 }
-
 
 /// Process the generated Cargo.toml to update dependencies and WIT paths
 fn process_cargo_toml(project_path: &Path) -> anyhow::Result<()> {
@@ -112,7 +207,8 @@ fn process_cargo_toml(project_path: &Path) -> anyhow::Result<()> {
     }
 
     // Update WIT file paths to use the deployed files
-    if let Some(metadata) = doc.get_mut("package")
+    if let Some(metadata) = doc
+        .get_mut("package")
         .and_then(|p| p.as_table_mut())
         .and_then(|t| t.get_mut("metadata"))
         .and_then(|m| m.as_table_mut())
@@ -129,16 +225,26 @@ fn process_cargo_toml(project_path: &Path) -> anyhow::Result<()> {
                 if let Some(path_value) = table.get_mut("path") {
                     match key.as_ref() {
                         "miden:base" => {
-                            *path_value = toml_edit::Value::from(format!("{}/miden.wit", WIT_DEPS_PATH));
+                            *path_value =
+                                toml_edit::Value::from(format!("{}/miden.wit", WIT_DEPS_PATH));
                         }
                         "miden:core-intrinsics" => {
-                            *path_value = toml_edit::Value::from(format!("{}/miden-core-intrinsics.wit", WIT_DEPS_PATH));
+                            *path_value = toml_edit::Value::from(format!(
+                                "{}/miden-core-intrinsics.wit",
+                                WIT_DEPS_PATH
+                            ));
                         }
                         "miden:core-stdlib" => {
-                            *path_value = toml_edit::Value::from(format!("{}/miden-core-stdlib.wit", WIT_DEPS_PATH));
+                            *path_value = toml_edit::Value::from(format!(
+                                "{}/miden-core-stdlib.wit",
+                                WIT_DEPS_PATH
+                            ));
                         }
                         "miden:core-base" => {
-                            *path_value = toml_edit::Value::from(format!("{}/miden-core-base.wit", WIT_DEPS_PATH));
+                            *path_value = toml_edit::Value::from(format!(
+                                "{}/miden-core-base.wit",
+                                WIT_DEPS_PATH
+                            ));
                         }
                         _ => {
                             // For project-specific WIT files, check if they exist in wit/
@@ -148,7 +254,10 @@ fn process_cargo_toml(project_path: &Path) -> anyhow::Result<()> {
                                     let wit_file = project_path.join("wit").join(file_name);
                                     if wit_file.exists() {
                                         // Update to use the wit/ directory path
-                                        *path_value = toml_edit::Value::from(format!("wit/{}", file_name.to_string_lossy()));
+                                        *path_value = toml_edit::Value::from(format!(
+                                            "wit/{}",
+                                            file_name.to_string_lossy()
+                                        ));
                                     }
                                     // Don't remove anything, just leave other paths as they are
                                 }
@@ -165,3 +274,63 @@ fn process_cargo_toml(project_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Update note project's dependencies to use local contract
+fn update_note_dependencies(
+    main_dir: &Path,
+    note_dir: &str,
+    dependency_name: &str,
+    contract_dir: &str,
+    wit_file_name: &str,
+) -> anyhow::Result<()> {
+    let note_cargo_toml = main_dir.join(note_dir).join("Cargo.toml");
+    let content = fs::read_to_string(&note_cargo_toml)?;
+    let mut doc = content.parse::<DocumentMut>()?;
+
+    // Update miden dependency to use local path
+    if let Some(miden_deps) = doc
+        .get_mut("package")
+        .and_then(|p| p.as_table_mut())
+        .and_then(|t| t.get_mut("metadata"))
+        .and_then(|m| m.as_table_mut())
+        .and_then(|t| t.get_mut("miden"))
+        .and_then(|m| m.as_table_mut())
+        .and_then(|t| t.get_mut("dependencies"))
+        .and_then(|d| d.as_table_mut())
+    {
+        if let Some(dep) = miden_deps.get_mut(dependency_name) {
+            *dep = Item::Value(toml_edit::Value::InlineTable({
+                let mut table = toml_edit::InlineTable::new();
+                table.insert("path", format!("../{}", contract_dir).into());
+                table
+            }));
+        }
+    }
+
+    // Update WIT file dependency to use local contract
+    if let Some(wit_deps) = doc
+        .get_mut("package")
+        .and_then(|p| p.as_table_mut())
+        .and_then(|t| t.get_mut("metadata"))
+        .and_then(|m| m.as_table_mut())
+        .and_then(|t| t.get_mut("component"))
+        .and_then(|c| c.as_table_mut())
+        .and_then(|t| t.get_mut("target"))
+        .and_then(|t| t.as_table_mut())
+        .and_then(|t| t.get_mut("dependencies"))
+        .and_then(|d| d.as_table_mut())
+    {
+        if let Some(wit_dep) = wit_deps.get_mut(dependency_name) {
+            if let Some(table) = wit_dep.as_inline_table_mut() {
+                if let Some(path_value) = table.get_mut("path") {
+                    *path_value = toml_edit::Value::from(format!(
+                        "../{}/wit/{}",
+                        contract_dir, wit_file_name
+                    ));
+                }
+            }
+        }
+    }
+
+    fs::write(&note_cargo_toml, doc.to_string())?;
+    Ok(())
+}

--- a/tools/cargo-miden/src/commands/mod.rs
+++ b/tools/cargo-miden/src/commands/mod.rs
@@ -1,3 +1,5 @@
-mod new_project;
+pub mod example_project;
+pub mod new_project;
 
-pub use new_project::*;
+pub use example_project::ExampleCommand;
+pub use new_project::NewCommand;

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -11,7 +11,7 @@ use clap::Args;
 ///
 /// Before changing it make sure the new tag exists in the rust-templates repo and points to the
 /// desired commit.
-const TEMPLATES_REPO_TAG: &str = "v0.11.1";
+const TEMPLATES_REPO_TAG: &str = "v0.11.5";
 
 /// The folder name to put Miden SDK WIT files in
 pub const WIT_DEPS_PATH: &str = "wit-deps";
@@ -184,13 +184,14 @@ impl NewCommand {
             define,
             ..Default::default()
         };
-        cargo_generate::generate(generate_args)
+        let project_path = cargo_generate::generate(generate_args)
             .context("Failed to scaffold new Miden project from the template")?;
 
-        // Deploy WIT files if creating an account or note script project
-        let project_template = self.template.unwrap_or_default();
-        if project_template.account || project_template.note {
-            deploy_wit_files(&self.path).context("Failed to deploy WIT files to the project")?;
+        // Check if the project has WIT files
+        let wit_dir = project_path.join("wit");
+        if wit_dir.exists() && wit_dir.is_dir() {
+            // Deploy core WIT files to the project
+            deploy_wit_files(&project_path).context("Failed to deploy WIT files")?;
         }
 
         Ok(self.path)

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -198,7 +198,7 @@ impl NewCommand {
 }
 
 /// Deploy WIT files to the project's wit directory
-fn deploy_wit_files(project_path: &Path) -> anyhow::Result<()> {
+pub fn deploy_wit_files(project_path: &Path) -> anyhow::Result<()> {
     // Create wit directory
     let wit_dir = project_path.join(WIT_DEPS_PATH);
     fs::create_dir_all(&wit_dir)?;
@@ -223,7 +223,7 @@ fn deploy_wit_files(project_path: &Path) -> anyhow::Result<()> {
 }
 
 /// Helper function to write a WIT file
-fn write_wit_file(path: &PathBuf, content: &str) -> anyhow::Result<()> {
+pub fn write_wit_file(path: &PathBuf, content: &str) -> anyhow::Result<()> {
     let mut file = fs::File::create(path)?;
     file.write_all(content.as_bytes())?;
     Ok(())

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -11,7 +11,7 @@ use clap::Args;
 ///
 /// Before changing it make sure the new tag exists in the rust-templates repo and points to the
 /// desired commit.
-const TEMPLATES_REPO_TAG: &str = "v0.11.6";
+const TEMPLATES_REPO_TAG: &str = "v0.11.0";
 
 /// The folder name to put Miden SDK WIT files in
 pub const WIT_DEPS_PATH: &str = "wit-deps";

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -11,7 +11,7 @@ use clap::Args;
 ///
 /// Before changing it make sure the new tag exists in the rust-templates repo and points to the
 /// desired commit.
-const TEMPLATES_REPO_TAG: &str = "v0.11.5";
+const TEMPLATES_REPO_TAG: &str = "v0.11.6";
 
 /// The folder name to put Miden SDK WIT files in
 pub const WIT_DEPS_PATH: &str = "wit-deps";
@@ -60,7 +60,7 @@ impl ProjectTemplate {
 
 impl Default for ProjectTemplate {
     fn default() -> Self {
-        Self::program()
+        Self::account()
     }
 }
 
@@ -158,7 +158,7 @@ impl NewCommand {
                 TemplatePath {
                     git: Some("https://github.com/0xMiden/rust-templates".into()),
                     tag: Some(TEMPLATES_REPO_TAG.into()),
-                    auto_path: Some(format!("new/{}", project_kind_str)),
+                    auto_path: Some(project_kind_str),
                     ..Default::default()
                 }
             }

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -11,8 +11,8 @@ use cargo_component::{
     load_component_metadata, load_metadata, run_cargo_command,
 };
 use clap::{CommandFactory, Parser};
-use commands::NewCommand;
-pub use commands::WIT_DEPS_PATH;
+pub use commands::example_project::WIT_DEPS_PATH;
+use commands::{ExampleCommand, NewCommand};
 use compile_masm::wasm_to_masm;
 use dependencies::process_miden_dependencies;
 use midenc_session::{RollupTarget, TargetEnv};
@@ -39,7 +39,7 @@ fn version() -> &'static str {
 /// The list of commands that are built-in to `cargo-miden`.
 const BUILTIN_COMMANDS: &[&str] = &[
     "miden", // for indirection via `cargo miden`
-    "new",
+    "new", "example",
 ];
 
 /// The list of commands that are explicitly unsupported by `cargo-miden`.
@@ -74,6 +74,7 @@ enum CargoMiden {
 #[derive(Parser)]
 enum Command {
     New(NewCommand),
+    Example(ExampleCommand),
 }
 
 fn detect_subcommand<I, T>(args: I) -> Option<String>
@@ -131,6 +132,10 @@ where
             match CargoMiden::parse_from(args.clone()) {
                 CargoMiden::Miden(cmd) | CargoMiden::Command(cmd) => match cmd {
                     Command::New(cmd) => {
+                        let project_path = cmd.exec()?;
+                        Ok(Some(CommandOutput::NewCommandOutput { project_path }))
+                    }
+                    Command::Example(cmd) => {
                         let project_path = cmd.exec()?;
                         Ok(Some(CommandOutput::NewCommandOutput { project_path }))
                     }

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -216,7 +216,6 @@ where
                     "hash-one-to-one",
                     "hash-two-to-one",
                     "add-asset",
-                    "add",
                     "unchecked-from-u64",
                 ]
                 .into_iter()

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -56,7 +56,7 @@ const AFTER_HELP: &str = "Unrecognized subcommands will be passed to cargo verba
 /// Cargo integration for Miden
 #[derive(Parser)]
 #[clap(
-    bin_name = "cargo",
+    bin_name = "cargo miden",
     version,
     propagate_version = true,
     arg_required_else_help = true,

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -6,13 +6,13 @@ use cargo_miden::{run, OutputType, WIT_DEPS_PATH};
 use miden_mast_package::Package;
 use midenc_session::miden_assembly::utils::Deserializable;
 
-fn example_project_args(project_name: &str, template: &str) -> Vec<String> {
-    let args: Vec<String> = ["cargo", "miden", "example", project_name, template]
-        .into_iter()
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-        .collect();
-    args
+fn example_project_args(example_name: &str) -> Vec<String> {
+    vec![
+        "cargo".to_string(),
+        "miden".to_string(),
+        "example".to_string(),
+        example_name.to_string(),
+    ]
 }
 
 fn new_project_args(project_name: &str, template: &str) -> Vec<String> {
@@ -39,33 +39,37 @@ fn test_example_templates() {
     // to use an out-of-band signal like this instead
     env::set_var("TEST", "1");
 
-    // empty template means no template option is passing, thus using the default project template
-    let r#default = build_example_project_from_template("");
-    assert!(r#default.is_library());
+    // Test basic-wallet example
+    let wallet = build_example_project_from_template("basic-wallet");
+    assert!(wallet.is_library());
 
-    let note = build_example_project_from_template("--note");
-    assert!(note.is_program());
+    // Test counter-contract example
+    let counter = build_example_project_from_template("counter-contract");
+    assert!(counter.is_library());
 
-    let program = build_example_project_from_template("--program");
+    // Test fibonacci example
+    let program = build_example_project_from_template("fibonacci");
     assert!(program.is_program());
 
     // Verify program projects don't have WIT files
-    verify_no_wit_files_for_example_template("--program");
+    verify_no_wit_files_for_example_template("fibonacci");
 }
 
 /// Verify that WIT files are not present for program template
-fn verify_no_wit_files_for_example_template(template: &str) {
+fn verify_no_wit_files_for_example_template(example_name: &str) {
     let restore_dir = env::current_dir().unwrap();
-    let temp_dir = env::temp_dir();
+    let temp_dir = env::temp_dir().join(format!(
+        "test_no_wit_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    fs::create_dir_all(&temp_dir).unwrap();
     env::set_current_dir(&temp_dir).unwrap();
-    let project_name = format!("test_no_wit_files_{}", template.replace("--", ""));
-    let expected_new_project_dir = &temp_dir.join(&project_name);
-    if expected_new_project_dir.exists() {
-        fs::remove_dir_all(expected_new_project_dir).unwrap();
-    }
 
-    // Create the project
-    let args = example_project_args(&project_name, template);
+    // Create the project - it will be named after the example
+    let args = example_project_args(example_name);
     let output = run(args.into_iter(), OutputType::Masm)
         .expect("Failed to create new project")
         .expect("Expected build output");
@@ -81,40 +85,28 @@ fn verify_no_wit_files_for_example_template(template: &str) {
     let wit_dir = new_project_path.join(WIT_DEPS_PATH);
     assert!(
         !wit_dir.exists() || wit_dir.read_dir().unwrap().count() == 0,
-        "WIT directory should not exist or be empty for {} template",
-        template
+        "WIT directory should not exist or be empty for {} example",
+        example_name
     );
 
     env::set_current_dir(restore_dir).unwrap();
-    fs::remove_dir_all(new_project_path).unwrap();
+    fs::remove_dir_all(temp_dir).unwrap();
 }
 
-fn build_example_project_from_template(template: &str) -> Package {
+fn build_example_project_from_template(example_name: &str) -> Package {
     let restore_dir = env::current_dir().unwrap();
-    let temp_dir = env::temp_dir();
+    let temp_dir = env::temp_dir().join(format!(
+        "test_example_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    fs::create_dir_all(&temp_dir).unwrap();
     env::set_current_dir(&temp_dir).unwrap();
 
-    if template == "--note" {
-        // create the counter contract cargo project since the note depends on it
-        let project_name = "counter-contract";
-        let expected_new_project_dir = &temp_dir.join(project_name);
-        dbg!(&expected_new_project_dir);
-        if expected_new_project_dir.exists() {
-            fs::remove_dir_all(expected_new_project_dir).unwrap();
-        }
-        let output = run(example_project_args(project_name, "").into_iter(), OutputType::Masm)
-            .expect("Failed to create new counter-contract dependency project")
-            .expect("'cargo miden example' should return Some(CommandOutput)");
-    }
-
-    let project_name = "test_proj_underscore";
-    let expected_new_project_dir = &temp_dir.join(project_name);
-    dbg!(&expected_new_project_dir);
-    if expected_new_project_dir.exists() {
-        fs::remove_dir_all(expected_new_project_dir).unwrap();
-    }
-
-    let args = example_project_args(project_name, template);
+    // Create the project - it will be named after the example
+    let args = example_project_args(example_name);
 
     let output = run(args.into_iter(), OutputType::Masm)
         .expect("Failed to create new project")
@@ -127,7 +119,6 @@ fn build_example_project_from_template(template: &str) -> Package {
     };
     dbg!(&new_project_path);
     assert!(new_project_path.exists());
-    assert_eq!(new_project_path, expected_new_project_dir.canonicalize().unwrap());
     env::set_current_dir(&new_project_path).unwrap();
 
     // build with the dev profile
@@ -169,7 +160,7 @@ fn build_example_project_from_template(template: &str) -> Package {
     let package = Package::read_from_bytes(&package_bytes).unwrap();
 
     env::set_current_dir(restore_dir).unwrap();
-    fs::remove_dir_all(new_project_path).unwrap();
+    fs::remove_dir_all(temp_dir).unwrap();
     package
 }
 
@@ -199,7 +190,7 @@ fn test_new_clean_templates() {
     verify_no_wit_files_for_new_template("--program");
 }
 
-/// Verify that WIT files are not present for program template  
+/// Verify that WIT files are not present for program template
 fn verify_no_wit_files_for_new_template(template: &str) {
     let restore_dir = env::current_dir().unwrap();
     let temp_dir = env::temp_dir();

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -345,7 +345,7 @@ fn build_new_project_from_template(template: &str) -> Package {
     let args = new_project_args(project_name, template);
 
     let output = run(args.into_iter(), OutputType::Masm)
-        .expect("Failed to create new project")
+        .expect("Failed to create new project from {template} template")
         .expect("'cargo miden new' should return Some(CommandOutput)");
     let new_project_path = match output {
         cargo_miden::CommandOutput::NewCommandOutput { project_path } => {

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -6,8 +6,16 @@ use cargo_miden::{run, OutputType, WIT_DEPS_PATH};
 use miden_mast_package::Package;
 use midenc_session::miden_assembly::utils::Deserializable;
 
+fn example_project_args(project_name: &str, template: &str) -> Vec<String> {
+    let args: Vec<String> = ["cargo", "miden", "example", project_name, template]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+    args
+}
+
 fn new_project_args(project_name: &str, template: &str) -> Vec<String> {
-    // let args: Vec<String> = ["cargo", "miden", "new", template, project_name]
     let args: Vec<String> = ["cargo", "miden", "new", project_name, template]
         .into_iter()
         .filter(|s| !s.is_empty())
@@ -20,7 +28,7 @@ fn new_project_args(project_name: &str, template: &str) -> Vec<String> {
 // that depend on the current directory
 
 #[test]
-fn test_templates() {
+fn test_example_templates() {
     let _ = env_logger::Builder::from_env("MIDENC_TRACE")
         .is_test(true)
         .format_timestamp(None)
@@ -32,25 +40,171 @@ fn test_templates() {
     env::set_var("TEST", "1");
 
     // empty template means no template option is passing, thus using the default project template
-    let r#default = build_new_project_from_template("");
+    let r#default = build_example_project_from_template("");
     assert!(r#default.is_library());
+
+    let note = build_example_project_from_template("--note");
+    assert!(note.is_program());
+
+    let program = build_example_project_from_template("--program");
+    assert!(program.is_program());
+
+    // Verify program projects don't have WIT files
+    verify_no_wit_files_for_example_template("--program");
+}
+
+/// Verify that WIT files are not present for program template
+fn verify_no_wit_files_for_example_template(template: &str) {
+    let restore_dir = env::current_dir().unwrap();
+    let temp_dir = env::temp_dir();
+    env::set_current_dir(&temp_dir).unwrap();
+    let project_name = format!("test_no_wit_files_{}", template.replace("--", ""));
+    let expected_new_project_dir = &temp_dir.join(&project_name);
+    if expected_new_project_dir.exists() {
+        fs::remove_dir_all(expected_new_project_dir).unwrap();
+    }
+
+    // Create the project
+    let args = example_project_args(&project_name, template);
+    let output = run(args.into_iter(), OutputType::Masm)
+        .expect("Failed to create new project")
+        .expect("Expected build output");
+    let new_project_path = match output {
+        cargo_miden::CommandOutput::NewCommandOutput { project_path } => {
+            project_path.canonicalize().unwrap()
+        }
+        other => panic!("Expected NewCommandOutput, got {:?}", other),
+    };
+    env::set_current_dir(&new_project_path).unwrap();
+
+    // Verify the wit directory does not exist or is empty for program template
+    let wit_dir = new_project_path.join(WIT_DEPS_PATH);
+    assert!(
+        !wit_dir.exists() || wit_dir.read_dir().unwrap().count() == 0,
+        "WIT directory should not exist or be empty for {} template",
+        template
+    );
+
+    env::set_current_dir(restore_dir).unwrap();
+    fs::remove_dir_all(new_project_path).unwrap();
+}
+
+fn build_example_project_from_template(template: &str) -> Package {
+    let restore_dir = env::current_dir().unwrap();
+    let temp_dir = env::temp_dir();
+    env::set_current_dir(&temp_dir).unwrap();
+
+    if template == "--note" {
+        // create the counter contract cargo project since the note depends on it
+        let project_name = "counter-contract";
+        let expected_new_project_dir = &temp_dir.join(project_name);
+        dbg!(&expected_new_project_dir);
+        if expected_new_project_dir.exists() {
+            fs::remove_dir_all(expected_new_project_dir).unwrap();
+        }
+        let output = run(example_project_args(project_name, "").into_iter(), OutputType::Masm)
+            .expect("Failed to create new counter-contract dependency project")
+            .expect("'cargo miden example' should return Some(CommandOutput)");
+    }
+
+    let project_name = "test_proj_underscore";
+    let expected_new_project_dir = &temp_dir.join(project_name);
+    dbg!(&expected_new_project_dir);
+    if expected_new_project_dir.exists() {
+        fs::remove_dir_all(expected_new_project_dir).unwrap();
+    }
+
+    let args = example_project_args(project_name, template);
+
+    let output = run(args.into_iter(), OutputType::Masm)
+        .expect("Failed to create new project")
+        .expect("'cargo miden example' should return Some(CommandOutput)");
+    let new_project_path = match output {
+        cargo_miden::CommandOutput::NewCommandOutput { project_path } => {
+            project_path.canonicalize().unwrap()
+        }
+        other => panic!("Expected NewCommandOutput, got {:?}", other),
+    };
+    dbg!(&new_project_path);
+    assert!(new_project_path.exists());
+    assert_eq!(new_project_path, expected_new_project_dir.canonicalize().unwrap());
+    env::set_current_dir(&new_project_path).unwrap();
+
+    // build with the dev profile
+    let args = ["cargo", "miden", "build"].iter().map(|s| s.to_string());
+    let output = run(args, OutputType::Masm)
+        .expect("Failed to compile with the dev profile")
+        .expect("'cargo miden build' should return Some(CommandOutput)");
+    let expected_masm_path = match output {
+        cargo_miden::CommandOutput::BuildCommandOutput { output } => match output {
+            cargo_miden::BuildOutput::Masm { artifact_path } => artifact_path,
+            other => panic!("Expected Masm output, got {:?}", other),
+        },
+        other => panic!("Expected BuildCommandOutput, got {:?}", other),
+    };
+    dbg!(&expected_masm_path);
+    assert!(expected_masm_path.exists());
+    assert!(expected_masm_path.to_str().unwrap().contains("/debug/"));
+    assert_eq!(expected_masm_path.extension().unwrap(), "masp");
+    assert!(expected_masm_path.metadata().unwrap().len() > 0);
+
+    // build with the release profile
+    let args = ["cargo", "miden", "build", "--release"].iter().map(|s| s.to_string());
+    let output = run(args, OutputType::Masm)
+        .expect("Failed to compile with the release profile")
+        .expect("'cargo miden build --release' should return Some(CommandOutput)");
+    let expected_masm_path = match output {
+        cargo_miden::CommandOutput::BuildCommandOutput { output } => match output {
+            cargo_miden::BuildOutput::Masm { artifact_path } => artifact_path,
+            other => panic!("Expected Masm output, got {:?}", other),
+        },
+        other => panic!("Expected BuildCommandOutput, got {:?}", other),
+    };
+    dbg!(&expected_masm_path);
+    assert!(expected_masm_path.exists());
+    assert_eq!(expected_masm_path.extension().unwrap(), "masp");
+    assert!(expected_masm_path.to_str().unwrap().contains("/release/"));
+    assert!(expected_masm_path.metadata().unwrap().len() > 0);
+    let package_bytes = fs::read(expected_masm_path).unwrap();
+    let package = Package::read_from_bytes(&package_bytes).unwrap();
+
+    env::set_current_dir(restore_dir).unwrap();
+    fs::remove_dir_all(new_project_path).unwrap();
+    package
+}
+
+#[test]
+fn test_new_clean_templates() {
+    let _ = env_logger::Builder::from_env("MIDENC_TRACE")
+        .is_test(true)
+        .format_timestamp(None)
+        .try_init();
+    // Signal to `cargo-miden` that we're running in a test harness.
+    env::set_var("TEST", "1");
+
+    // empty template means no template option is passing, thus using the default project template (program)
+    let r#default = build_new_project_from_template("");
+    assert!(r#default.is_program());
 
     let note = build_new_project_from_template("--note");
     assert!(note.is_program());
+
+    let account = build_new_project_from_template("--account");
+    assert!(account.is_library());
 
     let program = build_new_project_from_template("--program");
     assert!(program.is_program());
 
     // Verify program projects don't have WIT files
-    verify_no_wit_files_for_template("--program");
+    verify_no_wit_files_for_new_template("--program");
 }
 
-/// Verify that WIT files are not present for program template
-fn verify_no_wit_files_for_template(template: &str) {
+/// Verify that WIT files are not present for program template  
+fn verify_no_wit_files_for_new_template(template: &str) {
     let restore_dir = env::current_dir().unwrap();
     let temp_dir = env::temp_dir();
     env::set_current_dir(&temp_dir).unwrap();
-    let project_name = format!("test_no_wit_files_{}", template.replace("--", ""));
+    let project_name = format!("test_new_no_wit_files_{}", template.replace("--", ""));
     let expected_new_project_dir = &temp_dir.join(&project_name);
     if expected_new_project_dir.exists() {
         fs::remove_dir_all(expected_new_project_dir).unwrap();
@@ -86,20 +240,7 @@ fn build_new_project_from_template(template: &str) -> Package {
     let temp_dir = env::temp_dir();
     env::set_current_dir(&temp_dir).unwrap();
 
-    if template == "--note" {
-        // create the counter contract cargo project since the note depends on it
-        let project_name = "counter-contract";
-        let expected_new_project_dir = &temp_dir.join(project_name);
-        dbg!(&expected_new_project_dir);
-        if expected_new_project_dir.exists() {
-            fs::remove_dir_all(expected_new_project_dir).unwrap();
-        }
-        let output = run(new_project_args(project_name, "").into_iter(), OutputType::Masm)
-            .expect("Failed to create new counter-contract dependency project")
-            .expect("'cargo miden new' should return Some(CommandOutput)");
-    }
-
-    let project_name = "test_proj_underscore";
+    let project_name = "test_new_proj_underscore";
     let expected_new_project_dir = &temp_dir.join(project_name);
     dbg!(&expected_new_project_dir);
     if expected_new_project_dir.exists() {


### PR DESCRIPTION
Close #514 

**This PR is stacked on the #588 and should be merged after it**

Counter PR in `rust-templates` repo - https://github.com/0xMiden/rust-templates/pull/17

This PR:
- Changes the new project template for account and note script to be clean `add` example (like the Rust `cargo new` for a library);
- Adds `cargo miden example` command that copies an example from the `examples` folder of the compiler repo;
