### PR TITLE
fix(codegen): missing result renaming in ptrtoint lowering

### DIFF
--- a/codegen/masm/src/lower/lowering.rs
+++ b/codegen/masm/src/lower/lowering.rs
@@ -953,8 +953,9 @@ impl HirLowering for arith::Max {
 impl HirLowering for hir::PtrToInt {
     fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
         let result_ty = self.result().ty().clone();
-        emitter.stack.pop().expect("operand stack is empty");
-        emitter.stack.push(result_ty);
+        let mut inst_emitter = emitter.inst_emitter(self.as_operation());
+        inst_emitter.pop().expect("operand stack is empty");
+        inst_emitter.push(result_ty);
         Ok(())
     }
 }


### PR DESCRIPTION
While looking at our lowering for `hir.ptr_to_int`, I realized that we weren't correctly renaming the result value on the operand stack, which is pushed as a type, to an SSA value, because we were implementing the lowering manually, rather than going through `InstOpEmitter`. The effect of this is that subsequent operand stack scheduling that tried to look up that value by name, would fail to find it.

We weren't yet using `hir.ptr_to_int` anywhere, which is why this hasn't come up yet.