### PR TITLE
fix: start `Linker::reserved_memory_pages` on the next page after rustc reservation for the Rust stack

### DIFF
--- a/codegen/masm/intrinsics/mem.masm
+++ b/codegen/masm/intrinsics/mem.masm
@@ -41,7 +41,10 @@ end
 #
 # This must be called before any other heap intrinsics are called. This is checked by each intrinsic
 export.heap_init # [heap_base]
-    dup.0 push.0 swap.1 push.MAGIC # [MAGIC, heap_base, heap_size, heap_top]
+    dup.0 # [heap_base, heap_base]
+    push.0 # [0, heap_base, heap_base]
+    swap.1 # [heap_base, 0, heap_base]
+    push.MAGIC # [MAGIC, heap_base, heap_size(0), heap_top(heap_base)]
     mem_storew.HEAP_INFO_ADDR
     dropw
 end

--- a/codegen/masm/src/linker.rs
+++ b/codegen/masm/src/linker.rs
@@ -5,6 +5,7 @@ use midenc_hir::{
 
 const DEFAULT_PAGE_SIZE: u32 = 2u32.pow(16);
 /// Currently, Wasm modules produced by rustc reserve 16 pages for the Rust stack
+/// (see __stack_pointer global variable value in Wasm).
 const DEFAULT_RESERVATION: u32 = 16;
 
 pub struct LinkInfo {
@@ -74,7 +75,10 @@ pub struct Linker {
 
 impl Default for Linker {
     fn default() -> Self {
-        Self::new(DEFAULT_RESERVATION, DEFAULT_PAGE_SIZE)
+        // We start our reserved memory from the next page after the rustc reserved for the
+        // Rust stack to avoid overlapping.
+        let reserved_memory_pages = DEFAULT_RESERVATION + 1;
+        Self::new(reserved_memory_pages, DEFAULT_PAGE_SIZE)
     }
 }
 

--- a/codegen/masm/src/linker.rs
+++ b/codegen/masm/src/linker.rs
@@ -6,7 +6,9 @@ use midenc_hir::{
 const DEFAULT_PAGE_SIZE: u32 = 2u32.pow(16);
 /// Currently, Wasm modules produced by rustc reserve 16 pages for the Rust stack
 /// (see __stack_pointer global variable value in Wasm).
-const DEFAULT_RESERVATION: u32 = 16;
+// We start our reserved memory from the next page after the rustc reserved for the
+// Rust stack to avoid overlapping with Rust `static` vars.
+const DEFAULT_RESERVATION: u32 = 17;
 
 pub struct LinkInfo {
     component: builtin::ComponentId,
@@ -75,10 +77,7 @@ pub struct Linker {
 
 impl Default for Linker {
     fn default() -> Self {
-        // We start our reserved memory from the next page after the rustc reserved for the
-        // Rust stack to avoid overlapping.
-        let reserved_memory_pages = DEFAULT_RESERVATION + 1;
-        Self::new(reserved_memory_pages, DEFAULT_PAGE_SIZE)
+        Self::new(DEFAULT_RESERVATION, DEFAULT_PAGE_SIZE)
     }
 }
 

--- a/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
+++ b/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::abi_transform_stdlib_blake3_hash
@@ -126,7 +126,7 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
 end
 
 export.entrypoint
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -140,7 +140,7 @@ export.entrypoint
     swap.1
     u32wrapping_sub
     u32and
-    push.1048576
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -356,7 +356,7 @@ export.entrypoint
     exec.::intrinsics::mem::store_dw
     trace.252
     nop
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -18,7 +18,7 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278544
 end
 
 # mod root_ns:root@1.0.0::abi_transform_tx_kernel_get_inputs_4
@@ -34,7 +34,7 @@ proc.miden_base_sys::bindings::note::extern_note_get_inputs
 end
 
 export.entrypoint
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -44,7 +44,7 @@ export.entrypoint
     nop
     push.16
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -242,7 +242,7 @@ export.entrypoint
                     movup.2
                     swap.1
                     u32wrapping_add
-                    push.1114112
+                    push.1114176
                     u32divmod.4
                     swap.1
                     trace.240
@@ -546,7 +546,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -556,7 +556,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
     nop
     push.16
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -676,7 +676,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
         nop
         push.16
         u32wrapping_add
-        push.1114112
+        push.1114176
         u32divmod.4
         swap.1
         trace.240
@@ -716,7 +716,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
 end
 
 proc.miden_base_sys::bindings::note::get_inputs
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -726,7 +726,7 @@ proc.miden_base_sys::bindings::note::get_inputs
     nop
     push.16
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -843,7 +843,7 @@ proc.miden_base_sys::bindings::note::get_inputs
     nop
     push.16
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -858,7 +858,7 @@ proc.<miden_stdlib_sys::intrinsics::felt::Felt as core::convert::From<u32>>::fro
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::deallocate
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -868,7 +868,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     nop
     push.16
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -961,7 +961,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     end
     push.16
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -972,7 +972,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -982,7 +982,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1369,7 +1369,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1380,7 +1380,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
 end
 
 proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1390,7 +1390,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1484,7 +1484,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -1,7 +1,7 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -18,7 +18,7 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262160
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::abi_transform_tx_kernel_get_inputs_4
@@ -34,7 +34,7 @@ proc.miden_base_sys::bindings::note::extern_note_get_inputs
 end
 
 export.entrypoint
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -44,7 +44,7 @@ export.entrypoint
     nop
     push.16
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -242,7 +242,7 @@ export.entrypoint
                     movup.2
                     swap.1
                     u32wrapping_add
-                    push.1048640
+                    push.1114112
                     u32divmod.4
                     swap.1
                     trace.240
@@ -546,7 +546,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -556,7 +556,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
     nop
     push.16
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -676,7 +676,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
         nop
         push.16
         u32wrapping_add
-        push.1048640
+        push.1114112
         u32divmod.4
         swap.1
         trace.240
@@ -716,7 +716,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
 end
 
 proc.miden_base_sys::bindings::note::get_inputs
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -726,7 +726,7 @@ proc.miden_base_sys::bindings::note::get_inputs
     nop
     push.16
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -843,7 +843,7 @@ proc.miden_base_sys::bindings::note::get_inputs
     nop
     push.16
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -858,7 +858,7 @@ proc.<miden_stdlib_sys::intrinsics::felt::Felt as core::convert::From<u32>>::fro
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::deallocate
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -868,7 +868,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     nop
     push.16
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -961,7 +961,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     end
     push.16
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -972,7 +972,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -982,7 +982,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -1369,7 +1369,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -1380,7 +1380,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
 end
 
 proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -1390,7 +1390,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -1484,7 +1484,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/add_felt.masm
+++ b/tests/integration/expected/add_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::add_felt

--- a/tests/integration/expected/add_i16.masm
+++ b/tests/integration/expected/add_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_06c525756fe79253a5d667de4160df5c89e45269648c98bb21fd9430caec0b19

--- a/tests/integration/expected/add_i32.masm
+++ b/tests/integration/expected/add_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_e52816950d9b2deff10441c5aff28d88268e921c4c01a207c8743d871bd3a69f

--- a/tests/integration/expected/add_i64.masm
+++ b/tests/integration/expected/add_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_cc1ebe8ed410a033febcc7c6a7e1b2473b2337e0dff32b08d3c91be5bbc2cc0a

--- a/tests/integration/expected/add_i8.masm
+++ b/tests/integration/expected/add_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_62ba1afb3113b5a2557098b909eff557cd716bf21b07843db3bfb765ff41e9f7

--- a/tests/integration/expected/add_u16.masm
+++ b/tests/integration/expected/add_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_41c5fa21fe36fdf84a953669187b56426048e7b2f08e8de91e3e989c579ed46f

--- a/tests/integration/expected/add_u32.masm
+++ b/tests/integration/expected/add_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_2aac0275c4e31b615b4d6bf7d39869ccab374d5df702b3ef708ea7f981b4073c

--- a/tests/integration/expected/add_u64.masm
+++ b/tests/integration/expected/add_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_2c24c814fbf0c5ee22a60f52279e8f7639d56708da347e071f1130dc19dc9c07

--- a/tests/integration/expected/add_u8.masm
+++ b/tests/integration/expected/add_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_9c74aa9695b645cec4339ff01ac3e35e31b39b1feb0dfeef6ee7c94789fbcfce

--- a/tests/integration/expected/and_bool.masm
+++ b/tests/integration/expected/and_bool.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_f19303d702f807a0f2b8aebdfd8b2b6ae52ee927040711d5dfd94aac9e67f2c7

--- a/tests/integration/expected/arg_order.masm
+++ b/tests/integration/expected/arg_order.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::arg_order
 
 export.entrypoint
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -27,7 +27,7 @@ export.entrypoint
     swap.1
     u32wrapping_sub
     u32and
-    push.1048576
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -222,7 +222,7 @@ export.entrypoint
     exec.::intrinsics::mem::load_felt
     trace.252
     nop
-    push.1048576
+    push.1114112
     movup.2
     swap.1
     u32divmod.4

--- a/tests/integration/expected/band_i16.masm
+++ b/tests/integration/expected/band_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_34638703ab78fea8050898ab92e28a6a09cade611d4a9a3601c8667b275e57ee

--- a/tests/integration/expected/band_i32.masm
+++ b/tests/integration/expected/band_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_9ee88137407daefa6fa252f24e800d9fc4690951edfe7f8303f2f5225ed6eea3

--- a/tests/integration/expected/band_i64.masm
+++ b/tests/integration/expected/band_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_fdee33d480318f3f6165aabcaf90e290011f2d459d009ce9a6ea019e73b0e6b4

--- a/tests/integration/expected/band_i8.masm
+++ b/tests/integration/expected/band_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_a20ca31834cfb559286ab8bbb00ce2e657f38ec95d8459342621bc218581241d

--- a/tests/integration/expected/band_u16.masm
+++ b/tests/integration/expected/band_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_41457a077e1338454c33613079552cd2abe9d4fd50975cf8d2d8d9ee664dfbb6

--- a/tests/integration/expected/band_u32.masm
+++ b/tests/integration/expected/band_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_82d1878f26a40c75c635298e80f65f7a5aac492ad99eb90909a97ab273f4c1ad

--- a/tests/integration/expected/band_u64.masm
+++ b/tests/integration/expected/band_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_8509e2e84a91835b60f651a4adb33e43024ab7f31520e5ee5b5a97f181859a40

--- a/tests/integration/expected/band_u8.masm
+++ b/tests/integration/expected/band_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_3be102ea36db2b23b9f6f0e34bfb210f4f562d75c14b2d53d64bdcc630a44aa6

--- a/tests/integration/expected/bnot_bool.masm
+++ b/tests/integration/expected/bnot_bool.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_77ff166ebf5be0d308b881f765d5f8ef913f838ea7e86a97499b030fa1c0f3f4

--- a/tests/integration/expected/bnot_i16.masm
+++ b/tests/integration/expected/bnot_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_e24d4ca783335c84dc5ae676aec479bda06baf4852fc00f30dac4021d07cf59f

--- a/tests/integration/expected/bnot_i32.masm
+++ b/tests/integration/expected/bnot_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_0d63a98a6809a92584f1dbaab4dfd841caaf9cab88744275bd4ed034006fc6ed

--- a/tests/integration/expected/bnot_i64.masm
+++ b/tests/integration/expected/bnot_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_b907170bd28f219043267cdd24dc67337632f05fcaab8f9a4efb14def28e8e3e

--- a/tests/integration/expected/bnot_i8.masm
+++ b/tests/integration/expected/bnot_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_1f608e193c7b4c41422a7e789e491655410126a59a757a5572c1ed81892c7c0b

--- a/tests/integration/expected/bnot_u16.masm
+++ b/tests/integration/expected/bnot_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_801b0e92eabaaba12053c65b60b81c5cb57e2d5bf386ab548321cf375005baea

--- a/tests/integration/expected/bnot_u32.masm
+++ b/tests/integration/expected/bnot_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_dc5405fd1533a0bda8a8715a70ef89a33300844687446825e2ae7bfc5a34655a

--- a/tests/integration/expected/bnot_u64.masm
+++ b/tests/integration/expected/bnot_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_345f3c1e58fe5c9ef31421da6a362d9cadbf519ad68045840229e8b76f58a4f4

--- a/tests/integration/expected/bnot_u8.masm
+++ b/tests/integration/expected/bnot_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_5e3a237ba6b351b72bc4ac66517613ffe85ccd4b728c40b405f3a9ff93506063

--- a/tests/integration/expected/bor_i16.masm
+++ b/tests/integration/expected/bor_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_44e33b9e14fa2be1f40cdd20712edb995a941e3a1a153b46fb87e39dcbcdebc1

--- a/tests/integration/expected/bor_i32.masm
+++ b/tests/integration/expected/bor_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_e24b176dbd0fa5b54e01370fc307f6f1a06748cd8946e58e7d1469dceadc6d92

--- a/tests/integration/expected/bor_i64.masm
+++ b/tests/integration/expected/bor_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_19d92981d2d7f148eaa97011bd0bd979fbc793cadadb334c67791824f38e7bf8

--- a/tests/integration/expected/bor_i8.masm
+++ b/tests/integration/expected/bor_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_6b279a51e04f2b6fc0be10e9ad685e34fcfc2cbc2c726847699f4721f48e3713

--- a/tests/integration/expected/bor_u16.masm
+++ b/tests/integration/expected/bor_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_fe8fe146eac1710c2c8529e4df4810118e471d0c279c48e765ff28ad800d1aab

--- a/tests/integration/expected/bor_u32.masm
+++ b/tests/integration/expected/bor_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_e3bb04a56c487ecfc0dd1c57e0d354745ffb321466dc47bd02d51513cc6980d1

--- a/tests/integration/expected/bor_u64.masm
+++ b/tests/integration/expected/bor_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_e8616ef7e15d87b491a1dbcccfe42b1dcb7a90b965c27549b2b5d9604d28acee

--- a/tests/integration/expected/bor_u8.masm
+++ b/tests/integration/expected/bor_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_a0d8359c86d6548c3cdc5448b2a38351e3498e1db98a8d3d4bbbc27afa05af09

--- a/tests/integration/expected/bxor_i16.masm
+++ b/tests/integration/expected/bxor_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_cb1e0c1a18c279735e94c50dd925290caa430ac65188eb20eb437a4391d25640

--- a/tests/integration/expected/bxor_i32.masm
+++ b/tests/integration/expected/bxor_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_1c4d375403281e14e710bf442e5556c06e5933dce447f206252657b1345611f0

--- a/tests/integration/expected/bxor_i64.masm
+++ b/tests/integration/expected/bxor_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_bbe2169ccd3bb4080a705f38ed5ef633d3af9e172e8f9b41ae4ee10f8059e176

--- a/tests/integration/expected/bxor_i8.masm
+++ b/tests/integration/expected/bxor_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_da1dfc177b6a72c28237264497437ada8ba555111d180be7b99b1d60791da41c

--- a/tests/integration/expected/bxor_u16.masm
+++ b/tests/integration/expected/bxor_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_255d3558f03d3b3be3d933d40e9ae32b53db7dd904e40aafd5677d694056c91b

--- a/tests/integration/expected/bxor_u32.masm
+++ b/tests/integration/expected/bxor_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_b25131cea5088f57eb35dec78eb814ce753ab95c1f4faf8447870d9b6d1525dd

--- a/tests/integration/expected/bxor_u64.masm
+++ b/tests/integration/expected/bxor_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_ab1d59bc3952451e2ac6a22333bf5458760622594546976d2d1488d607497ae7

--- a/tests/integration/expected/bxor_u8.masm
+++ b/tests/integration/expected/bxor_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_e442bdf6f0faa5b55270b06bb284534cce773aa9180fde57cdeeeddf42bb21e6

--- a/tests/integration/expected/collatz.masm
+++ b/tests/integration/expected/collatz.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::collatz

--- a/tests/integration/expected/core::cmp::max_u8_u8.masm
+++ b/tests/integration/expected/core::cmp::max_u8_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_adcf2f13ea1f22958c5a92d1674643acc093416b0b2de0fee390636adfcf090a

--- a/tests/integration/expected/core::cmp::min_i32_i32.masm
+++ b/tests/integration/expected/core::cmp::min_i32_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_473cae57ec6aea1b2fa1e6ffdabf82016fbf6e38e3acdf12f2f612d1044a9d0c

--- a/tests/integration/expected/core::cmp::min_u32_u32.masm
+++ b/tests/integration/expected/core::cmp::min_u32_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_d58f2727da94ef76690ba318a633249545f9e38779d69d96f04c561d52921cd4

--- a/tests/integration/expected/core::cmp::min_u8_u8.masm
+++ b/tests/integration/expected/core::cmp::min_u8_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_86004120286ad9607be152901a86f66a999ee9dd70f4520b4ba4d6af29300327

--- a/tests/integration/expected/div_felt.masm
+++ b/tests/integration/expected/div_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::div_felt

--- a/tests/integration/expected/eq_felt.masm
+++ b/tests/integration/expected/eq_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::eq_felt

--- a/tests/integration/expected/eq_i16.masm
+++ b/tests/integration/expected/eq_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_517fb449f17b407495bba1888d666bc76885dc2541249b2f6cfe05173973099e

--- a/tests/integration/expected/eq_i32.masm
+++ b/tests/integration/expected/eq_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_3a92b0607377b819decb1029f8199a70990302e258cc8ee55f612c4d879c74f4

--- a/tests/integration/expected/eq_i64.masm
+++ b/tests/integration/expected/eq_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_bcf098a70fb61198130acb429b0b2900b9c9d11c5cab0241410bb862be7ce2a8

--- a/tests/integration/expected/eq_i8.masm
+++ b/tests/integration/expected/eq_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_c2c2ad0caabf21644314027afcbfb75555fa063ab09504517a70196ddd47c892

--- a/tests/integration/expected/eq_u16.masm
+++ b/tests/integration/expected/eq_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_5e53494a4e3a0adfb638a6e562baf4c446d2f54c63ea6d33dec923896f12cea8

--- a/tests/integration/expected/eq_u32.masm
+++ b/tests/integration/expected/eq_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_528be949250a0d0dcd9cd0e4c74a012863f8f305b2ac8043a575d81640315ac0

--- a/tests/integration/expected/eq_u64.masm
+++ b/tests/integration/expected/eq_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_90e3e1f038c3b9b7ba2a8c0e9313f59dc3bc3f54fe235a4c5c325df06e46d3b0

--- a/tests/integration/expected/eq_u8.masm
+++ b/tests/integration/expected/eq_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_909444ffebd8fe6b867a4d7833f385ece2e4ae4363fd04241342e9bef1affc93

--- a/tests/integration/expected/examples/basic_wallet.masm
+++ b/tests/integration/expected/examples/basic_wallet.masm
@@ -21,7 +21,7 @@ export.send-asset
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -38,10 +38,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262160
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262161
+    mem_store.278529
 end
 
 # mod miden:basic-wallet/basic-wallet@1.0.0::basic_wallet
@@ -177,7 +177,7 @@ proc.basic_wallet::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -187,7 +187,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
     nop
     push.32
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -288,7 +288,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
     nop
     push.32
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -299,7 +299,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
 end
 
 export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -309,7 +309,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
     nop
     push.48
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -506,7 +506,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
     drop
     push.48
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -517,7 +517,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048644
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -546,7 +546,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048644
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/examples/basic_wallet.masm
+++ b/tests/integration/expected/examples/basic_wallet.masm
@@ -38,10 +38,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278545
 end
 
 # mod miden:basic-wallet/basic-wallet@1.0.0::basic_wallet
@@ -177,7 +177,7 @@ proc.basic_wallet::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -187,7 +187,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
     nop
     push.32
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -288,7 +288,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
     nop
     push.32
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -299,7 +299,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
 end
 
 export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -309,7 +309,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
     nop
     push.48
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -506,7 +506,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
     drop
     push.48
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -517,7 +517,7 @@ export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -546,7 +546,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114180
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/examples/counter.masm
+++ b/tests/integration/expected/examples/counter.masm
@@ -38,10 +38,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278545
 end
 
 # mod miden:counter-contract/counter@0.1.0::counter_contract
@@ -233,7 +233,7 @@ proc.counter_contract::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:counter-contract/counter@0.1.0#get-count
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -243,7 +243,7 @@ export.miden:counter-contract/counter@0.1.0#get-count
     nop
     push.32
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -432,7 +432,7 @@ export.miden:counter-contract/counter@0.1.0#get-count
     movup.2
     swap.1
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -443,7 +443,7 @@ export.miden:counter-contract/counter@0.1.0#get-count
 end
 
 export.miden:counter-contract/counter@0.1.0#increment-count
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -453,7 +453,7 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     nop
     push.80
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -744,7 +744,7 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     movup.2
     swap.1
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -755,7 +755,7 @@ export.miden:counter-contract/counter@0.1.0#increment-count
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -784,7 +784,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114180
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/examples/counter.masm
+++ b/tests/integration/expected/examples/counter.masm
@@ -21,7 +21,7 @@ export.increment-count
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -38,10 +38,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262160
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262161
+    mem_store.278529
 end
 
 # mod miden:counter-contract/counter@0.1.0::counter_contract
@@ -233,7 +233,7 @@ proc.counter_contract::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:counter-contract/counter@0.1.0#get-count
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -243,7 +243,7 @@ export.miden:counter-contract/counter@0.1.0#get-count
     nop
     push.32
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -432,7 +432,7 @@ export.miden:counter-contract/counter@0.1.0#get-count
     movup.2
     swap.1
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -443,7 +443,7 @@ export.miden:counter-contract/counter@0.1.0#get-count
 end
 
 export.miden:counter-contract/counter@0.1.0#increment-count
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -453,7 +453,7 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     nop
     push.80
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -744,7 +744,7 @@ export.miden:counter-contract/counter@0.1.0#increment-count
     movup.2
     swap.1
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -755,7 +755,7 @@ export.miden:counter-contract/counter@0.1.0#increment-count
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048644
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -784,7 +784,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048644
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/examples/counter_note.masm
+++ b/tests/integration/expected/examples/counter_note.masm
@@ -11,7 +11,7 @@ export.note-script
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262160
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262161
+    mem_store.278529
 end
 
 # mod miden:base/note-script@1.0.0::counter_note
@@ -90,7 +90,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048644
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -119,7 +119,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048644
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/examples/counter_note.masm
+++ b/tests/integration/expected/examples/counter_note.masm
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278545
 end
 
 # mod miden:base/note-script@1.0.0::counter_note
@@ -90,7 +90,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -119,7 +119,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114180
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/examples/fib.masm
+++ b/tests/integration/expected/examples/fib.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::fibonacci

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -11,7 +11,7 @@ export.note-script
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262184
+    mem_store.278568
     push.0
     u32assert
-    mem_store.262185
+    mem_store.278569
 end
 
 # mod miden:base/note-script@1.0.0::p2id
@@ -81,7 +81,7 @@ proc.p2id::bindings::__link_custom_section_describing_imports
 end
 
 proc.__rustc::__rust_alloc
-    push.1048740
+    push.1114276
     u32divmod.4
     swap.1
     trace.240
@@ -107,7 +107,7 @@ proc.__rustc::__rust_dealloc
 end
 
 proc.__rustc::__rust_alloc_zeroed
-    push.1048740
+    push.1114276
     u32divmod.4
     swap.1
     trace.240
@@ -193,7 +193,7 @@ proc.__rustc::__rust_alloc_zeroed
 end
 
 export.miden:base/note-script@1.0.0#note-script
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -203,7 +203,7 @@ export.miden:base/note-script@1.0.0#note-script
     nop
     push.32
     u32wrapping_sub
-    push.1048736
+    push.1114272
     dup.1
     swap.1
     u32divmod.4
@@ -564,7 +564,7 @@ export.miden:base/note-script@1.0.0#note-script
         nop
         push.32
         u32wrapping_add
-        push.1048736
+        push.1114272
         u32divmod.4
         swap.1
         trace.240
@@ -580,7 +580,7 @@ proc.__rustc::__rust_no_alloc_shim_is_unstable_v2
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048740
+    push.1114276
     u32divmod.4
     swap.1
     trace.240
@@ -609,7 +609,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048740
+        push.1114276
         u32divmod.4
         swap.1
         trace.240
@@ -831,7 +831,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -841,7 +841,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
     nop
     push.16
     u32wrapping_sub
-    push.1048736
+    push.1114272
     dup.1
     swap.1
     u32divmod.4
@@ -961,7 +961,7 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
         nop
         push.16
         u32wrapping_add
-        push.1048736
+        push.1114272
         u32divmod.4
         swap.1
         trace.240
@@ -1009,7 +1009,7 @@ proc.miden_base_sys::bindings::account::get_id
 end
 
 proc.miden_base_sys::bindings::note::get_inputs
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1019,7 +1019,7 @@ proc.miden_base_sys::bindings::note::get_inputs
     nop
     push.16
     u32wrapping_sub
-    push.1048736
+    push.1114272
     dup.1
     swap.1
     u32divmod.4
@@ -1029,7 +1029,7 @@ proc.miden_base_sys::bindings::note::get_inputs
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    push.1048740
+    push.1114276
     u32divmod.4
     swap.1
     trace.240
@@ -1145,7 +1145,7 @@ proc.miden_base_sys::bindings::note::get_inputs
     nop
     push.16
     u32wrapping_add
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1156,7 +1156,7 @@ proc.miden_base_sys::bindings::note::get_inputs
 end
 
 proc.miden_base_sys::bindings::note::get_assets
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1166,7 +1166,7 @@ proc.miden_base_sys::bindings::note::get_assets
     nop
     push.16
     u32wrapping_sub
-    push.1048736
+    push.1114272
     dup.1
     swap.1
     u32divmod.4
@@ -1176,7 +1176,7 @@ proc.miden_base_sys::bindings::note::get_assets
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    push.1048740
+    push.1114276
     u32divmod.4
     swap.1
     trace.240
@@ -1292,7 +1292,7 @@ proc.miden_base_sys::bindings::note::get_assets
     nop
     push.16
     u32wrapping_add
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1303,7 +1303,7 @@ proc.miden_base_sys::bindings::note::get_assets
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::deallocate
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1313,7 +1313,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     nop
     push.16
     u32wrapping_sub
-    push.1048736
+    push.1114272
     dup.1
     swap.1
     u32divmod.4
@@ -1406,7 +1406,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     end
     push.16
     u32wrapping_add
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1417,7 +1417,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1427,7 +1427,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_sub
-    push.1048736
+    push.1114272
     dup.1
     swap.1
     u32divmod.4
@@ -1814,7 +1814,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_add
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1825,7 +1825,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
 end
 
 proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240
@@ -1835,7 +1835,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_sub
-    push.1048736
+    push.1114272
     dup.1
     swap.1
     u32divmod.4
@@ -1929,7 +1929,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_add
-    push.1048736
+    push.1114272
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/examples/storage_example.masm
+++ b/tests/integration/expected/examples/storage_example.masm
@@ -38,10 +38,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278545
 end
 
 # mod miden:storage-example/foo@1.0.0::storage_example
@@ -282,7 +282,7 @@ proc.storage_example::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:storage-example/foo@1.0.0#set-asset-qty
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -292,7 +292,7 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     nop
     push.64
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -545,7 +545,7 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     end
     push.64
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -556,7 +556,7 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
 end
 
 export.miden:storage-example/foo@1.0.0#get-asset-qty
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -566,7 +566,7 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     nop
     push.32
     u32wrapping_sub
-    push.1114112
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -688,7 +688,7 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     movup.2
     swap.1
     u32wrapping_add
-    push.1114112
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -699,7 +699,7 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -728,7 +728,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114180
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/examples/storage_example.masm
+++ b/tests/integration/expected/examples/storage_example.masm
@@ -21,7 +21,7 @@ export.get-asset-qty
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -38,10 +38,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262160
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262161
+    mem_store.278529
 end
 
 # mod miden:storage-example/foo@1.0.0::storage_example
@@ -282,7 +282,7 @@ proc.storage_example::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:storage-example/foo@1.0.0#set-asset-qty
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -292,7 +292,7 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     nop
     push.64
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -545,7 +545,7 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
     end
     push.64
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -556,7 +556,7 @@ export.miden:storage-example/foo@1.0.0#set-asset-qty
 end
 
 export.miden:storage-example/foo@1.0.0#get-asset-qty
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -566,7 +566,7 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     nop
     push.32
     u32wrapping_sub
-    push.1048640
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -688,7 +688,7 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
     movup.2
     swap.1
     u32wrapping_add
-    push.1048640
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -699,7 +699,7 @@ export.miden:storage-example/foo@1.0.0#get-asset-qty
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048644
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -728,7 +728,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048644
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/func_arg_same.masm
+++ b/tests/integration/expected/func_arg_same.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::func_arg_same

--- a/tests/integration/expected/ge_felt.masm
+++ b/tests/integration/expected/ge_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::ge_felt

--- a/tests/integration/expected/ge_i32.masm
+++ b/tests/integration/expected/ge_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_1e76175a91b5fc3090baafa017f5a38c53c37f1e1a73be7ebaa886f57b9f86fb

--- a/tests/integration/expected/ge_i64.masm
+++ b/tests/integration/expected/ge_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_9edabb66d927b03a3d0e64c65bad79cd5488a5bf59a9059a832f3582c7184d6b

--- a/tests/integration/expected/ge_u16.masm
+++ b/tests/integration/expected/ge_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_6b89d656eff2711a9ee50d11f22845c4cbbc0df54339492d30dcf628910850d2

--- a/tests/integration/expected/ge_u32.masm
+++ b/tests/integration/expected/ge_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_a6a04660dda2007e5b39d22340b438c2120c4114b075c90883d9b212365eb5fe

--- a/tests/integration/expected/ge_u64.masm
+++ b/tests/integration/expected/ge_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_b008d40be4d6e94465c1a26de42c380b06e09a3774e7a937bf5c338fd437b333

--- a/tests/integration/expected/ge_u8.masm
+++ b/tests/integration/expected/ge_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_a7d66021fee4ca04dff85edcc2a0482cfea1494683ab39c1ae381746dfbf0d98

--- a/tests/integration/expected/gt_felt.masm
+++ b/tests/integration/expected/gt_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::gt_felt

--- a/tests/integration/expected/gt_i32.masm
+++ b/tests/integration/expected/gt_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_9d2e8775109dcfc1c935f1f5d3649375cc140aedefb7659a7c1d3720c82086ec

--- a/tests/integration/expected/gt_i64.masm
+++ b/tests/integration/expected/gt_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_7d82f2e08b811f59ed036f725c1b72ca685b95ee301d765a74b8f7da3048058b

--- a/tests/integration/expected/gt_u16.masm
+++ b/tests/integration/expected/gt_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_cacaae112ac2013d020f0f82f9c334edde1d01c5854d6174ba2ebf34c2a8fc37

--- a/tests/integration/expected/gt_u32.masm
+++ b/tests/integration/expected/gt_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_35873b6ce3c76e068032779fcd1e75617c26429a13cc7bcd687d3302885cf1f1

--- a/tests/integration/expected/gt_u64.masm
+++ b/tests/integration/expected/gt_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_6489ee5460bd7aa58670638ded1591ff3f7c6abbcc5423cc0a2f5a4feb1ca663

--- a/tests/integration/expected/gt_u8.masm
+++ b/tests/integration/expected/gt_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_455aa9bc12d63425df846020b1734fc76252696200bb44305ecdb2dacce6f789

--- a/tests/integration/expected/hash_elements.masm
+++ b/tests/integration/expected/hash_elements.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::hash_elements
@@ -70,7 +70,7 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_hash_memory
 end
 
 export.entrypoint
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -80,7 +80,7 @@ export.entrypoint
     nop
     push.16
     u32wrapping_sub
-    push.1048576
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -169,7 +169,7 @@ export.entrypoint
     nop
     push.16
     u32wrapping_add
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -186,7 +186,7 @@ proc.__rustc::__rust_dealloc
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::deallocate
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -196,7 +196,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     nop
     push.16
     u32wrapping_sub
-    push.1048576
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -289,7 +289,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     end
     push.16
     u32wrapping_add
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/hmerge.masm
+++ b/tests/integration/expected/hmerge.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::hmerge
 
 export.entrypoint
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -23,7 +23,7 @@ export.entrypoint
     nop
     push.48
     u32wrapping_sub
-    push.1048576
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -213,7 +213,7 @@ export.entrypoint
     movup.2
     swap.1
     u32wrapping_add
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/is_prime.masm
+++ b/tests/integration/expected/is_prime.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::is_prime

--- a/tests/integration/expected/le_felt.masm
+++ b/tests/integration/expected/le_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::le_felt

--- a/tests/integration/expected/le_i32.masm
+++ b/tests/integration/expected/le_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_92cb575434e29cb53446988749bb020eaeee06891c154db71ddd9e1df57a151a

--- a/tests/integration/expected/le_i64.masm
+++ b/tests/integration/expected/le_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_d1d5c9c08b80e76c14cb392695a30c0d0f06df4b14bd1301c713918bb7259fd5

--- a/tests/integration/expected/le_u16.masm
+++ b/tests/integration/expected/le_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_8e5b56cf449e682f0de4180f5e5ed7f7dd36f7d96e84a0c17bc979aa91efca6e

--- a/tests/integration/expected/le_u32.masm
+++ b/tests/integration/expected/le_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_bb7287e639f21ae334cbe77ea9953a6971d3586eb3527866fb5a973c6a9d7999

--- a/tests/integration/expected/le_u64.masm
+++ b/tests/integration/expected/le_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_175cf1929f30f3603a14a8443c3a31ee62ac12c89cd674c497750d11c4b1fcb6

--- a/tests/integration/expected/le_u8.masm
+++ b/tests/integration/expected/le_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_6b31118a71e100e1653e01e16012428a3ef4b388ea4b8aa8f00a0e4ff40c4ad9

--- a/tests/integration/expected/lt_felt.masm
+++ b/tests/integration/expected/lt_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::lt_felt

--- a/tests/integration/expected/lt_i32.masm
+++ b/tests/integration/expected/lt_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_5693119d28cd4640a4976d9000775e22d586752187efa219aae5739cf37d894a

--- a/tests/integration/expected/lt_i64.masm
+++ b/tests/integration/expected/lt_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_193ef2ef135ab65a9e3987e493e8cf00a81359975e6bffaf693a15c44afbf24b

--- a/tests/integration/expected/lt_u16.masm
+++ b/tests/integration/expected/lt_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_66380427a6137e56f56ac9060dff040ec50d21b1cf2dab70538313874bc4a594

--- a/tests/integration/expected/lt_u32.masm
+++ b/tests/integration/expected/lt_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_1fcb2f151e54a93413cfbf27b720161db50a02b59d060ed448c3ffe2c3c9cc6c

--- a/tests/integration/expected/lt_u64.masm
+++ b/tests/integration/expected/lt_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_416d83d84b3ae500f053222602966b59099d85bd2706dbbaf20b4eb34e76cf0e

--- a/tests/integration/expected/lt_u8.masm
+++ b/tests/integration/expected/lt_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_b8700ecc87997bcf6eefb8bf0b6e645582a0ad9339bbe24fccc168e4c61e746e

--- a/tests/integration/expected/mul_felt.masm
+++ b/tests/integration/expected/mul_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::mul_felt

--- a/tests/integration/expected/mul_i32.masm
+++ b/tests/integration/expected/mul_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_4a870fe7a144fba5513f0d246ed1179aba172aab8f12afb574634dd1bb298024

--- a/tests/integration/expected/mul_i64.masm
+++ b/tests/integration/expected/mul_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_ee95318918a451f864b66b576532b422841bcd75ad8a62c4d4d3489a9158c08d

--- a/tests/integration/expected/mul_u16.masm
+++ b/tests/integration/expected/mul_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_1503849cd0d258094fa54f6a7e16334db70e5daa56a5858f344d2a2c90b757d6

--- a/tests/integration/expected/mul_u32.masm
+++ b/tests/integration/expected/mul_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_774ac315a535180c25b481293c43de2ad5b38b8ed718ccd906a367b8df969453

--- a/tests/integration/expected/mul_u64.masm
+++ b/tests/integration/expected/mul_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_ef43647914852c132ded20e7ab9569f69610af521a6074095544ea088f8908ae

--- a/tests/integration/expected/mul_u8.masm
+++ b/tests/integration/expected/mul_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_3332f4e22611553fee6834bdfb5edc7af11b545fb7a55941be9fef2efaecf059

--- a/tests/integration/expected/neg_felt.masm
+++ b/tests/integration/expected/neg_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::neg_felt

--- a/tests/integration/expected/neg_i16.masm
+++ b/tests/integration/expected/neg_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_ff799fd5021c298afc16f98dda4d174c028df9b4ad9e425d365d3c1fb3cef25a

--- a/tests/integration/expected/neg_i32.masm
+++ b/tests/integration/expected/neg_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_ad225f3904404156f79b92bcde2daa108dc69c4c2e00a61030a898c2fcb6f87c

--- a/tests/integration/expected/neg_i64.masm
+++ b/tests/integration/expected/neg_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_7e6ecbf37c062a73130e37145b77eb9dd3cce8aa16128ac9fcca7dc837ca562c

--- a/tests/integration/expected/neg_i8.masm
+++ b/tests/integration/expected/neg_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_7564589530886ab89f7963543a4d7e1529e7436aaa330e5e742ddde3149deefe

--- a/tests/integration/expected/or_bool.masm
+++ b/tests/integration/expected/or_bool.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_f1d36010a1862f085dfb5f246228723fc87e291a764ca76107b03554afd7db26

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.masm
@@ -11,7 +11,7 @@ export.process-felt
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262153
+    mem_store.278529
 end
 
 # mod miden:cross-ctx-account/foo@1.0.0::cross_ctx_account
@@ -45,7 +45,7 @@ proc.cross_ctx_account::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:cross-ctx-account/foo@1.0.0#process-felt
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -98,7 +98,7 @@ export.miden:cross-ctx-account/foo@1.0.0#process-felt
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -127,7 +127,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048612
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.masm
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278536
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278537
 end
 
 # mod miden:cross-ctx-account/foo@1.0.0::cross_ctx_account
@@ -45,7 +45,7 @@ proc.cross_ctx_account::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:cross-ctx-account/foo@1.0.0#process-felt
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -98,7 +98,7 @@ export.miden:cross-ctx-account/foo@1.0.0#process-felt
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -127,7 +127,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114148
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_account_word.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account_word.masm
@@ -419,10 +419,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278536
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278537
 end
 
 # mod miden:cross-ctx-account-word/foo@1.0.0::cross_ctx_account_word
@@ -436,7 +436,7 @@ proc.cross_ctx_account_word::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-word
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -539,7 +539,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-word
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-another-word
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -652,7 +652,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-felt
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-pair
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -711,7 +711,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-pair
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-triple
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -792,7 +792,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-triple
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-mixed
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -1004,7 +1004,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-mixed
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-nested
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -1085,7 +1085,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-nested
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -1114,7 +1114,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114148
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_account_word.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account_word.masm
@@ -402,7 +402,7 @@ export.process-nested
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -419,10 +419,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262153
+    mem_store.278529
 end
 
 # mod miden:cross-ctx-account-word/foo@1.0.0::cross_ctx_account_word
@@ -436,7 +436,7 @@ proc.cross_ctx_account_word::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-word
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -539,7 +539,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-word
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-another-word
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -652,7 +652,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-felt
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-pair
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -711,7 +711,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-pair
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-triple
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -792,7 +792,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-triple
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-mixed
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -1004,7 +1004,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-mixed
 end
 
 export.miden:cross-ctx-account-word/foo@1.0.0#process-nested
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -1085,7 +1085,7 @@ export.miden:cross-ctx-account-word/foo@1.0.0#process-nested
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -1114,7 +1114,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048612
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_account_word_arg.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account_word_arg.masm
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278536
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278537
 end
 
 # mod miden:cross-ctx-account-word-arg/foo@1.0.0::cross_ctx_account_word_arg
@@ -137,7 +137,7 @@ export.miden:cross-ctx-account-word-arg/foo@1.0.0#process-word.1
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -166,7 +166,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114148
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_account_word_arg.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account_word_arg.masm
@@ -11,7 +11,7 @@ export.process-word
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262153
+    mem_store.278529
 end
 
 # mod miden:cross-ctx-account-word-arg/foo@1.0.0::cross_ctx_account_word_arg
@@ -137,7 +137,7 @@ export.miden:cross-ctx-account-word-arg/foo@1.0.0#process-word.1
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -166,7 +166,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048612
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.masm
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278536
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278537
 end
 
 # mod miden:base/note-script@1.0.0::cross_ctx_note
@@ -53,7 +53,7 @@ proc.cross_ctx_note::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:base/note-script@1.0.0#note-script
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -116,7 +116,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -145,7 +145,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114148
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_note.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note.masm
@@ -11,7 +11,7 @@ export.note-script
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262153
+    mem_store.278529
 end
 
 # mod miden:base/note-script@1.0.0::cross_ctx_note
@@ -53,7 +53,7 @@ proc.cross_ctx_note::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:base/note-script@1.0.0#note-script
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -116,7 +116,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -145,7 +145,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048612
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_note_word.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note_word.masm
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278536
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278537
 end
 
 # mod miden:base/note-script@1.0.0::cross_ctx_note_word
@@ -458,7 +458,7 @@ proc.cross_ctx_note_word::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:base/note-script@1.0.0#note-script
-    push.1114112
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -468,7 +468,7 @@ export.miden:base/note-script@1.0.0#note-script
     nop
     push.32
     u32wrapping_sub
-    push.1114112
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -1092,7 +1092,7 @@ export.miden:base/note-script@1.0.0#note-script
         assert_eq
         push.32
         u32wrapping_add
-        push.1114112
+        push.1114144
         u32divmod.4
         swap.1
         trace.240
@@ -1108,7 +1108,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -1137,7 +1137,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114148
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_note_word.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note_word.masm
@@ -11,7 +11,7 @@ export.note-script
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262153
+    mem_store.278529
 end
 
 # mod miden:base/note-script@1.0.0::cross_ctx_note_word
@@ -458,7 +458,7 @@ proc.cross_ctx_note_word::bindings::__link_custom_section_describing_imports
 end
 
 export.miden:base/note-script@1.0.0#note-script
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -468,7 +468,7 @@ export.miden:base/note-script@1.0.0#note-script
     nop
     push.32
     u32wrapping_sub
-    push.1048608
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -1092,7 +1092,7 @@ export.miden:base/note-script@1.0.0#note-script
         assert_eq
         push.32
         u32wrapping_add
-        push.1048608
+        push.1114112
         u32divmod.4
         swap.1
         trace.240
@@ -1108,7 +1108,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -1137,7 +1137,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048612
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_note_word_arg.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note_word_arg.masm
@@ -11,7 +11,7 @@ export.note-script
 end
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
     push.0
     u32assert
-    mem_store.262153
+    mem_store.278529
 end
 
 # mod miden:base/note-script@1.0.0::cross_ctx_note_word_arg
@@ -91,7 +91,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1048612
+    push.1114116
     u32divmod.4
     swap.1
     trace.240
@@ -120,7 +120,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1048612
+        push.1114116
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/rust_sdk/cross_ctx_note_word_arg.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_note_word_arg.masm
@@ -28,10 +28,10 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278536
     push.0
     u32assert
-    mem_store.278529
+    mem_store.278537
 end
 
 # mod miden:base/note-script@1.0.0::cross_ctx_note_word_arg
@@ -91,7 +91,7 @@ export.miden:base/note-script@1.0.0#note-script
 end
 
 proc.wit_bindgen_rt::run_ctors_once
-    push.1114116
+    push.1114148
     u32divmod.4
     swap.1
     trace.240
@@ -120,7 +120,7 @@ proc.wit_bindgen_rt::run_ctors_once
     if.true
         nop
     else
-        push.1114116
+        push.1114148
         u32divmod.4
         swap.1
         trace.240

--- a/tests/integration/expected/shl_i16.masm
+++ b/tests/integration/expected/shl_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_c3eed17236100365f8c1660de046d9d6663a7b82697275884d4fcb6fa25a7447

--- a/tests/integration/expected/shl_i32.masm
+++ b/tests/integration/expected/shl_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_bb1e5acff11c647800da7bb67237f59cfa6dcc846fe64b76bfdce3d151cb1de9

--- a/tests/integration/expected/shl_i64.masm
+++ b/tests/integration/expected/shl_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_9d7fa5c817c0e8ad40aeb12756fb108047ae365f6bc8c673617a6bc264b3917a

--- a/tests/integration/expected/shl_i8.masm
+++ b/tests/integration/expected/shl_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_64d9b2f2c2b5e80b282b2d87195903012daf88be2507d12d0bc75d869a811922

--- a/tests/integration/expected/shl_u16.masm
+++ b/tests/integration/expected/shl_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_3ab387e5fafe4f8316074728a13b9c62413b6215a11492c80aa3e1d10383e008

--- a/tests/integration/expected/shl_u32.masm
+++ b/tests/integration/expected/shl_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_3618ee9a49fe14195a2097b20a230da5249d5b99ab7da35b402a7c16f4fa5609

--- a/tests/integration/expected/shl_u64.masm
+++ b/tests/integration/expected/shl_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_ef9c837ab7c2bd11aacdf5ad41eb9264c0daecd169f2b4cfe73fd928059744bb

--- a/tests/integration/expected/shl_u8.masm
+++ b/tests/integration/expected/shl_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_b211bf2251e0ca4732fe0f4b9390e5838c61a0ef97c8b47f099f8c5ab3657e7f

--- a/tests/integration/expected/shr_i64.masm
+++ b/tests/integration/expected/shr_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_186d93d83b74a241eb99ffa0ead88d2435a288695c19f22c9c35eecfda978717

--- a/tests/integration/expected/shr_u16.masm
+++ b/tests/integration/expected/shr_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_96d61f728452f9b581e6c765749adb51e9f48ad7e7527bde3c25a5943fa1a541

--- a/tests/integration/expected/shr_u32.masm
+++ b/tests/integration/expected/shr_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_98363f37c9b0fb3dc27cafaa81c0eb63c6a764c82cbedfc0da3e37a43e1d2331

--- a/tests/integration/expected/shr_u64.masm
+++ b/tests/integration/expected/shr_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_9efc7a825f7a743a5fc284e5d1f0d3fc1bb239f780841274be29a84565e75592

--- a/tests/integration/expected/shr_u8.masm
+++ b/tests/integration/expected/shr_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_04fd0cb7f25bc890cc2570ad64142734f4731c48e1507938bd1b769f028cf2c4

--- a/tests/integration/expected/sub_felt.masm
+++ b/tests/integration/expected/sub_felt.masm
@@ -1,13 +1,13 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::sub_felt

--- a/tests/integration/expected/sub_i16.masm
+++ b/tests/integration/expected/sub_i16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_b6360a7c4709c8e140b5433c6b25904ac7efbab248a7f37933a33b31d5f40c49

--- a/tests/integration/expected/sub_i32.masm
+++ b/tests/integration/expected/sub_i32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_6fc6fd0b2e86628d32094545ba25215329fcd62cd1f981d0dbdd2c989eed3a52

--- a/tests/integration/expected/sub_i64.masm
+++ b/tests/integration/expected/sub_i64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_c2e6cec606b20447e4c5accdc801c32098f0d7cda3811f8c4e38f16911210b8f

--- a/tests/integration/expected/sub_i8.masm
+++ b/tests/integration/expected/sub_i8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_c22e1496a88c74570b0e64374e0cf2e7a89efbbc6ead48d3e0471d8654d2afdc

--- a/tests/integration/expected/sub_u16.masm
+++ b/tests/integration/expected/sub_u16.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_d8aa82f0674d72cf16435a3b3f6c248ab8b08b77539ac08b01e393fd53f96cb7

--- a/tests/integration/expected/sub_u32.masm
+++ b/tests/integration/expected/sub_u32.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_19bb93ff4625e8bdb6a3470a0b61a142a94458a4ee602822cb8360bf1f07368f

--- a/tests/integration/expected/sub_u64.masm
+++ b/tests/integration/expected/sub_u64.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_07a967cd239987abbfb9236f41c9268dd55be09bc1efb30f1e4684134ef772b0

--- a/tests/integration/expected/sub_u8.masm
+++ b/tests/integration/expected/sub_u8.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_be0120d0a160e710cbd53bd6dc4ac525bbb3596615ae6ec2d5f88c74c069aabe

--- a/tests/integration/expected/types/array.masm
+++ b/tests/integration/expected/types/array.masm
@@ -18,13 +18,13 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278544
     push.1048616
     u32assert
-    mem_store.278529
+    mem_store.278545
     push.1048624
     u32assert
-    mem_store.278530
+    mem_store.278546
 end
 
 # mod root_ns:root@1.0.0::test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6

--- a/tests/integration/expected/types/array.masm
+++ b/tests/integration/expected/types/array.masm
@@ -1,7 +1,7 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -18,13 +18,13 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262160
+    mem_store.278528
     push.1048616
     u32assert
-    mem_store.262161
+    mem_store.278529
     push.1048624
     u32assert
-    mem_store.262162
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6

--- a/tests/integration/expected/types/static_mut.masm
+++ b/tests/integration/expected/types/static_mut.masm
@@ -18,13 +18,13 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.278528
+    mem_store.278536
     push.1048585
     u32assert
-    mem_store.278529
+    mem_store.278537
     push.1048592
     u32assert
-    mem_store.278530
+    mem_store.278538
 end
 
 # mod root_ns:root@1.0.0::test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4

--- a/tests/integration/expected/types/static_mut.masm
+++ b/tests/integration/expected/types/static_mut.masm
@@ -1,7 +1,7 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -18,13 +18,13 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
     push.1048585
     u32assert
-    mem_store.262153
+    mem_store.278529
     push.1048592
     u32assert
-    mem_store.262154
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4

--- a/tests/integration/expected/vec_alloc_new.masm
+++ b/tests/integration/expected/vec_alloc_new.masm
@@ -1,7 +1,7 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
@@ -18,14 +18,14 @@ export.init
     drop
     push.1048576
     u32assert
-    mem_store.262152
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::vec_alloc_new
 
 export.entrypoint
     drop
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -35,7 +35,7 @@ export.entrypoint
     nop
     push.32
     u32wrapping_sub
-    push.1048608
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -195,7 +195,7 @@ export.entrypoint
         nop
         push.32
         u32wrapping_add
-        push.1048608
+        push.1114112
         u32divmod.4
         swap.1
         trace.240
@@ -512,7 +512,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::deallocate
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -522,7 +522,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     nop
     push.16
     u32wrapping_sub
-    push.1048608
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -615,7 +615,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     end
     push.16
     u32wrapping_add
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -626,7 +626,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -636,7 +636,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_sub
-    push.1048608
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -1023,7 +1023,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
     nop
     push.16
     u32wrapping_add
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -1034,7 +1034,7 @@ proc.alloc::raw_vec::RawVecInner<A>::try_allocate_in
 end
 
 proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -1044,7 +1044,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_sub
-    push.1048608
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -1138,7 +1138,7 @@ proc.<alloc::alloc::Global as core::alloc::Allocator>::allocate
     nop
     push.16
     u32wrapping_add
-    push.1048608
+    push.1114112
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/vec_alloc_vec.hir
+++ b/tests/integration/expected/vec_alloc_vec.hir
@@ -1,387 +1,436 @@
 builtin.component root_ns:root@1.0.0 {
     builtin.module public @vec_alloc_vec {
-        public builtin.function @entrypoint(v0: felt) -> felt {
-        ^block6(v0: felt):
-            v3 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
-            v4 = hir.bitcast v3 : ptr<byte, i32>;
-            v5 = hir.load v4 : i32;
-            v6 = arith.constant 16 : i32;
-            v7 = arith.sub v5, v6 : i32 #[overflow = wrapping];
-            v8 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
-            v9 = hir.bitcast v8 : ptr<byte, i32>;
-            hir.store v9, v7;
+        public builtin.function @entrypoint(v0: i32) -> felt {
+        ^block6(v0: i32):
+            v4 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
+            v5 = hir.bitcast v4 : ptr<byte, i32>;
+            v6 = hir.load v5 : i32;
+            v7 = arith.constant 16 : i32;
+            v8 = arith.sub v6, v7 : i32 #[overflow = wrapping];
+            v9 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
+            v10 = hir.bitcast v9 : ptr<byte, i32>;
+            hir.store v10, v8;
             hir.exec @root_ns:root@1.0.0/vec_alloc_vec/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-            v11 = arith.constant 4 : i32;
-            v10 = arith.constant 8 : i32;
-            v12 = hir.exec @root_ns:root@1.0.0/vec_alloc_vec/__rustc::__rust_alloc(v10, v11) : i32
+            v12 = arith.constant 4 : i32;
+            v11 = arith.constant 12 : i32;
+            v13 = hir.exec @root_ns:root@1.0.0/vec_alloc_vec/__rustc::__rust_alloc(v11, v12) : i32
+            v335 = arith.constant 0 : i32;
             v2 = arith.constant 0 : i32;
-            v14 = arith.neq v12, v2 : i1;
-            cf.cond_br v14 ^block8, ^block9;
+            v15 = arith.eq v13, v2 : i1;
+            v16 = arith.zext v15 : u32;
+            v17 = hir.bitcast v16 : i32;
+            v19 = arith.neq v17, v335 : i1;
+            v308, v309 = scf.if v19 : felt, u32 {
+            ^block9:
+                v333 = arith.constant 12 : i32;
+                v334 = arith.constant 4 : i32;
+                hir.exec @root_ns:root@1.0.0/vec_alloc_vec/alloc::alloc::handle_alloc_error(v334, v333)
+                v300 = arith.constant 0 : u32;
+                v304 = ub.poison felt : felt;
+                scf.yield v304, v300;
+            } else {
+            ^block10:
+                v27 = arith.constant 8 : u32;
+                v26 = hir.bitcast v13 : u32;
+                v28 = arith.add v26, v27 : u32 #[overflow = checked];
+                v29 = arith.constant 4 : u32;
+                v30 = arith.mod v28, v29 : u32;
+                hir.assertz v30 #[code = 250];
+                v297 = arith.constant 3 : felt;
+                v31 = hir.int_to_ptr v28 : ptr<byte, felt>;
+                hir.store v31, v297;
+                v332 = arith.constant 4 : u32;
+                v32 = hir.bitcast v13 : u32;
+                v34 = arith.add v32, v332 : u32 #[overflow = checked];
+                v331 = arith.constant 4 : u32;
+                v36 = arith.mod v34, v331 : u32;
+                hir.assertz v36 #[code = 250];
+                v298 = arith.constant 2 : felt;
+                v37 = hir.int_to_ptr v34 : ptr<byte, felt>;
+                hir.store v37, v298;
+                v38 = hir.bitcast v13 : u32;
+                v330 = arith.constant 4 : u32;
+                v40 = arith.mod v38, v330 : u32;
+                hir.assertz v40 #[code = 250];
+                v299 = arith.constant 1 : felt;
+                v41 = hir.int_to_ptr v38 : ptr<byte, felt>;
+                hir.store v41, v299;
+                v44 = arith.constant 12 : u32;
+                v43 = hir.bitcast v8 : u32;
+                v45 = arith.add v43, v44 : u32 #[overflow = checked];
+                v329 = arith.constant 4 : u32;
+                v47 = arith.mod v45, v329 : u32;
+                hir.assertz v47 #[code = 250];
+                v24 = arith.constant 3 : i32;
+                v48 = hir.int_to_ptr v45 : ptr<byte, i32>;
+                hir.store v48, v24;
+                v328 = arith.constant 8 : u32;
+                v49 = hir.bitcast v8 : u32;
+                v51 = arith.add v49, v328 : u32 #[overflow = checked];
+                v327 = arith.constant 4 : u32;
+                v53 = arith.mod v51, v327 : u32;
+                hir.assertz v53 #[code = 250];
+                v54 = hir.int_to_ptr v51 : ptr<byte, i32>;
+                hir.store v54, v13;
+                v326 = arith.constant 4 : u32;
+                v56 = hir.bitcast v8 : u32;
+                v58 = arith.add v56, v326 : u32 #[overflow = checked];
+                v325 = arith.constant 4 : u32;
+                v60 = arith.mod v58, v325 : u32;
+                hir.assertz v60 #[code = 250];
+                v324 = arith.constant 3 : i32;
+                v61 = hir.int_to_ptr v58 : ptr<byte, i32>;
+                hir.store v61, v324;
+                v323 = arith.constant 0 : i32;
+                v296 = arith.constant 3 : u32;
+                v63 = hir.bitcast v0 : u32;
+                v65 = arith.gte v63, v296 : i1;
+                v66 = arith.zext v65 : u32;
+                v67 = hir.bitcast v66 : i32;
+                v69 = arith.neq v67, v323 : i1;
+                v314 = scf.if v69 : felt {
+                ^block44:
+                    v322 = ub.poison felt : felt;
+                    scf.yield v322;
+                } else {
+                ^block11:
+                    v295 = arith.constant 2 : u32;
+                    v72 = arith.shl v0, v295 : i32;
+                    v73 = arith.add v13, v72 : i32 #[overflow = wrapping];
+                    v74 = hir.bitcast v73 : u32;
+                    v321 = arith.constant 4 : u32;
+                    v76 = arith.mod v74, v321 : u32;
+                    hir.assertz v76 #[code = 250];
+                    v77 = hir.int_to_ptr v74 : ptr<byte, felt>;
+                    v78 = hir.load v77 : felt;
+                    v319 = arith.constant 4 : i32;
+                    v320 = arith.constant 4 : i32;
+                    v80 = arith.add v8, v320 : i32 #[overflow = wrapping];
+                    hir.exec @root_ns:root@1.0.0/vec_alloc_vec/alloc::raw_vec::RawVecInner<A>::deallocate(v80, v319, v319)
+                    v318 = arith.constant 16 : i32;
+                    v84 = arith.add v8, v318 : i32 #[overflow = wrapping];
+                    v85 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
+                    v86 = hir.bitcast v85 : ptr<byte, i32>;
+                    hir.store v86, v84;
+                    scf.yield v78;
+                };
+                v305 = arith.constant 1 : u32;
+                v317 = arith.constant 0 : u32;
+                v315 = cf.select v69, v317, v305 : u32;
+                scf.yield v314, v315;
+            };
+            v316 = arith.constant 0 : u32;
+            v313 = arith.eq v309, v316 : i1;
+            cf.cond_br v313 ^block8, ^block46(v308);
         ^block8:
-            v18 = arith.constant 4 : u32;
-            v17 = hir.bitcast v12 : u32;
-            v19 = arith.add v17, v18 : u32 #[overflow = checked];
-            v281 = arith.constant 4 : u32;
-            v21 = arith.mod v19, v281 : u32;
-            hir.assertz v21 #[code = 250];
-            v22 = hir.int_to_ptr v19 : ptr<byte, felt>;
-            hir.store v22, v0;
-            v23 = hir.bitcast v12 : u32;
-            v280 = arith.constant 4 : u32;
-            v25 = arith.mod v23, v280 : u32;
-            hir.assertz v25 #[code = 250];
-            v26 = hir.int_to_ptr v23 : ptr<byte, felt>;
-            hir.store v26, v0;
-            v29 = arith.constant 12 : u32;
-            v28 = hir.bitcast v7 : u32;
-            v30 = arith.add v28, v29 : u32 #[overflow = checked];
-            v279 = arith.constant 4 : u32;
-            v32 = arith.mod v30, v279 : u32;
-            hir.assertz v32 #[code = 250];
-            v27 = arith.constant 2 : i32;
-            v33 = hir.int_to_ptr v30 : ptr<byte, i32>;
-            hir.store v33, v27;
-            v35 = arith.constant 8 : u32;
-            v34 = hir.bitcast v7 : u32;
-            v36 = arith.add v34, v35 : u32 #[overflow = checked];
-            v278 = arith.constant 4 : u32;
-            v38 = arith.mod v36, v278 : u32;
-            hir.assertz v38 #[code = 250];
-            v39 = hir.int_to_ptr v36 : ptr<byte, i32>;
-            hir.store v39, v12;
-            v277 = arith.constant 4 : u32;
-            v41 = hir.bitcast v7 : u32;
-            v43 = arith.add v41, v277 : u32 #[overflow = checked];
-            v276 = arith.constant 4 : u32;
-            v45 = arith.mod v43, v276 : u32;
-            hir.assertz v45 #[code = 250];
-            v275 = arith.constant 2 : i32;
-            v46 = hir.int_to_ptr v43 : ptr<byte, i32>;
-            hir.store v46, v275;
-            v267 = arith.constant 1048576 : felt;
-            v47 = hir.bitcast v12 : felt;
-            hir.assert_eq v47, v267;
-            v273 = arith.constant 4 : i32;
-            v274 = arith.constant 4 : i32;
-            v53 = arith.add v7, v274 : i32 #[overflow = wrapping];
-            hir.exec @root_ns:root@1.0.0/vec_alloc_vec/alloc::raw_vec::RawVecInner<A>::deallocate(v53, v273, v273)
-            v272 = arith.constant 16 : i32;
-            v57 = arith.add v7, v272 : i32 #[overflow = wrapping];
-            v58 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
-            v59 = hir.bitcast v58 : ptr<byte, i32>;
-            hir.store v59, v57;
-            v266 = arith.constant 0 : felt;
-            builtin.ret v266;
-        ^block9:
-            v270 = arith.constant 8 : i32;
-            v271 = arith.constant 4 : i32;
-            hir.exec @root_ns:root@1.0.0/vec_alloc_vec/alloc::alloc::handle_alloc_error(v271, v270)
             ub.unreachable ;
+        ^block46(v301: felt):
+            builtin.ret v301;
         };
 
-        private builtin.function @__rustc::__rust_alloc(v60: i32, v61: i32) -> i32 {
-        ^block10(v60: i32, v61: i32):
-            v63 = arith.constant 1048576 : i32;
-            v64 = hir.exec @root_ns:root@1.0.0/vec_alloc_vec/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v63, v61, v60) : i32
-            builtin.ret v64;
+        private builtin.function @__rustc::__rust_alloc(v89: i32, v90: i32) -> i32 {
+        ^block12(v89: i32, v90: i32):
+            v92 = arith.constant 1048576 : i32;
+            v93 = hir.exec @root_ns:root@1.0.0/vec_alloc_vec/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v92, v90, v89) : i32
+            builtin.ret v93;
         };
 
-        private builtin.function @__rustc::__rust_dealloc(v65: i32, v66: i32, v67: i32) {
-        ^block12(v65: i32, v66: i32, v67: i32):
+        private builtin.function @__rustc::__rust_dealloc(v94: i32, v95: i32, v96: i32) {
+        ^block14(v94: i32, v95: i32, v96: i32):
             builtin.ret ;
         };
 
         private builtin.function @__rustc::__rust_no_alloc_shim_is_unstable_v2() {
-        ^block14:
+        ^block16:
             builtin.ret ;
         };
 
-        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v68: i32, v69: i32, v70: i32) -> i32 {
-        ^block16(v68: i32, v69: i32, v70: i32):
-            v73 = arith.constant 16 : i32;
-            v72 = arith.constant 0 : i32;
-            v283 = arith.constant 16 : u32;
-            v75 = hir.bitcast v69 : u32;
-            v77 = arith.gt v75, v283 : i1;
-            v78 = arith.zext v77 : u32;
-            v79 = hir.bitcast v78 : i32;
-            v81 = arith.neq v79, v72 : i1;
-            v82 = cf.select v81, v69, v73 : i32;
-            v322 = arith.constant 0 : i32;
-            v83 = arith.constant -1 : i32;
-            v84 = arith.add v82, v83 : i32 #[overflow = wrapping];
-            v85 = arith.band v82, v84 : i32;
-            v87 = arith.neq v85, v322 : i1;
-            v292, v293 = scf.if v87 : i32, u32 {
-            ^block46:
-                v284 = arith.constant 0 : u32;
-                v288 = ub.poison i32 : i32;
-                scf.yield v288, v284;
+        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v97: i32, v98: i32, v99: i32) -> i32 {
+        ^block18(v97: i32, v98: i32, v99: i32):
+            v102 = arith.constant 16 : i32;
+            v101 = arith.constant 0 : i32;
+            v337 = arith.constant 16 : u32;
+            v104 = hir.bitcast v98 : u32;
+            v106 = arith.gt v104, v337 : i1;
+            v107 = arith.zext v106 : u32;
+            v108 = hir.bitcast v107 : i32;
+            v110 = arith.neq v108, v101 : i1;
+            v111 = cf.select v110, v98, v102 : i32;
+            v376 = arith.constant 0 : i32;
+            v112 = arith.constant -1 : i32;
+            v113 = arith.add v111, v112 : i32 #[overflow = wrapping];
+            v114 = arith.band v111, v113 : i32;
+            v116 = arith.neq v114, v376 : i1;
+            v346, v347 = scf.if v116 : i32, u32 {
+            ^block51:
+                v338 = arith.constant 0 : u32;
+                v342 = ub.poison i32 : i32;
+                scf.yield v342, v338;
             } else {
-            ^block19:
-                v89 = hir.exec @root_ns:root@1.0.0/vec_alloc_vec/core::ptr::alignment::Alignment::max(v69, v82) : i32
-                v321 = arith.constant 0 : i32;
-                v88 = arith.constant -2147483648 : i32;
-                v90 = arith.sub v88, v89 : i32 #[overflow = wrapping];
-                v92 = hir.bitcast v90 : u32;
-                v91 = hir.bitcast v70 : u32;
-                v93 = arith.gt v91, v92 : i1;
-                v94 = arith.zext v93 : u32;
-                v95 = hir.bitcast v94 : i32;
-                v97 = arith.neq v95, v321 : i1;
-                v307 = scf.if v97 : i32 {
-                ^block45:
-                    v320 = ub.poison i32 : i32;
-                    scf.yield v320;
+            ^block21:
+                v118 = hir.exec @root_ns:root@1.0.0/vec_alloc_vec/core::ptr::alignment::Alignment::max(v98, v111) : i32
+                v375 = arith.constant 0 : i32;
+                v117 = arith.constant -2147483648 : i32;
+                v119 = arith.sub v117, v118 : i32 #[overflow = wrapping];
+                v121 = hir.bitcast v119 : u32;
+                v120 = hir.bitcast v99 : u32;
+                v122 = arith.gt v120, v121 : i1;
+                v123 = arith.zext v122 : u32;
+                v124 = hir.bitcast v123 : i32;
+                v126 = arith.neq v124, v375 : i1;
+                v361 = scf.if v126 : i32 {
+                ^block50:
+                    v374 = ub.poison i32 : i32;
+                    scf.yield v374;
                 } else {
-                ^block20:
-                    v318 = arith.constant 0 : i32;
-                    v103 = arith.sub v318, v89 : i32 #[overflow = wrapping];
-                    v319 = arith.constant -1 : i32;
-                    v99 = arith.add v70, v89 : i32 #[overflow = wrapping];
-                    v101 = arith.add v99, v319 : i32 #[overflow = wrapping];
-                    v104 = arith.band v101, v103 : i32;
-                    v105 = hir.bitcast v68 : u32;
-                    v106 = arith.constant 4 : u32;
-                    v107 = arith.mod v105, v106 : u32;
-                    hir.assertz v107 #[code = 250];
-                    v108 = hir.int_to_ptr v105 : ptr<byte, i32>;
-                    v109 = hir.load v108 : i32;
-                    v317 = arith.constant 0 : i32;
-                    v111 = arith.neq v109, v317 : i1;
-                    scf.if v111{
-                    ^block44:
+                ^block22:
+                    v372 = arith.constant 0 : i32;
+                    v132 = arith.sub v372, v118 : i32 #[overflow = wrapping];
+                    v373 = arith.constant -1 : i32;
+                    v128 = arith.add v99, v118 : i32 #[overflow = wrapping];
+                    v130 = arith.add v128, v373 : i32 #[overflow = wrapping];
+                    v133 = arith.band v130, v132 : i32;
+                    v134 = hir.bitcast v97 : u32;
+                    v135 = arith.constant 4 : u32;
+                    v136 = arith.mod v134, v135 : u32;
+                    hir.assertz v136 #[code = 250];
+                    v137 = hir.int_to_ptr v134 : ptr<byte, i32>;
+                    v138 = hir.load v137 : i32;
+                    v371 = arith.constant 0 : i32;
+                    v140 = arith.neq v138, v371 : i1;
+                    scf.if v140{
+                    ^block49:
                         scf.yield ;
-                    } else {
-                    ^block22:
-                        v112 = hir.exec @intrinsics/mem/heap_base() : i32
-                        v113 = hir.mem_size  : u32;
-                        v119 = hir.bitcast v68 : u32;
-                        v316 = arith.constant 4 : u32;
-                        v121 = arith.mod v119, v316 : u32;
-                        hir.assertz v121 #[code = 250];
-                        v315 = arith.constant 16 : u32;
-                        v114 = hir.bitcast v113 : i32;
-                        v117 = arith.shl v114, v315 : i32;
-                        v118 = arith.add v112, v117 : i32 #[overflow = wrapping];
-                        v122 = hir.int_to_ptr v119 : ptr<byte, i32>;
-                        hir.store v122, v118;
-                        scf.yield ;
-                    };
-                    v125 = hir.bitcast v68 : u32;
-                    v314 = arith.constant 4 : u32;
-                    v127 = arith.mod v125, v314 : u32;
-                    hir.assertz v127 #[code = 250];
-                    v128 = hir.int_to_ptr v125 : ptr<byte, i32>;
-                    v129 = hir.load v128 : i32;
-                    v313 = arith.constant 0 : i32;
-                    v133 = hir.bitcast v104 : u32;
-                    v123 = arith.constant 268435456 : i32;
-                    v130 = arith.sub v123, v129 : i32 #[overflow = wrapping];
-                    v132 = hir.bitcast v130 : u32;
-                    v134 = arith.lt v132, v133 : i1;
-                    v135 = arith.zext v134 : u32;
-                    v136 = hir.bitcast v135 : i32;
-                    v138 = arith.neq v136, v313 : i1;
-                    v306 = scf.if v138 : i32 {
-                    ^block23:
-                        v312 = arith.constant 0 : i32;
-                        scf.yield v312;
                     } else {
                     ^block24:
-                        v140 = hir.bitcast v68 : u32;
-                        v311 = arith.constant 4 : u32;
-                        v142 = arith.mod v140, v311 : u32;
-                        hir.assertz v142 #[code = 250];
-                        v139 = arith.add v129, v104 : i32 #[overflow = wrapping];
-                        v143 = hir.int_to_ptr v140 : ptr<byte, i32>;
-                        hir.store v143, v139;
-                        v145 = arith.add v129, v89 : i32 #[overflow = wrapping];
-                        scf.yield v145;
+                        v141 = hir.exec @intrinsics/mem/heap_base() : i32
+                        v142 = hir.mem_size  : u32;
+                        v148 = hir.bitcast v97 : u32;
+                        v370 = arith.constant 4 : u32;
+                        v150 = arith.mod v148, v370 : u32;
+                        hir.assertz v150 #[code = 250];
+                        v369 = arith.constant 16 : u32;
+                        v143 = hir.bitcast v142 : i32;
+                        v146 = arith.shl v143, v369 : i32;
+                        v147 = arith.add v141, v146 : i32 #[overflow = wrapping];
+                        v151 = hir.int_to_ptr v148 : ptr<byte, i32>;
+                        hir.store v151, v147;
+                        scf.yield ;
                     };
-                    scf.yield v306;
+                    v154 = hir.bitcast v97 : u32;
+                    v368 = arith.constant 4 : u32;
+                    v156 = arith.mod v154, v368 : u32;
+                    hir.assertz v156 #[code = 250];
+                    v157 = hir.int_to_ptr v154 : ptr<byte, i32>;
+                    v158 = hir.load v157 : i32;
+                    v367 = arith.constant 0 : i32;
+                    v162 = hir.bitcast v133 : u32;
+                    v152 = arith.constant 268435456 : i32;
+                    v159 = arith.sub v152, v158 : i32 #[overflow = wrapping];
+                    v161 = hir.bitcast v159 : u32;
+                    v163 = arith.lt v161, v162 : i1;
+                    v164 = arith.zext v163 : u32;
+                    v165 = hir.bitcast v164 : i32;
+                    v167 = arith.neq v165, v367 : i1;
+                    v360 = scf.if v167 : i32 {
+                    ^block25:
+                        v366 = arith.constant 0 : i32;
+                        scf.yield v366;
+                    } else {
+                    ^block26:
+                        v169 = hir.bitcast v97 : u32;
+                        v365 = arith.constant 4 : u32;
+                        v171 = arith.mod v169, v365 : u32;
+                        hir.assertz v171 #[code = 250];
+                        v168 = arith.add v158, v133 : i32 #[overflow = wrapping];
+                        v172 = hir.int_to_ptr v169 : ptr<byte, i32>;
+                        hir.store v172, v168;
+                        v174 = arith.add v158, v118 : i32 #[overflow = wrapping];
+                        scf.yield v174;
+                    };
+                    scf.yield v360;
                 };
-                v289 = arith.constant 1 : u32;
-                v310 = arith.constant 0 : u32;
-                v308 = cf.select v97, v310, v289 : u32;
-                scf.yield v307, v308;
+                v343 = arith.constant 1 : u32;
+                v364 = arith.constant 0 : u32;
+                v362 = cf.select v126, v364, v343 : u32;
+                scf.yield v361, v362;
             };
-            v309 = arith.constant 0 : u32;
-            v305 = arith.eq v293, v309 : i1;
-            cf.cond_br v305 ^block18, ^block48(v292);
-        ^block18:
+            v363 = arith.constant 0 : u32;
+            v359 = arith.eq v347, v363 : i1;
+            cf.cond_br v359 ^block20, ^block53(v346);
+        ^block20:
             ub.unreachable ;
-        ^block48(v285: i32):
-            builtin.ret v285;
+        ^block53(v339: i32):
+            builtin.ret v339;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v148: i32, v149: i32, v150: i32) {
-        ^block25(v148: i32, v149: i32, v150: i32):
-            v152 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
-            v153 = hir.bitcast v152 : ptr<byte, i32>;
-            v154 = hir.load v153 : i32;
-            v155 = arith.constant 16 : i32;
-            v156 = arith.sub v154, v155 : i32 #[overflow = wrapping];
-            v157 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
-            v158 = hir.bitcast v157 : ptr<byte, i32>;
-            hir.store v158, v156;
-            v159 = arith.constant 4 : i32;
-            v160 = arith.add v156, v159 : i32 #[overflow = wrapping];
-            hir.exec @root_ns:root@1.0.0/vec_alloc_vec/alloc::raw_vec::RawVecInner<A>::current_memory(v160, v148, v149, v150)
-            v162 = arith.constant 8 : u32;
-            v161 = hir.bitcast v156 : u32;
-            v163 = arith.add v161, v162 : u32 #[overflow = checked];
-            v164 = arith.constant 4 : u32;
-            v165 = arith.mod v163, v164 : u32;
-            hir.assertz v165 #[code = 250];
-            v166 = hir.int_to_ptr v163 : ptr<byte, i32>;
-            v167 = hir.load v166 : i32;
-            v329 = arith.constant 0 : i32;
-            v151 = arith.constant 0 : i32;
-            v169 = arith.eq v167, v151 : i1;
-            v170 = arith.zext v169 : u32;
-            v171 = hir.bitcast v170 : i32;
-            v173 = arith.neq v171, v329 : i1;
-            scf.if v173{
-            ^block52:
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v177: i32, v178: i32, v179: i32) {
+        ^block27(v177: i32, v178: i32, v179: i32):
+            v181 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
+            v182 = hir.bitcast v181 : ptr<byte, i32>;
+            v183 = hir.load v182 : i32;
+            v184 = arith.constant 16 : i32;
+            v185 = arith.sub v183, v184 : i32 #[overflow = wrapping];
+            v186 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
+            v187 = hir.bitcast v186 : ptr<byte, i32>;
+            hir.store v187, v185;
+            v188 = arith.constant 4 : i32;
+            v189 = arith.add v185, v188 : i32 #[overflow = wrapping];
+            hir.exec @root_ns:root@1.0.0/vec_alloc_vec/alloc::raw_vec::RawVecInner<A>::current_memory(v189, v177, v178, v179)
+            v191 = arith.constant 8 : u32;
+            v190 = hir.bitcast v185 : u32;
+            v192 = arith.add v190, v191 : u32 #[overflow = checked];
+            v193 = arith.constant 4 : u32;
+            v194 = arith.mod v192, v193 : u32;
+            hir.assertz v194 #[code = 250];
+            v195 = hir.int_to_ptr v192 : ptr<byte, i32>;
+            v196 = hir.load v195 : i32;
+            v383 = arith.constant 0 : i32;
+            v180 = arith.constant 0 : i32;
+            v198 = arith.eq v196, v180 : i1;
+            v199 = arith.zext v198 : u32;
+            v200 = hir.bitcast v199 : i32;
+            v202 = arith.neq v200, v383 : i1;
+            scf.if v202{
+            ^block57:
                 scf.yield ;
             } else {
-            ^block28:
-                v328 = arith.constant 4 : u32;
-                v174 = hir.bitcast v156 : u32;
-                v176 = arith.add v174, v328 : u32 #[overflow = checked];
-                v327 = arith.constant 4 : u32;
-                v178 = arith.mod v176, v327 : u32;
-                hir.assertz v178 #[code = 250];
-                v179 = hir.int_to_ptr v176 : ptr<byte, i32>;
-                v180 = hir.load v179 : i32;
-                v182 = arith.constant 12 : u32;
-                v181 = hir.bitcast v156 : u32;
-                v183 = arith.add v181, v182 : u32 #[overflow = checked];
-                v326 = arith.constant 4 : u32;
-                v185 = arith.mod v183, v326 : u32;
-                hir.assertz v185 #[code = 250];
-                v186 = hir.int_to_ptr v183 : ptr<byte, i32>;
-                v187 = hir.load v186 : i32;
-                hir.exec @root_ns:root@1.0.0/vec_alloc_vec/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v180, v167, v187)
+            ^block30:
+                v382 = arith.constant 4 : u32;
+                v203 = hir.bitcast v185 : u32;
+                v205 = arith.add v203, v382 : u32 #[overflow = checked];
+                v381 = arith.constant 4 : u32;
+                v207 = arith.mod v205, v381 : u32;
+                hir.assertz v207 #[code = 250];
+                v208 = hir.int_to_ptr v205 : ptr<byte, i32>;
+                v209 = hir.load v208 : i32;
+                v211 = arith.constant 12 : u32;
+                v210 = hir.bitcast v185 : u32;
+                v212 = arith.add v210, v211 : u32 #[overflow = checked];
+                v380 = arith.constant 4 : u32;
+                v214 = arith.mod v212, v380 : u32;
+                hir.assertz v214 #[code = 250];
+                v215 = hir.int_to_ptr v212 : ptr<byte, i32>;
+                v216 = hir.load v215 : i32;
+                hir.exec @root_ns:root@1.0.0/vec_alloc_vec/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v209, v196, v216)
                 scf.yield ;
             };
-            v325 = arith.constant 16 : i32;
-            v190 = arith.add v156, v325 : i32 #[overflow = wrapping];
-            v191 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
-            v192 = hir.bitcast v191 : ptr<byte, i32>;
-            hir.store v192, v190;
+            v379 = arith.constant 16 : i32;
+            v219 = arith.add v185, v379 : i32 #[overflow = wrapping];
+            v220 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
+            v221 = hir.bitcast v220 : ptr<byte, i32>;
+            hir.store v221, v219;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v193: i32, v194: i32, v195: i32, v196: i32) {
-        ^block29(v193: i32, v194: i32, v195: i32, v196: i32):
-            v355 = arith.constant 0 : i32;
-            v197 = arith.constant 0 : i32;
-            v201 = arith.eq v196, v197 : i1;
-            v202 = arith.zext v201 : u32;
-            v203 = hir.bitcast v202 : i32;
-            v205 = arith.neq v203, v355 : i1;
-            v342, v343 = scf.if v205 : i32, i32 {
-            ^block55:
-                v354 = arith.constant 0 : i32;
-                v199 = arith.constant 4 : i32;
-                scf.yield v199, v354;
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v222: i32, v223: i32, v224: i32, v225: i32) {
+        ^block31(v222: i32, v223: i32, v224: i32, v225: i32):
+            v409 = arith.constant 0 : i32;
+            v226 = arith.constant 0 : i32;
+            v230 = arith.eq v225, v226 : i1;
+            v231 = arith.zext v230 : u32;
+            v232 = hir.bitcast v231 : i32;
+            v234 = arith.neq v232, v409 : i1;
+            v396, v397 = scf.if v234 : i32, i32 {
+            ^block60:
+                v408 = arith.constant 0 : i32;
+                v228 = arith.constant 4 : i32;
+                scf.yield v228, v408;
             } else {
-            ^block32:
-                v206 = hir.bitcast v194 : u32;
-                v241 = arith.constant 4 : u32;
-                v208 = arith.mod v206, v241 : u32;
-                hir.assertz v208 #[code = 250];
-                v209 = hir.int_to_ptr v206 : ptr<byte, i32>;
-                v210 = hir.load v209 : i32;
-                v352 = arith.constant 0 : i32;
-                v353 = arith.constant 0 : i32;
-                v212 = arith.eq v210, v353 : i1;
-                v213 = arith.zext v212 : u32;
-                v214 = hir.bitcast v213 : i32;
-                v216 = arith.neq v214, v352 : i1;
-                v340 = scf.if v216 : i32 {
-                ^block54:
-                    v351 = arith.constant 0 : i32;
-                    scf.yield v351;
+            ^block34:
+                v235 = hir.bitcast v223 : u32;
+                v270 = arith.constant 4 : u32;
+                v237 = arith.mod v235, v270 : u32;
+                hir.assertz v237 #[code = 250];
+                v238 = hir.int_to_ptr v235 : ptr<byte, i32>;
+                v239 = hir.load v238 : i32;
+                v406 = arith.constant 0 : i32;
+                v407 = arith.constant 0 : i32;
+                v241 = arith.eq v239, v407 : i1;
+                v242 = arith.zext v241 : u32;
+                v243 = hir.bitcast v242 : i32;
+                v245 = arith.neq v243, v406 : i1;
+                v394 = scf.if v245 : i32 {
+                ^block59:
+                    v405 = arith.constant 0 : i32;
+                    scf.yield v405;
                 } else {
-                ^block33:
-                    v350 = arith.constant 4 : u32;
-                    v217 = hir.bitcast v193 : u32;
-                    v219 = arith.add v217, v350 : u32 #[overflow = checked];
-                    v349 = arith.constant 4 : u32;
-                    v221 = arith.mod v219, v349 : u32;
-                    hir.assertz v221 #[code = 250];
-                    v222 = hir.int_to_ptr v219 : ptr<byte, i32>;
-                    hir.store v222, v195;
-                    v348 = arith.constant 4 : u32;
-                    v223 = hir.bitcast v194 : u32;
-                    v225 = arith.add v223, v348 : u32 #[overflow = checked];
-                    v347 = arith.constant 4 : u32;
-                    v227 = arith.mod v225, v347 : u32;
-                    hir.assertz v227 #[code = 250];
-                    v228 = hir.int_to_ptr v225 : ptr<byte, i32>;
-                    v229 = hir.load v228 : i32;
-                    v230 = hir.bitcast v193 : u32;
-                    v346 = arith.constant 4 : u32;
-                    v232 = arith.mod v230, v346 : u32;
-                    hir.assertz v232 #[code = 250];
-                    v233 = hir.int_to_ptr v230 : ptr<byte, i32>;
-                    hir.store v233, v229;
-                    v234 = arith.mul v210, v196 : i32 #[overflow = wrapping];
-                    scf.yield v234;
+                ^block35:
+                    v404 = arith.constant 4 : u32;
+                    v246 = hir.bitcast v222 : u32;
+                    v248 = arith.add v246, v404 : u32 #[overflow = checked];
+                    v403 = arith.constant 4 : u32;
+                    v250 = arith.mod v248, v403 : u32;
+                    hir.assertz v250 #[code = 250];
+                    v251 = hir.int_to_ptr v248 : ptr<byte, i32>;
+                    hir.store v251, v224;
+                    v402 = arith.constant 4 : u32;
+                    v252 = hir.bitcast v223 : u32;
+                    v254 = arith.add v252, v402 : u32 #[overflow = checked];
+                    v401 = arith.constant 4 : u32;
+                    v256 = arith.mod v254, v401 : u32;
+                    hir.assertz v256 #[code = 250];
+                    v257 = hir.int_to_ptr v254 : ptr<byte, i32>;
+                    v258 = hir.load v257 : i32;
+                    v259 = hir.bitcast v222 : u32;
+                    v400 = arith.constant 4 : u32;
+                    v261 = arith.mod v259, v400 : u32;
+                    hir.assertz v261 #[code = 250];
+                    v262 = hir.int_to_ptr v259 : ptr<byte, i32>;
+                    hir.store v262, v258;
+                    v263 = arith.mul v239, v225 : i32 #[overflow = wrapping];
+                    scf.yield v263;
                 };
-                v235 = arith.constant 8 : i32;
-                v345 = arith.constant 4 : i32;
-                v341 = cf.select v216, v345, v235 : i32;
-                scf.yield v341, v340;
+                v264 = arith.constant 8 : i32;
+                v399 = arith.constant 4 : i32;
+                v395 = cf.select v245, v399, v264 : i32;
+                scf.yield v395, v394;
             };
-            v238 = arith.add v193, v342 : i32 #[overflow = wrapping];
-            v240 = hir.bitcast v238 : u32;
-            v344 = arith.constant 4 : u32;
-            v242 = arith.mod v240, v344 : u32;
-            hir.assertz v242 #[code = 250];
-            v243 = hir.int_to_ptr v240 : ptr<byte, i32>;
-            hir.store v243, v343;
+            v267 = arith.add v222, v396 : i32 #[overflow = wrapping];
+            v269 = hir.bitcast v267 : u32;
+            v398 = arith.constant 4 : u32;
+            v271 = arith.mod v269, v398 : u32;
+            hir.assertz v271 #[code = 250];
+            v272 = hir.int_to_ptr v269 : ptr<byte, i32>;
+            hir.store v272, v397;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v244: i32, v245: i32, v246: i32) {
-        ^block34(v244: i32, v245: i32, v246: i32):
-            v357 = arith.constant 0 : i32;
-            v247 = arith.constant 0 : i32;
-            v248 = arith.eq v246, v247 : i1;
-            v249 = arith.zext v248 : u32;
-            v250 = hir.bitcast v249 : i32;
-            v252 = arith.neq v250, v357 : i1;
-            scf.if v252{
-            ^block36:
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v273: i32, v274: i32, v275: i32) {
+        ^block36(v273: i32, v274: i32, v275: i32):
+            v411 = arith.constant 0 : i32;
+            v276 = arith.constant 0 : i32;
+            v277 = arith.eq v275, v276 : i1;
+            v278 = arith.zext v277 : u32;
+            v279 = hir.bitcast v278 : i32;
+            v281 = arith.neq v279, v411 : i1;
+            scf.if v281{
+            ^block38:
                 scf.yield ;
             } else {
-            ^block37:
-                hir.exec @root_ns:root@1.0.0/vec_alloc_vec/__rustc::__rust_dealloc(v244, v246, v245)
+            ^block39:
+                hir.exec @root_ns:root@1.0.0/vec_alloc_vec/__rustc::__rust_dealloc(v273, v275, v274)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::alloc::handle_alloc_error(v253: i32, v254: i32) {
-        ^block38(v253: i32, v254: i32):
+        private builtin.function @alloc::alloc::handle_alloc_error(v282: i32, v283: i32) {
+        ^block40(v282: i32, v283: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v255: i32, v256: i32) -> i32 {
-        ^block40(v255: i32, v256: i32):
-            v263 = arith.constant 0 : i32;
-            v259 = hir.bitcast v256 : u32;
-            v258 = hir.bitcast v255 : u32;
-            v260 = arith.gt v258, v259 : i1;
-            v261 = arith.zext v260 : u32;
-            v262 = hir.bitcast v261 : i32;
-            v264 = arith.neq v262, v263 : i1;
-            v265 = cf.select v264, v255, v256 : i32;
-            builtin.ret v265;
+        private builtin.function @core::ptr::alignment::Alignment::max(v284: i32, v285: i32) -> i32 {
+        ^block42(v284: i32, v285: i32):
+            v292 = arith.constant 0 : i32;
+            v288 = hir.bitcast v285 : u32;
+            v287 = hir.bitcast v284 : u32;
+            v289 = arith.gt v287, v288 : i1;
+            v290 = arith.zext v289 : u32;
+            v291 = hir.bitcast v290 : i32;
+            v293 = arith.neq v291, v292 : i1;
+            v294 = cf.select v293, v284, v285 : i32;
+            builtin.ret v294;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {

--- a/tests/integration/expected/vec_alloc_vec.masm
+++ b/tests/integration/expected/vec_alloc_vec.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
 end
 
 # mod root_ns:root@1.0.0::vec_alloc_vec
 
 export.entrypoint
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -23,7 +23,7 @@ export.entrypoint
     nop
     push.16
     u32wrapping_sub
-    push.1048576
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -160,7 +160,7 @@ export.entrypoint
         nop
         push.16
         u32wrapping_add
-        push.1048576
+        push.1114112
         u32divmod.4
         swap.1
         trace.240
@@ -386,7 +386,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::deallocate
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240
@@ -396,7 +396,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     nop
     push.16
     u32wrapping_sub
-    push.1048576
+    push.1114112
     dup.1
     swap.1
     u32divmod.4
@@ -489,7 +489,7 @@ proc.alloc::raw_vec::RawVecInner<A>::deallocate
     end
     push.16
     u32wrapping_add
-    push.1048576
+    push.1114112
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/vec_alloc_vec.masm
+++ b/tests/integration/expected/vec_alloc_vec.masm
@@ -39,17 +39,51 @@ export.entrypoint
     trace.252
     nop
     push.4
-    push.8
+    push.12
     trace.240
     nop
     exec.::root_ns:root@1.0.0::vec_alloc_vec::__rustc::__rust_alloc
     trace.252
     nop
     push.0
-    dup.1
+    push.0
+    dup.2
     swap.1
+    eq
     neq
     if.true
+        drop
+        drop
+        drop
+        push.12
+        push.4
+        trace.240
+        nop
+        exec.::root_ns:root@1.0.0::vec_alloc_vec::alloc::alloc::handle_alloc_error
+        trace.252
+        nop
+        push.0
+        push.3735929054
+    else
+        push.8
+        dup.1
+        add
+        u32assert
+        push.4
+        dup.1
+        swap.1
+        u32mod
+        u32assert
+        assertz
+        push.3
+        swap.1
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::store_felt
+        trace.252
+        nop
         push.4
         dup.1
         add
@@ -60,7 +94,7 @@ export.entrypoint
         u32mod
         u32assert
         assertz
-        dup.3
+        push.2
         swap.1
         u32divmod.4
         swap.1
@@ -76,7 +110,7 @@ export.entrypoint
         u32mod
         u32assert
         assertz
-        movup.3
+        push.1
         swap.1
         u32divmod.4
         swap.1
@@ -95,7 +129,7 @@ export.entrypoint
         u32mod
         u32assert
         assertz
-        push.2
+        push.3
         swap.1
         u32divmod.4
         swap.1
@@ -133,34 +167,8 @@ export.entrypoint
         u32mod
         u32assert
         assertz
-        push.2
+        push.3
         swap.1
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::store_sw
-        trace.252
-        nop
-        push.1048576
-        swap.1
-        assert_eq
-        push.4
-        push.4
-        dup.2
-        swap.1
-        u32wrapping_add
-        dup.1
-        swap.2
-        swap.1
-        trace.240
-        nop
-        exec.::root_ns:root@1.0.0::vec_alloc_vec::alloc::raw_vec::RawVecInner<A>::deallocate
-        trace.252
-        nop
-        push.16
-        u32wrapping_add
-        push.1114112
         u32divmod.4
         swap.1
         trace.240
@@ -169,19 +177,81 @@ export.entrypoint
         trace.252
         nop
         push.0
-    else
+        push.3
+        dup.4
+        swap.1
+        u32gte
+        neq
+        dup.0
+        if.true
+            movdn.3
+            drop
+            drop
+            drop
+            push.3735929054
+        else
+            push.2
+            movup.4
+            swap.1
+            u32shl
+            movup.2
+            swap.1
+            u32wrapping_add
+            push.4
+            dup.1
+            swap.1
+            u32mod
+            u32assert
+            assertz
+            u32divmod.4
+            swap.1
+            trace.240
+            nop
+            exec.::intrinsics::mem::load_felt
+            trace.252
+            nop
+            push.4
+            push.4
+            dup.4
+            swap.1
+            u32wrapping_add
+            dup.1
+            swap.2
+            swap.1
+            trace.240
+            nop
+            exec.::root_ns:root@1.0.0::vec_alloc_vec::alloc::raw_vec::RawVecInner<A>::deallocate
+            trace.252
+            nop
+            push.16
+            movup.3
+            swap.1
+            u32wrapping_add
+            push.1114112
+            u32divmod.4
+            swap.1
+            trace.240
+            nop
+            exec.::intrinsics::mem::store_sw
+            trace.252
+            nop
+        end
+        push.1
+        push.0
+        movup.3
+        cdrop
+        swap.1
+    end
+    push.0
+    movup.2
+    swap.1
+    eq
+    if.true
         drop
-        drop
-        drop
-        push.8
-        push.4
-        trace.240
-        nop
-        exec.::root_ns:root@1.0.0::vec_alloc_vec::alloc::alloc::handle_alloc_error
-        trace.252
-        nop
         push.0
         assert
+    else
+        nop
     end
 end
 

--- a/tests/integration/expected/vec_alloc_vec.wat
+++ b/tests/integration/expected/vec_alloc_vec.wat
@@ -1,24 +1,21 @@
 (module $vec_alloc_vec.wasm
   (type (;0;) (func (param i32) (result f32)))
-  (type (;1;) (func (param f32 f32)))
-  (type (;2;) (func (result i32)))
-  (type (;3;) (func (param f32) (result f32)))
-  (type (;4;) (func (param i32 i32) (result i32)))
-  (type (;5;) (func (param i32 i32 i32)))
-  (type (;6;) (func))
-  (type (;7;) (func (param i32 i32 i32) (result i32)))
-  (type (;8;) (func (param i32 i32 i32 i32)))
-  (type (;9;) (func (param i32 i32)))
+  (type (;1;) (func (result i32)))
+  (type (;2;) (func (param i32 i32) (result i32)))
+  (type (;3;) (func (param i32 i32 i32)))
+  (type (;4;) (func))
+  (type (;5;) (func (param i32 i32 i32) (result i32)))
+  (type (;6;) (func (param i32 i32 i32 i32)))
+  (type (;7;) (func (param i32 i32)))
   (import "miden:core-intrinsics/intrinsics-felt@1.0.0" "from-u32" (func $miden_stdlib_sys::intrinsics::felt::extern_from_u32 (;0;) (type 0)))
-  (import "miden:core-intrinsics/intrinsics-felt@1.0.0" "assert-eq" (func $miden_stdlib_sys::intrinsics::felt::extern_assert_eq (;1;) (type 1)))
-  (import "miden:core-intrinsics/intrinsics-mem@1.0.0" "heap-base" (func $miden_sdk_alloc::heap_base (;2;) (type 2)))
+  (import "miden:core-intrinsics/intrinsics-mem@1.0.0" "heap-base" (func $miden_sdk_alloc::heap_base (;1;) (type 1)))
   (table (;0;) 1 1 funcref)
   (memory (;0;) 17)
   (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
   (export "memory" (memory 0))
   (export "entrypoint" (func $entrypoint))
-  (func $entrypoint (;3;) (type 3) (param f32) (result f32)
-    (local i32 i32)
+  (func $entrypoint (;2;) (type 0) (param i32) (result f32)
+    (local i32 i32 f32 f32)
     global.get $__stack_pointer
     i32.const 16
     i32.sub
@@ -26,62 +23,79 @@
     global.set $__stack_pointer
     call $__rustc::__rust_no_alloc_shim_is_unstable_v2
     block ;; label = @1
-      i32.const 8
+      block ;; label = @2
+        i32.const 12
+        i32.const 4
+        call $__rustc::__rust_alloc
+        local.tee 2
+        i32.eqz
+        br_if 0 (;@2;)
+        i32.const 1
+        call $miden_stdlib_sys::intrinsics::felt::extern_from_u32
+        local.set 3
+        i32.const 2
+        call $miden_stdlib_sys::intrinsics::felt::extern_from_u32
+        local.set 4
+        local.get 2
+        i32.const 3
+        call $miden_stdlib_sys::intrinsics::felt::extern_from_u32
+        f32.store offset=8
+        local.get 2
+        local.get 4
+        f32.store offset=4
+        local.get 2
+        local.get 3
+        f32.store
+        local.get 1
+        i32.const 3
+        i32.store offset=12
+        local.get 1
+        local.get 2
+        i32.store offset=8
+        local.get 1
+        i32.const 3
+        i32.store offset=4
+        local.get 0
+        i32.const 3
+        i32.ge_u
+        br_if 1 (;@1;)
+        local.get 2
+        local.get 0
+        i32.const 2
+        i32.shl
+        i32.add
+        f32.load
+        local.set 3
+        local.get 1
+        i32.const 4
+        i32.add
+        i32.const 4
+        i32.const 4
+        call $alloc::raw_vec::RawVecInner<A>::deallocate
+        local.get 1
+        i32.const 16
+        i32.add
+        global.set $__stack_pointer
+        local.get 3
+        return
+      end
       i32.const 4
-      call $__rustc::__rust_alloc
-      local.tee 2
-      br_if 0 (;@1;)
-      i32.const 4
-      i32.const 8
+      i32.const 12
       call $alloc::alloc::handle_alloc_error
-      unreachable
     end
-    local.get 2
-    local.get 0
-    f32.store offset=4
-    local.get 2
-    local.get 0
-    f32.store
-    local.get 1
-    i32.const 2
-    i32.store offset=12
-    local.get 1
-    local.get 2
-    i32.store offset=8
-    local.get 1
-    i32.const 2
-    i32.store offset=4
-    local.get 2
-    call $miden_stdlib_sys::intrinsics::felt::extern_from_u32
-    i32.const 1048576
-    call $miden_stdlib_sys::intrinsics::felt::extern_from_u32
-    call $miden_stdlib_sys::intrinsics::felt::extern_assert_eq
-    i32.const 0
-    call $miden_stdlib_sys::intrinsics::felt::extern_from_u32
-    local.set 0
-    local.get 1
-    i32.const 4
-    i32.add
-    i32.const 4
-    i32.const 4
-    call $alloc::raw_vec::RawVecInner<A>::deallocate
-    local.get 1
-    i32.const 16
-    i32.add
-    global.set $__stack_pointer
-    local.get 0
+    unreachable
   )
-  (func $__rustc::__rust_alloc (;4;) (type 4) (param i32 i32) (result i32)
+  (func $__rustc::__rust_alloc (;3;) (type 2) (param i32 i32) (result i32)
     i32.const 1048576
     local.get 1
     local.get 0
     call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
   )
-  (func $__rustc::__rust_dealloc (;5;) (type 5) (param i32 i32 i32))
-  (func $__rustc::__rust_no_alloc_shim_is_unstable_v2 (;6;) (type 6)
+  (func $__rustc::__rust_dealloc (;4;) (type 3) (param i32 i32 i32))
+  (func $__rustc::__rust_no_alloc_shim_is_unstable_v2 (;5;) (type 4)
     return
   )
-  (func $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc (;7;) (type 7) (param i32 i32 i32) (result i32)
+  (func $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc (;6;) (type 5) (param i32 i32 i32) (result i32)
     (local i32 i32)
     block ;; label = @1
       local.get 1
@@ -153,7 +167,7 @@
     end
     unreachable
   )
-  (func $alloc::raw_vec::RawVecInner<A>::deallocate (;8;) (type 5) (param i32 i32 i32)
+  (func $alloc::raw_vec::RawVecInner<A>::deallocate (;7;) (type 3) (param i32 i32 i32)
     (local i32)
     global.get $__stack_pointer
     i32.const 16
@@ -185,7 +199,7 @@
     i32.add
     global.set $__stack_pointer
   )
-  (func $alloc::raw_vec::RawVecInner<A>::current_memory (;9;) (type 8) (param i32 i32 i32 i32)
+  (func $alloc::raw_vec::RawVecInner<A>::current_memory (;8;) (type 6) (param i32 i32 i32 i32)
     (local i32 i32 i32)
     i32.const 0
     local.set 4
@@ -220,7 +234,7 @@
     local.get 4
     i32.store
   )
-  (func $<alloc::alloc::Global as core::alloc::Allocator>::deallocate (;10;) (type 5) (param i32 i32 i32)
+  (func $<alloc::alloc::Global as core::alloc::Allocator>::deallocate (;9;) (type 3) (param i32 i32 i32)
     block ;; label = @1
       local.get 2
       i32.eqz
@@ -231,10 +245,10 @@
       call $__rustc::__rust_dealloc
     end
   )
-  (func $alloc::alloc::handle_alloc_error (;11;) (type 9) (param i32 i32)
+  (func $alloc::alloc::handle_alloc_error (;10;) (type 7) (param i32 i32)
     unreachable
   )
-  (func $core::ptr::alignment::Alignment::max (;12;) (type 4) (param i32 i32) (result i32)
+  (func $core::ptr::alignment::Alignment::max (;11;) (type 2) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     local.get 0

--- a/tests/integration/expected/xor_bool.masm
+++ b/tests/integration/expected/xor_bool.masm
@@ -1,19 +1,19 @@
 # mod root_ns:root@1.0.0
 
 export.init
-    push.1114112
+    push.1179648
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
     push.1048576
     u32assert
-    mem_store.262144
+    mem_store.278528
     push.1048576
     u32assert
-    mem_store.262145
+    mem_store.278529
     push.1048576
     u32assert
-    mem_store.262146
+    mem_store.278530
 end
 
 # mod root_ns:root@1.0.0::test_rust_12478c1c469cdb8e5c0d08223b9ea0b6f7c1cade83ed772fb79969d2af3004cb


### PR DESCRIPTION
Close #595

This PR fixes the bug that manifests as if a `Vec` was allocated at the same address as the Rust stack. The root cause was that we put the first global variable (`__stack_pointer`) at the same address as the Rust stack pointer. Since the value of the `__stack_pointer` is the Rust stack address and the `BumpAlloc` instance is allocated on the stack, the `BumpAlloc::top` pointer got the value of the Rust stack address (`__stack_pointer`) and `BumpAlloc::maybe_init()` constructor skipped the `BumpAlloc::top` initialization.

This PR:
- adds an extra memory page to `DEFAULT_RESERVATION` to put the Wasm globals after the Rust `static` (needed when no data segments present);
- adds an extra memory page after the data segments before putting Wasm globals to accommodate Rust `static` (Rust puts them after data segments).
