### PR TITLE
fix: prevent panic in filestem() method with invalid paths

### DIFF
--- a/midenc-session/src/inputs.rs
+++ b/midenc-session/src/inputs.rs
@@ -195,7 +195,9 @@ impl InputFile {
 
     pub fn filestem(&self) -> &str {
         match &self.file {
-            InputType::Real(ref path) => path.file_stem().unwrap().to_str().unwrap(),
+            InputType::Real(ref path) => path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("noname"),
             InputType::Stdin { .. } => "noname",
         }
     }


### PR DESCRIPTION
Replace double unwrap() calls with a safe chain of and_then() and unwrap_or() to handle 
invalid file paths gracefully. This prevents potential panics when:
1. Path has no file name component (e.g., "/")
2. File name contains invalid UTF-8 characters
3. Other edge cases where file_stem() or to_str() might return None