### PR TITLE
chore: disable publishing for `midenc-expect-test` crate

### DIFF
--- a/tools/expect-test/Cargo.toml
+++ b/tools/expect-test/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 similar = "2"


### PR DESCRIPTION
Fixing the error https://github.com/0xMiden/compiler/actions/runs/15998674964/job/45127945249 from the previous publishing.