### PR TITLE
Add extensible benchmarking system with `is_prime` benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +906,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1145,6 +1184,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2370,6 +2445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,6 +2541,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2909,6 +3000,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3021,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3552,6 +3663,17 @@ dependencies = [
  "tonic-build 0.13.1",
  "tracing",
  "web-sys",
+]
+
+[[package]]
+name = "miden-compiler-benches"
+version = "0.1.5"
+dependencies = [
+ "anyhow",
+ "clap",
+ "criterion",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -4519,6 +4641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4854,6 +4982,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -5431,6 +5587,26 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -6665,6 +6841,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,17 +3666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-compiler-benches"
-version = "0.1.5"
-dependencies = [
- "anyhow",
- "clap",
- "criterion",
- "serde",
- "toml",
-]
-
-[[package]]
 name = "miden-core"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,6 +3973,17 @@ dependencies = [
  "env_logger",
  "human-panic",
  "midenc-driver",
+]
+
+[[package]]
+name = "midenc-benchmark-runner"
+version = "0.1.5"
+dependencies = [
+ "anyhow",
+ "clap",
+ "criterion",
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,12 +2426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,17 +2894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "iri-string"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,6 +2901,17 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3890,7 +3884,7 @@ dependencies = [
  "clap",
  "criterion",
  "serde",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "benches",
     "codegen/*",
     "dialects/*",
     "eval",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -155,6 +155,18 @@ description = "Run cargo-bloat"
 command = "cargo"
 args = ["bloat", "${@}"]
 
+[tasks.bench]
+category = "Benchmarks"
+description = "Runs benchmarks written in Rust"
+command = "cargo"
+args = [
+    "run",
+    "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)",
+    "-p",
+    "midenc-benchmark-runner",
+    "${@}",
+]
+
 [tasks.midenc]
 category = "Build"
 description = "Builds midenc and installs it to the bin folder"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "miden-compiler-benches"
+name = "midenc-benchmark-runner"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "miden-compiler-benches"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Benchmarks for the Miden compiler"
+publish = false
+
+[[bin]]
+name = "is_prime"
+path = "src/is_prime.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+serde = { workspace = true, features = ["std"] }
+toml.workspace = true
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "is_prime_bench"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -4,15 +4,33 @@ Benchmarks for measuring VM cycles and performance of Miden programs.
 
 ## Usage
 
+### From project root (recommended)
+
 ```bash
 # Run is_prime benchmark
-cargo run --bin is_prime
+cargo make bench --bin is_prime
 
 # Custom input
-cargo run --bin is_prime -- --input 97
+cargo make bench --bin is_prime -- --input 97
 
 # Multiple iterations
-cargo run --bin is_prime -- --input 29 --iterations 5
+cargo make bench --bin is_prime -- --input 97 --iterations 5
+
+# Custom source file
+cargo make bench --bin is_prime -- --source examples/is-prime/src/lib.rs --input 29
+```
+
+### Direct cargo commands
+
+```bash
+# Run is_prime benchmark
+cargo run -p midenc-benchmark-runner --bin is_prime
+
+# Custom input
+cargo run -p midenc-benchmark-runner --bin is_prime -- --input 97
+
+# Multiple iterations
+cargo run -p midenc-benchmark-runner --bin is_prime -- --input 29 --iterations 5
 
 # Criterion benchmarks
 cargo bench

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,36 @@
+# Miden Compiler Benchmarks
+
+Benchmarks for measuring VM cycles and performance of Miden programs.
+
+## Usage
+
+```bash
+# Run is_prime benchmark
+cargo run --bin is_prime
+
+# Custom input
+cargo run --bin is_prime -- --input 97
+
+# Multiple iterations
+cargo run --bin is_prime -- --input 29 --iterations 5
+
+# Criterion benchmarks
+cargo bench
+```
+
+## Benchmark Results
+
+| Input         | VM Cycles | Prime? |
+| ------------- | --------- | ------ |
+| 13            | 533       | ✓      |
+| 97            | 805       | ✓      |
+| 4,397         | 3,525     | ✓      |
+| 285,191       | 24,741    | ✓      |
+| 87,019,979    | 423,221   | ✓      |
+| 2,147,483,647 | 2,101,189 | ✓      |
+
+## Adding benchmarks
+
+1. Add binary to `src/`
+2. Add `[[bin]]` entry to `Cargo.toml`
+3. Use `BenchmarkRunner` from the lib

--- a/benches/benches/is_prime_bench.rs
+++ b/benches/benches/is_prime_bench.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use miden_compiler_benches::BenchmarkRunner;
+use midenc_benchmark_runner::BenchmarkRunner;
 
 fn bench_is_prime_compilation(c: &mut Criterion) {
     let runner = BenchmarkRunner::new().expect("Failed to create benchmark runner");

--- a/benches/benches/is_prime_bench.rs
+++ b/benches/benches/is_prime_bench.rs
@@ -31,7 +31,7 @@ fn bench_is_prime_execution(c: &mut Criterion) {
 
     // Test with different input values
     for input in [7, 29, 97, 997, 9973].iter() {
-        group.bench_with_input(format!("is_prime({})", input), input, |b, &input| {
+        group.bench_with_input(format!("is_prime({input})"), input, |b, &input| {
             b.iter(|| {
                 runner
                     .execute_masm(black_box(&masm_path), black_box(&[input as u64]))
@@ -51,13 +51,13 @@ fn bench_is_prime_full_pipeline(c: &mut Criterion) {
 
     // Test full compilation + execution pipeline
     for input in [29, 97, 997].iter() {
-        group.bench_with_input(format!("full_pipeline_is_prime({})", input), input, |b, &input| {
+        group.bench_with_input(format!("full_pipeline_is_prime({input})"), input, |b, &input| {
             b.iter(|| {
                 runner
                     .run_benchmark(
                         black_box(&source_path),
                         black_box(&[input as u64]),
-                        &format!("is_prime({})", input),
+                        &format!("is_prime({input})"),
                     )
                     .expect("Benchmark failed")
             })

--- a/benches/benches/is_prime_bench.rs
+++ b/benches/benches/is_prime_bench.rs
@@ -1,0 +1,76 @@
+//! Criterion benchmark for the is_prime program
+//!
+//! This provides detailed performance analysis using the Criterion benchmarking framework.
+
+use std::path::PathBuf;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use miden_compiler_benches::BenchmarkRunner;
+
+fn bench_is_prime_compilation(c: &mut Criterion) {
+    let runner = BenchmarkRunner::new().expect("Failed to create benchmark runner");
+    let source_path = PathBuf::from("../examples/is-prime/src/lib.rs");
+
+    c.bench_function("is_prime_compilation", |b| {
+        b.iter(|| {
+            runner
+                .compile_rust_to_masm(black_box(&source_path))
+                .expect("Compilation failed")
+        })
+    });
+}
+
+fn bench_is_prime_execution(c: &mut Criterion) {
+    let runner = BenchmarkRunner::new().expect("Failed to create benchmark runner");
+    let source_path = PathBuf::from("../examples/is-prime/src/lib.rs");
+
+    // Pre-compile the program
+    let masm_path = runner.compile_rust_to_masm(&source_path).expect("Failed to compile program");
+
+    let mut group = c.benchmark_group("is_prime_execution");
+
+    // Test with different input values
+    for input in [7, 29, 97, 997, 9973].iter() {
+        group.bench_with_input(format!("is_prime({})", input), input, |b, &input| {
+            b.iter(|| {
+                runner
+                    .execute_masm(black_box(&masm_path), black_box(&[input as u64]))
+                    .expect("Execution failed")
+            })
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_is_prime_full_pipeline(c: &mut Criterion) {
+    let runner = BenchmarkRunner::new().expect("Failed to create benchmark runner");
+    let source_path = PathBuf::from("../examples/is-prime/src/lib.rs");
+
+    let mut group = c.benchmark_group("is_prime_full_pipeline");
+
+    // Test full compilation + execution pipeline
+    for input in [29, 97, 997].iter() {
+        group.bench_with_input(format!("full_pipeline_is_prime({})", input), input, |b, &input| {
+            b.iter(|| {
+                runner
+                    .run_benchmark(
+                        black_box(&source_path),
+                        black_box(&[input as u64]),
+                        &format!("is_prime({})", input),
+                    )
+                    .expect("Benchmark failed")
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_is_prime_compilation,
+    bench_is_prime_execution,
+    bench_is_prime_full_pipeline
+);
+criterion_main!(benches);

--- a/benches/src/is_prime.rs
+++ b/benches/src/is_prime.rs
@@ -1,0 +1,101 @@
+//! Benchmark for the is_prime program
+//!
+//! This benchmark compiles the is_prime Rust program to Miden assembly
+//! and measures its execution performance in the Miden VM.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Arg, Command};
+use miden_compiler_benches::BenchmarkRunner;
+
+fn main() -> Result<()> {
+    let matches = Command::new("is_prime_benchmark")
+        .about("Benchmark the is_prime program in Miden VM")
+        .arg(
+            Arg::new("input")
+                .short('i')
+                .long("input")
+                .value_name("NUMBER")
+                .help("The number to test for primality")
+                .default_value("29"),
+        )
+        .arg(
+            Arg::new("source")
+                .short('s')
+                .long("source")
+                .value_name("PATH")
+                .help("Path to the is_prime source file")
+                .default_value("examples/is-prime/src/lib.rs"),
+        )
+        .arg(
+            Arg::new("iterations")
+                .short('n')
+                .long("iterations")
+                .value_name("COUNT")
+                .help("Number of iterations to run")
+                .default_value("1"),
+        )
+        .get_matches();
+
+    let input_number: u64 = matches
+        .get_one::<String>("input")
+        .unwrap()
+        .parse()
+        .expect("Input must be a valid number");
+
+    let source_path = PathBuf::from(matches.get_one::<String>("source").unwrap());
+
+    let iterations: usize = matches
+        .get_one::<String>("iterations")
+        .unwrap()
+        .parse()
+        .expect("Iterations must be a valid number");
+
+    println!("Is Prime Benchmark");
+    println!("==================");
+    println!("Input number: {}", input_number);
+    println!("Source file: {}", source_path.display());
+    println!("Iterations: {}", iterations);
+    println!();
+
+    let runner = BenchmarkRunner::new()?;
+
+    let mut total_cycles = 0;
+    let mut total_compile_time = 0;
+    let mut total_execution_time = 0;
+
+    for i in 1..=iterations {
+        if iterations > 1 {
+            println!("--- Iteration {} ---", i);
+        }
+
+        let stats = runner.run_benchmark(
+            &source_path,
+            &[input_number],
+            &format!("is_prime({})", input_number),
+        )?;
+
+        total_cycles += stats.vm_cycles;
+        total_compile_time += stats.compile_time_ms;
+        total_execution_time += stats.execution_time_ms;
+
+        if iterations > 1 {
+            println!();
+        }
+    }
+
+    if iterations > 1 {
+        println!("===============================================================================");
+        println!("Average results over {} iterations:", iterations);
+        println!("-------------------------------------------------------------------------------");
+        println!("Average VM cycles: {}", total_cycles / iterations);
+        println!("Average compilation time: {} ms", total_compile_time / iterations as u128);
+        println!("Average execution time: {} ms", total_execution_time / iterations as u128);
+        println!("Total compilation time: {} ms", total_compile_time);
+        println!("Total execution time: {} ms", total_execution_time);
+        println!("===============================================================================");
+    }
+
+    Ok(())
+}

--- a/benches/src/is_prime.rs
+++ b/benches/src/is_prime.rs
@@ -5,58 +5,35 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
-use clap::{Arg, Command};
-use miden_compiler_benches::BenchmarkRunner;
+use clap::Parser;
+use midenc_benchmark_runner::BenchmarkRunner;
 
-fn main() -> Result<()> {
-    let matches = Command::new("is_prime_benchmark")
-        .about("Benchmark the is_prime program in Miden VM")
-        .arg(
-            Arg::new("input")
-                .short('i')
-                .long("input")
-                .value_name("NUMBER")
-                .help("The number to test for primality")
-                .default_value("29"),
-        )
-        .arg(
-            Arg::new("source")
-                .short('s')
-                .long("source")
-                .value_name("PATH")
-                .help("Path to the is_prime source file")
-                .default_value("examples/is-prime/src/lib.rs"),
-        )
-        .arg(
-            Arg::new("iterations")
-                .short('n')
-                .long("iterations")
-                .value_name("COUNT")
-                .help("Number of iterations to run")
-                .default_value("1"),
-        )
-        .get_matches();
+#[derive(Parser)]
+struct Config {
+    /// The number to test for primality
+    #[arg(short = 'i', long, value_name = "NUMBER", default_value = "29")]
+    input: usize,
+    /// Path to the is_prime source file
+    #[arg(
+        short = 's',
+        long,
+        value_name = "PATH",
+        default_value = "examples/is-prime/src/lib.rs"
+    )]
+    source: PathBuf,
+    /// Number of iterations to run
+    #[arg(short = 'n', long, value_name = "COUNT", default_value = "1")]
+    iterations: usize,
+}
 
-    let input_number: u64 = matches
-        .get_one::<String>("input")
-        .unwrap()
-        .parse()
-        .expect("Input must be a valid number");
-
-    let source_path = PathBuf::from(matches.get_one::<String>("source").unwrap());
-
-    let iterations: usize = matches
-        .get_one::<String>("iterations")
-        .unwrap()
-        .parse()
-        .expect("Iterations must be a valid number");
+fn main() -> anyhow::Result<()> {
+    let config = Config::parse();
 
     println!("Is Prime Benchmark");
     println!("==================");
-    println!("Input number: {input_number}");
-    println!("Source file: {}", source_path.display());
-    println!("Iterations: {iterations}");
+    println!("Input number: {}", config.input);
+    println!("Source file: {}", config.source.display());
+    println!("Iterations: {}", config.iterations);
     println!();
 
     let runner = BenchmarkRunner::new()?;
@@ -65,33 +42,39 @@ fn main() -> Result<()> {
     let mut total_compile_time = 0;
     let mut total_execution_time = 0;
 
-    for i in 1..=iterations {
-        if iterations > 1 {
+    for i in 1..=config.iterations {
+        if config.iterations > 1 {
             println!("--- Iteration {i} ---");
         }
 
         let stats = runner.run_benchmark(
-            &source_path,
-            &[input_number],
-            &format!("is_prime({input_number})"),
+            &config.source,
+            &[config.input as u64],
+            &format!("is_prime({})", config.input),
         )?;
 
         total_cycles += stats.vm_cycles;
         total_compile_time += stats.compile_time_ms;
         total_execution_time += stats.execution_time_ms;
 
-        if iterations > 1 {
+        if config.iterations > 1 {
             println!();
         }
     }
 
-    if iterations > 1 {
+    if config.iterations > 1 {
         println!("===============================================================================");
-        println!("Average results over {iterations} iterations:");
+        println!("Average results over {} iterations:", config.iterations);
         println!("-------------------------------------------------------------------------------");
-        println!("Average VM cycles: {}", total_cycles / iterations);
-        println!("Average compilation time: {} ms", total_compile_time / iterations as u128);
-        println!("Average execution time: {} ms", total_execution_time / iterations as u128);
+        println!("Average VM cycles: {}", total_cycles / config.iterations);
+        println!(
+            "Average compilation time: {} ms",
+            total_compile_time / config.iterations as u128
+        );
+        println!(
+            "Average execution time: {} ms",
+            total_execution_time / config.iterations as u128
+        );
         println!("Total compilation time: {total_compile_time} ms");
         println!("Total execution time: {total_execution_time} ms");
         println!("===============================================================================");

--- a/benches/src/is_prime.rs
+++ b/benches/src/is_prime.rs
@@ -54,9 +54,9 @@ fn main() -> Result<()> {
 
     println!("Is Prime Benchmark");
     println!("==================");
-    println!("Input number: {}", input_number);
+    println!("Input number: {input_number}");
     println!("Source file: {}", source_path.display());
-    println!("Iterations: {}", iterations);
+    println!("Iterations: {iterations}");
     println!();
 
     let runner = BenchmarkRunner::new()?;
@@ -67,13 +67,13 @@ fn main() -> Result<()> {
 
     for i in 1..=iterations {
         if iterations > 1 {
-            println!("--- Iteration {} ---", i);
+            println!("--- Iteration {i} ---");
         }
 
         let stats = runner.run_benchmark(
             &source_path,
             &[input_number],
-            &format!("is_prime({})", input_number),
+            &format!("is_prime({input_number})"),
         )?;
 
         total_cycles += stats.vm_cycles;
@@ -87,13 +87,13 @@ fn main() -> Result<()> {
 
     if iterations > 1 {
         println!("===============================================================================");
-        println!("Average results over {} iterations:", iterations);
+        println!("Average results over {iterations} iterations:");
         println!("-------------------------------------------------------------------------------");
         println!("Average VM cycles: {}", total_cycles / iterations);
         println!("Average compilation time: {} ms", total_compile_time / iterations as u128);
         println!("Average execution time: {} ms", total_execution_time / iterations as u128);
-        println!("Total compilation time: {} ms", total_compile_time);
-        println!("Total execution time: {} ms", total_execution_time);
+        println!("Total compilation time: {total_compile_time} ms");
+        println!("Total execution time: {total_execution_time} ms");
         println!("===============================================================================");
     }
 

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,0 +1,200 @@
+//! Common benchmarking framework for Miden compiler programs
+//!
+//! This module provides utilities for compiling Rust programs to Miden assembly
+//! and measuring their execution performance in the Miden VM.
+
+use std::{
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+
+/// Execution statistics for a Miden program
+#[derive(Debug, Clone)]
+pub struct ExecutionStats {
+    /// Total VM cycles executed
+    pub vm_cycles: usize,
+    /// Compilation time in milliseconds
+    pub compile_time_ms: u128,
+    /// Execution time in milliseconds
+    pub execution_time_ms: u128,
+}
+
+impl ExecutionStats {
+    /// Create execution stats from midenc output
+    pub fn from_midenc_output(
+        output: &str,
+        compile_time_ms: u128,
+        execution_time_ms: u128,
+    ) -> Result<Self> {
+        // Parse the VM cycles from midenc output
+        let vm_cycles = Self::parse_vm_cycles(output)?;
+
+        Ok(Self {
+            vm_cycles,
+            compile_time_ms,
+            execution_time_ms,
+        })
+    }
+
+    /// Parse VM cycles from midenc run output
+    fn parse_vm_cycles(output: &str) -> Result<usize> {
+        for line in output.lines() {
+            if line.contains("VM cycles:") {
+                // Look for pattern like "VM cycles: 805 extended to 1024 steps"
+                if let Some(cycles_part) = line.split("VM cycles:").nth(1) {
+                    if let Some(cycles_str) = cycles_part.trim().split_whitespace().next() {
+                        return cycles_str.parse().with_context(|| {
+                            format!("Failed to parse VM cycles from: {}", cycles_str)
+                        });
+                    }
+                }
+            }
+        }
+        Err(anyhow::anyhow!("Could not find VM cycles in output"))
+    }
+
+    /// Print formatted execution statistics
+    pub fn print(&self, program_name: &str) {
+        println!("===============================================================================");
+        println!("Benchmark results for: {}", program_name);
+        println!("-------------------------------------------------------------------------------");
+        println!(
+            "VM cycles: {} extended to {} steps",
+            self.vm_cycles,
+            self.vm_cycles.next_power_of_two()
+        );
+        println!("Compilation time: {} ms", self.compile_time_ms);
+        println!("Execution time: {} ms", self.execution_time_ms);
+        println!("===============================================================================");
+    }
+}
+
+/// A benchmark runner for Miden programs
+pub struct BenchmarkRunner;
+
+impl BenchmarkRunner {
+    /// Create a new benchmark runner
+    pub fn new() -> Result<Self> {
+        Ok(Self)
+    }
+
+    /// Compile a Rust source file to Miden assembly using cargo miden
+    pub fn compile_rust_to_masm(&self, source_path: &Path) -> Result<PathBuf> {
+        let compile_start = Instant::now();
+
+        // Convert to absolute path if relative
+        let abs_source_path = if source_path.is_absolute() {
+            source_path.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(source_path)
+        };
+
+        // Get the directory containing the source file
+        let project_dir = abs_source_path.parent()
+            .and_then(|p| p.parent()) // Go up from src/ to project root
+            .ok_or_else(|| anyhow::anyhow!("Could not determine project directory"))?;
+
+        // Use cargo miden to build the project
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.arg("miden")
+            .arg("build")
+            .arg("--release")
+            .arg("--manifest-path")
+            .arg(project_dir.join("Cargo.toml"))
+            .current_dir(project_dir);
+
+        let output = cmd.output().with_context(|| "Failed to execute cargo miden build")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("cargo miden build failed: {}", stderr));
+        }
+
+        let compile_time = compile_start.elapsed();
+        println!("Compilation completed in {} ms", compile_time.as_millis());
+
+        // Find the generated .masp file
+        let target_dir = project_dir.join("target").join("miden").join("release");
+        let project_name = project_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| anyhow::anyhow!("Could not determine project name"))?;
+
+        // Convert hyphens to underscores for the MASP filename
+        let masp_filename = project_name.replace('-', "_");
+        let masp_path = target_dir.join(format!("{}.masp", masp_filename));
+
+        if !masp_path.exists() {
+            return Err(anyhow::anyhow!("Expected MASP file not found: {}", masp_path.display()));
+        }
+
+        Ok(masp_path)
+    }
+
+    /// Execute a Miden assembly program using midenc run and return execution statistics
+    pub fn execute_masm(&self, masm_path: &Path, inputs: &[u64]) -> Result<ExecutionStats> {
+        let execution_start = Instant::now();
+
+        // Create inputs file in TOML format
+        let inputs_content = format!(
+            r#"[inputs]
+stack = [{}]"#,
+            inputs.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(", ")
+        );
+
+        let inputs_file = masm_path.with_extension("inputs");
+        std::fs::write(&inputs_file, inputs_content)
+            .with_context(|| format!("Failed to write inputs file: {}", inputs_file.display()))?;
+
+        // Use midenc run to execute the program
+        let mut cmd = std::process::Command::new("midenc");
+        cmd.arg("run").arg(masm_path).arg("--inputs").arg(&inputs_file);
+
+        let output = cmd.output().with_context(|| "Failed to execute midenc run")?;
+
+        let execution_time = execution_start.elapsed();
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("midenc run failed: {}", stderr));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        println!("Program executed successfully");
+        println!("{}", stdout);
+
+        // Clean up inputs file
+        let _ = std::fs::remove_file(&inputs_file);
+
+        ExecutionStats::from_midenc_output(&stdout, 0, execution_time.as_millis())
+    }
+
+    /// Run a complete benchmark: compile Rust to MASM and execute
+    pub fn run_benchmark(
+        &self,
+        source_path: &Path,
+        inputs: &[u64],
+        program_name: &str,
+    ) -> Result<ExecutionStats> {
+        println!("Running benchmark for: {}", program_name);
+
+        let compile_start = Instant::now();
+        let masm_path = self.compile_rust_to_masm(source_path)?;
+        let compile_time = compile_start.elapsed();
+
+        let mut stats = self.execute_masm(&masm_path, inputs)?;
+        stats.compile_time_ms = compile_time.as_millis();
+
+        stats.print(program_name);
+
+        Ok(stats)
+    }
+}
+
+impl Default for BenchmarkRunner {
+    fn default() -> Self {
+        Self::new().expect("Failed to create benchmark runner")
+    }
+}

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -44,9 +44,9 @@ impl ExecutionStats {
             if line.contains("VM cycles:") {
                 // Look for pattern like "VM cycles: 805 extended to 1024 steps"
                 if let Some(cycles_part) = line.split("VM cycles:").nth(1) {
-                    if let Some(cycles_str) = cycles_part.trim().split_whitespace().next() {
+                    if let Some(cycles_str) = cycles_part.split_whitespace().next() {
                         return cycles_str.parse().with_context(|| {
-                            format!("Failed to parse VM cycles from: {}", cycles_str)
+                            format!("Failed to parse VM cycles from: {cycles_str}")
                         });
                     }
                 }
@@ -58,7 +58,7 @@ impl ExecutionStats {
     /// Print formatted execution statistics
     pub fn print(&self, program_name: &str) {
         println!("===============================================================================");
-        println!("Benchmark results for: {}", program_name);
+        println!("Benchmark results for: {program_name}");
         println!("-------------------------------------------------------------------------------");
         println!(
             "VM cycles: {} extended to {} steps",
@@ -124,7 +124,7 @@ impl BenchmarkRunner {
 
         // Convert hyphens to underscores for the MASP filename
         let masp_filename = project_name.replace('-', "_");
-        let masp_path = target_dir.join(format!("{}.masp", masp_filename));
+        let masp_path = target_dir.join(format!("{masp_filename}.masp"));
 
         if !masp_path.exists() {
             return Err(anyhow::anyhow!("Expected MASP file not found: {}", masp_path.display()));
@@ -163,7 +163,7 @@ stack = [{}]"#,
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         println!("Program executed successfully");
-        println!("{}", stdout);
+        println!("{stdout}");
 
         // Clean up inputs file
         let _ = std::fs::remove_file(&inputs_file);
@@ -178,7 +178,7 @@ stack = [{}]"#,
         inputs: &[u64],
         program_name: &str,
     ) -> Result<ExecutionStats> {
-        println!("Running benchmark for: {}", program_name);
+        println!("Running benchmark for: {program_name}");
 
         let compile_start = Instant::now();
         let masm_path = self.compile_rust_to_masm(source_path)?;


### PR DESCRIPTION
This PR adds a `benches/` directory with an extensible framework for benchmarking Miden compiler programs. The system automatically compiles Rust programs with `cargo miden build`, executes them with `midenc run`, and measures VM cycles and performance metrics.

**Usage:**
```bash
# Run is_prime benchmark
cargo run -p miden-compiler-benches --bin is_prime

# Test different inputs and iterations
cargo run -p miden-compiler-benches --bin is_prime -- --input 97 --iterations 3
```

The framework is designed to be easily extended for benchmarking other Miden programs by adding new binaries to `benches/src/`.