### PR TITLE
chore: remove `publish = false` for `midenc-expect-test` crate

### DIFF
--- a/tools/expect-test/Cargo.toml
+++ b/tools/expect-test/Cargo.toml
@@ -10,7 +10,6 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 edition.workspace = true
-publish = false
 
 [dependencies]
 similar = "2"


### PR DESCRIPTION
Reverts https://github.com/0xMiden/compiler/pull/580

We need to publish `midenc-expect-test` crate.