### PR TITLE
chore: prepare `v0.1.5` release 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Install `cargo-semver-checks` CLI tool [here](https://github.com/obi1kenobi/carg
 The release process for the Miden Compiler and Miden SDK is managed using the `release-plz` tool. The following steps outline the process for creating a new release:
 
 1. Run `release-plz update` in the repo root folder to update the crates versions and generate changelogs.
-2. Create a release PR naming the branch with the `release-plz-` suffix (its important to use this suffix to trigger the crate publishing on CI in step 4).
+2. Create a release PR naming the branch with the `release-plz-` prefix (its important to use this prefix to trigger the crate publishing on CI in step 4).
 3. Review the changes in the release PR, commit edits if needed and merge it into the main branch.
 4. The CI will automatically run `release-plz release` after the release PR is merged to publish the new versions to crates.io.
 5. Set a git tag for the published crates to mark the release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-miden"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "cargo-config2",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "miden"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "miden-base",
  "miden-base-sys",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "miden-base-macros",
  "miden-base-sys",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "miden-objects",
  "proc-macro2",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "miden-stdlib-sys",
 ]
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "miden-integration-tests"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.1.0"
+version = "0.1.5"
 
 [[package]]
 name = "miden-stdlib"
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.1.0"
+version = "0.1.5"
 
 [[package]]
 name = "miden-thiserror"
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "midenc"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "env_logger",
  "human-panic",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-codegen-masm"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "env_logger",
  "inventory",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-compile"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "clap",
  "inventory",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-debug"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "clap",
  "crossterm",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-arith"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "midenc-hir",
  "paste",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-cf"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-hir"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-scf"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "bitvec",
  "env_logger",
@@ -3987,14 +3987,14 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-ub"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "midenc-hir",
 ]
 
 [[package]]
 name = "midenc-driver"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "clap",
  "log",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-expect-test"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "once_cell",
  "similar",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-analysis"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "bitvec",
  "blink-alloc",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-eval"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "log",
  "miden-thiserror",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "Inflector",
  "darling",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-symbol"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "Inflector",
  "compact_str 0.9.0",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-transform"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "log",
  "midenc-hir",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "miden-formatting",
  "serde",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-session"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.5"
 rust-version = "1.86"
 authors = ["Miden contributors"]
 description = "An intermediate representation and compiler for Miden Assembly"
@@ -125,27 +125,27 @@ wasmparser = { version = "0.227", default-features = false, features = [
 ] }
 
 # Workspace crates
-midenc-codegen-masm = { version = "0.1.0", path = "codegen/masm" }
-midenc-dialect-arith = { version = "0.1.0", path = "dialects/arith" }
-midenc-dialect-hir = { version = "0.1.0", path = "dialects/hir" }
-midenc-dialect-scf = { version = "0.1.0", path = "dialects/scf" }
-midenc-dialect-cf = { version = "0.1.0", path = "dialects/cf" }
-midenc-dialect-ub = { version = "0.1.0", path = "dialects/ub" }
-midenc-hir = { version = "0.1.0", path = "hir" }
-midenc-hir-analysis = { version = "0.1.0", path = "hir-analysis" }
-midenc-hir-eval = { version = "0.1.0", path = "eval" }
-midenc-hir-macros = { version = "0.1.0", path = "hir-macros" }
-midenc-hir-symbol = { version = "0.1.0", path = "hir-symbol" }
-midenc-hir-transform = { version = "0.1.0", path = "hir-transform" }
-midenc-hir-type = { version = "0.1.0", path = "hir-type" }
-midenc-frontend-wasm = { version = "0.1.0", path = "frontend/wasm" }
-midenc-compile = { version = "0.1.0", path = "midenc-compile" }
-midenc-driver = { version = "0.1.0", path = "midenc-driver" }
-midenc-debug = { version = "0.1.0", path = "midenc-debug" }
-midenc-session = { version = "0.1.0", path = "midenc-session" }
-cargo-miden = { version = "0.1.0", path = "tools/cargo-miden" }
+midenc-codegen-masm = { version = "0.1.5", path = "codegen/masm" }
+midenc-dialect-arith = { version = "0.1.5", path = "dialects/arith" }
+midenc-dialect-hir = { version = "0.1.5", path = "dialects/hir" }
+midenc-dialect-scf = { version = "0.1.5", path = "dialects/scf" }
+midenc-dialect-cf = { version = "0.1.5", path = "dialects/cf" }
+midenc-dialect-ub = { version = "0.1.5", path = "dialects/ub" }
+midenc-hir = { version = "0.1.5", path = "hir" }
+midenc-hir-analysis = { version = "0.1.5", path = "hir-analysis" }
+midenc-hir-eval = { version = "0.1.5", path = "eval" }
+midenc-hir-macros = { version = "0.1.5", path = "hir-macros" }
+midenc-hir-symbol = { version = "0.1.5", path = "hir-symbol" }
+midenc-hir-transform = { version = "0.1.5", path = "hir-transform" }
+midenc-hir-type = { version = "0.1.5", path = "hir-type" }
+midenc-frontend-wasm = { version = "0.1.5", path = "frontend/wasm" }
+midenc-compile = { version = "0.1.5", path = "midenc-compile" }
+midenc-driver = { version = "0.1.5", path = "midenc-driver" }
+midenc-debug = { version = "0.1.5", path = "midenc-debug" }
+midenc-session = { version = "0.1.5", path = "midenc-session" }
+cargo-miden = { version = "0.1.5", path = "tools/cargo-miden" }
 miden-integration-tests = { version = "0.0.0", path = "tests/integration" }
-midenc-expect-test = { version = "0.1.0", path = "tools/expect-test" }
+midenc-expect-test = { version = "0.1.5", path = "tools/expect-test" }
 
 [patch.crates-io]
 #miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }

--- a/codegen/masm/CHANGELOG.md
+++ b/codegen/masm/CHANGELOG.md
@@ -6,6 +6,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.1.0...midenc-codegen-masm-v0.1.5) - 2025-07-01
+
+### Added
+
+- small integers in `struct` support in result in cross-context calls
+
+### Fixed
+
+- add immediate pointer to `OpEmitter::load_small`
+- call `truncate_stack` before returning from a `call`-able procedure
+- mask calculation in `trunc_int32` function (128 -> 255 for u8);
+
+### Other
+
+- Merge pull request #572 from 0xMiden/greenhat/i560-init-account-note
+- add `store_small_imm` function doc and assert
+- don't delegate in `store_small_imm` to `store_word_imm`,
+- add comments
+- remove redundant `store` tests
+- reduce stack manipulation in `store_small`
+- assert that type to be loaded and the pointee type have the
+- use `NativePtr::is_word_aligned`
+- remove `expect-test` in favor of `midenc-expect-test`
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.0.7...midenc-codegen-masm-v0.0.8) - 2025-04-24
 
 ### Added

--- a/dialects/hir/CHANGELOG.md
+++ b/dialects/hir/CHANGELOG.md
@@ -5,3 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-dialect-hir-v0.1.0...midenc-dialect-hir-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- delayed registration of scf dialect causes canonicalizations to be skipped

--- a/dialects/scf/CHANGELOG.md
+++ b/dialects/scf/CHANGELOG.md
@@ -5,3 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-dialect-scf-v0.1.0...midenc-dialect-scf-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- *(scf)* over-eager trivial if-to-select rewrite
+- delayed registration of scf dialect causes canonicalizations to be skipped
+
+### Other
+
+- remove `expect-test` in favor of `midenc-expect-test`

--- a/frontend/wasm/CHANGELOG.md
+++ b/frontend/wasm/CHANGELOG.md
@@ -6,6 +6,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-frontend-wasm-v0.1.0...midenc-frontend-wasm-v0.1.5) - 2025-07-01
+
+### Added
+
+- small integers in `struct` support in result in cross-context calls
+- *(frontend)* add the arbitrary shape `struct` support in
+- implement Wasm CM indirect lowering shim+fixup module bypass
+- add Miden SDK `note::get_assets` Rust bindings
+
+### Fixed
+
+- `ret` returns the exit block args
+- `ResolvedDataSegment::padding_needed()` to calculate an adjustment DOWN (not UP)
+- *(frontend)* ensure data segments are word-aligned for Miden VM #551
+- wasm import module names to be in sync with WIT files (Miden SDK)
+- consider function parameters size in felts (>16) when deciding if
+
+### Other
+
+- clean up debugging asserts
+- add type signature conversion tests for Wasm CM type flattening
+- use `DisplayValues` to avoid materiazing the `Vec` in the frontend
+- clean up commented out `dbg!` in the frontend
+- use `DisplayValues` to avoid materializing the `Vec`
+- add `target` in all `log` messages in the frontend
+- use `ValueRange` instead of `Vec<ValueRef>`
+- add more info to the assertions
+- use `assert!` instead of `if`
+- use `[0]` to get the first element
+- remove the `offset` in `load/store` in CanonABI
+- lift/lower `call`
+- use `SmallVec` for ABI transformation results
+- avoid extra allocation
+- use `SmallVec` for data segments
+- remove `expect-test` in favor of `midenc-expect-test`
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/midenc-frontend-wasm-v0.0.7...midenc-frontend-wasm-v0.0.8) - 2025-04-24
 
 ### Added

--- a/hir-transform/CHANGELOG.md
+++ b/hir-transform/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.1.0...midenc-hir-transform-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- delayed registration of scf dialect causes canonicalizations to be skipped
+- release borrowed op in `spill.rs` (to be `borrow_mut()`-ed later)
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/midenc-hir-transform-v0.0.7...midenc-hir-transform-v0.0.8) - 2025-04-24
 
 ### Fixed

--- a/hir/CHANGELOG.md
+++ b/hir/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.1.0...midenc-hir-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- prevent global variables from overlapping with data segments
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/midenc-hir-v0.0.7...midenc-hir-v0.0.8) - 2025-04-24
 
 ### Added

--- a/midenc-compile/CHANGELOG.md
+++ b/midenc-compile/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-compile-v0.1.0...midenc-compile-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- allow linking MASM modules without procedures type info to
+
+### Other
+
+- add format for entrypoint option
+- remove unused `LiftExportsCrossCtxStage`
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/midenc-compile-v0.0.7...midenc-compile-v0.0.8) - 2025-04-24
 
 ### Added

--- a/midenc-debug/CHANGELOG.md
+++ b/midenc-debug/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.1.0...midenc-debug-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- invoke `init` in the lifting function prologue, load the advice
+
+### Other
+
+- add format for entrypoint option
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/midenc-debug-v0.0.7...midenc-debug-v0.0.8) - 2025-04-24
 
 ### Added

--- a/sdk/alloc/CHANGELOG.md
+++ b/sdk/alloc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/miden-sdk-alloc-v0.1.0...miden-sdk-alloc-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- `BumpAlloc` to make all allocations minimally VM word-aligned (16 bytes)
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/miden-sdk-alloc-v0.0.7...miden-sdk-alloc-v0.0.8) - 2025-04-24
 
 ### Added

--- a/sdk/base-sys/CHANGELOG.md
+++ b/sdk/base-sys/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.1.0...miden-base-sys-v0.1.5) - 2025-07-01
+
+### Added
+
+- add Miden SDK `note::get_assets` Rust bindings
+
+### Fixed
+
+- `note` Miden SDK bindings for element-addressable memory in Miden VM #550
+- wasm import module names to be in sync with WIT files (Miden SDK)
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/miden-base-sys-v0.0.7...miden-base-sys-v0.0.8) - 2025-04-24
 
 ### Added

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 edition.workspace = true
 
 [dependencies]
-miden-stdlib-sys = { version = "0.1.0", path = "../stdlib-sys" }
+miden-stdlib-sys = { version = "0.1.5", path = "../stdlib-sys" }
 
 [features]
 default = []

--- a/sdk/base/Cargo.toml
+++ b/sdk/base/Cargo.toml
@@ -12,9 +12,9 @@ readme.workspace = true
 edition.workspace = true
 
 [dependencies]
-miden-base-sys = { version = "0.1.0", path = "../base-sys" }
-miden-stdlib-sys = { version = "0.1.0", path = "../stdlib-sys" }
-miden-base-macros = { version = "0.1.0", path = "../base-macros" }
+miden-base-sys = { version = "0.1.5", path = "../base-sys" }
+miden-stdlib-sys = { version = "0.1.5", path = "../stdlib-sys" }
+miden-base-macros = { version = "0.1.5", path = "../base-macros" }
 
 [features]
 default = []

--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -15,10 +15,10 @@ edition.workspace = true
 crate-type = ["rlib"]
 
 [dependencies]
-miden-sdk-alloc = { version = "0.1.0", path = "../alloc" }
-miden-stdlib-sys = { version = "0.1.0", path = "../stdlib-sys" }
-miden-base = { version = "0.1.0", path = "../base" }
-miden-base-sys = { version = "0.1.0", path = "../base-sys" }
+miden-sdk-alloc = { version = "0.1.5", path = "../alloc" }
+miden-stdlib-sys = { version = "0.1.5", path = "../stdlib-sys" }
+miden-base = { version = "0.1.5", path = "../base" }
+miden-base-sys = { version = "0.1.5", path = "../base-sys" }
 
 [features]
 default = []

--- a/sdk/stdlib-sys/CHANGELOG.md
+++ b/sdk/stdlib-sys/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.1.0...miden-stdlib-sys-v0.1.5) - 2025-07-01
+
+### Fixed
+
+- add missing felt intrinsics in Miden SDK WIT file
+
+### Other
+
+- add globals to cross-ctx-account and note test projects
+- fix doc comments
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/miden-stdlib-sys-v0.0.7...miden-stdlib-sys-v0.0.8) - 2025-04-24
 
 ### Added

--- a/tools/cargo-miden/CHANGELOG.md
+++ b/tools/cargo-miden/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.1.0...cargo-miden-v0.1.5) - 2025-07-01
+
+### Added
+
+- implement Wasm CM indirect lowering shim+fixup module bypass
+- *(cargo-miden)* switch rollup projects to `wasm32-wasip2` target
+
+### Other
+
+- sketch out generic testnet test infrastructure
+- add `counter_contract_debug_build` test to reproduce #510,
+- remove unused code (componentization) in
+
 ## [0.0.8](https://github.com/0xMiden/compiler/compare/cargo-miden-v0.0.7...cargo-miden-v0.0.8) - 2025-04-24
 
 ### Added

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -35,13 +35,13 @@ tokio.workspace = true
 cargo-config2 = "0.1.24"
 serde.workspace = true
 serde_json = "1.0"
-miden-stdlib-sys = { version = "0.1.0", path = "../../sdk/stdlib-sys", features = [
+miden-stdlib-sys = { version = "0.1.5", path = "../../sdk/stdlib-sys", features = [
     "wit",
 ] }
-miden-base-sys = { version = "0.1.0", path = "../../sdk/base-sys", features = [
+miden-base-sys = { version = "0.1.5", path = "../../sdk/base-sys", features = [
     "wit",
 ] }
-miden-base = { version = "0.1.0", path = "../../sdk/base", features = ["wit"] }
+miden-base = { version = "0.1.5", path = "../../sdk/base", features = ["wit"] }
 
 # from cargo-component
 semver.workspace = true

--- a/tools/expect-test/CHANGELOG.md
+++ b/tools/expect-test/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.5](https://github.com/0xMiden/compiler/compare/midenc-expect-test-v0.1.0...midenc-expect-test-v0.1.5) - 2025-07-01
+
+### Other
+
+- move `midenc-expect-test` to `tools` folder
+- update url
+- fix typos ([#243](https://github.com/0xMiden/compiler/pull/243))
+- a few minor improvements
+- set up mdbook deploy
+- add guides for compiling rust->masm
+- add mdbook skeleton
+- provide some initial usage instructions
+- Initial commit


### PR DESCRIPTION
This PR is created after running `release-plz update` and editing the version to `0.1.5`.
After this PR is merged, the CI job will publish the crates.
