### PR TITLE
fix: update Miden SDK `AccountId` type and `account::get_id()` for two felts (prefix and suffix) account ids

### DIFF
--- a/examples/basic-wallet/cargo-generate.toml
+++ b/examples/basic-wallet/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/examples/collatz/cargo-generate.toml
+++ b/examples/collatz/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/examples/counter-contract/cargo-generate.toml
+++ b/examples/counter-contract/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/examples/counter-note/cargo-generate.toml
+++ b/examples/counter-note/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/examples/fibonacci/cargo-generate.toml
+++ b/examples/fibonacci/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/examples/is-prime/cargo-generate.toml
+++ b/examples/is-prime/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/examples/p2id-note/cargo-generate.toml
+++ b/examples/p2id-note/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/examples/p2id-note/src/lib.rs
+++ b/examples/p2id-note/src/lib.rs
@@ -32,9 +32,12 @@ struct MyNote;
 impl Guest for MyNote {
     fn note_script() {
         let inputs = miden::note::get_inputs();
-        let target_account_id_felt = inputs[0];
+        // TODO: is this the right order of the prefix and suffix in the note inputs?
+        let target_account_id_prefix = inputs[0];
+        let target_account_id_suffix = inputs[1];
         let account_id = miden::account::get_id();
-        assert_eq(account_id.as_felt(), target_account_id_felt);
+        assert_eq(account_id.prefix, target_account_id_prefix);
+        assert_eq(account_id.suffix, target_account_id_suffix);
         let assets = miden::note::get_assets();
         for asset in assets {
             receive_asset(asset);

--- a/examples/storage-example/cargo-generate.toml
+++ b/examples/storage-example/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["target"]

--- a/frontend/wasm/src/miden_abi/transform.rs
+++ b/frontend/wasm/src/miden_abi/transform.rs
@@ -71,10 +71,9 @@ fn get_transform_strategy(path: &SymbolPath) -> Option<TransformStrategy> {
         symbols::Miden => match components.next()?.as_symbol_name() {
             symbols::Account => {
                 match components.next_if(|c| c.is_leaf())?.as_symbol_name().as_str() {
-                    tx_kernel::account::GET_ID | tx_kernel::account::INCR_NONCE => {
-                        Some(TransformStrategy::NoTransform)
-                    }
+                    tx_kernel::account::INCR_NONCE => Some(TransformStrategy::NoTransform),
                     tx_kernel::account::ADD_ASSET
+                    | tx_kernel::account::GET_ID
                     | tx_kernel::account::REMOVE_ASSET
                     | tx_kernel::account::GET_STORAGE_ITEM
                     | tx_kernel::account::SET_STORAGE_ITEM

--- a/frontend/wasm/src/miden_abi/tx_kernel/account.rs
+++ b/frontend/wasm/src/miden_abi/tx_kernel/account.rs
@@ -33,7 +33,7 @@ pub(crate) fn signatures() -> ModuleFunctionTypeMap {
         Symbol::from(REMOVE_ASSET),
         FunctionType::new(CallConv::Wasm, [Felt, Felt, Felt, Felt], [Felt, Felt, Felt, Felt]),
     );
-    account.insert(Symbol::from(GET_ID), FunctionType::new(CallConv::Wasm, [], [Felt]));
+    account.insert(Symbol::from(GET_ID), FunctionType::new(CallConv::Wasm, [], [Felt, Felt]));
     account.insert(
         Symbol::from(GET_STORAGE_ITEM),
         FunctionType::new(CallConv::Wasm, [Felt], [Felt, Felt, Felt, Felt]),

--- a/sdk/base-sys/src/bindings/account.rs
+++ b/sdk/base-sys/src/bindings/account.rs
@@ -6,7 +6,7 @@ use super::types::{AccountId, Asset};
 #[link(wasm_import_module = "miden:core-base/account@1.0.0")]
 extern "C" {
     #[link_name = "get-id"]
-    pub fn extern_account_get_id() -> AccountId;
+    pub fn extern_account_get_id(ptr: *mut AccountId);
     #[link_name = "add-asset"]
     pub fn extern_account_add_asset(_: Felt, _: Felt, _: Felt, _: Felt, ptr: *mut Asset);
     #[link_name = "remove-asset"]
@@ -17,7 +17,11 @@ extern "C" {
 
 /// Get the account ID of the currently executing note account.
 pub fn get_id() -> AccountId {
-    unsafe { extern_account_get_id() }
+    unsafe {
+        let mut ret_area = ::core::mem::MaybeUninit::<AccountId>::uninit();
+        extern_account_get_id(ret_area.as_mut_ptr());
+        ret_area.assume_init()
+    }
 }
 
 /// Add the specified asset to the vault.

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -1,21 +1,13 @@
 use miden_stdlib_sys::{Felt, Word};
 
-#[repr(transparent)]
+#[allow(unused)]
 #[derive(Copy, Clone)]
-pub struct AccountId(Felt);
-
-impl AccountId {
-    #[inline(always)]
-    pub const fn as_felt(&self) -> Felt {
-        self.0
-    }
+pub struct AccountId {
+    pub prefix: Felt,
+    pub suffix: Felt,
 }
 
-impl From<AccountId> for Felt {
-    fn from(account_id: AccountId) -> Felt {
-        account_id.0
-    }
-}
+impl AccountId {}
 
 #[repr(transparent)]
 pub struct Asset {

--- a/sdk/base-sys/wit/miden-core-base.wit
+++ b/sdk/base-sys/wit/miden-core-base.wit
@@ -14,7 +14,7 @@ interface account {
     /// Remove the specified asset from the vault
     remove-asset: func(asset0: f32, asset1: f32, asset2: f32, asset3: f32, result-ptr: s32);
     /// Get the id of the currently executing account
-    get-id: func() -> f32;
+    get-id: func(result-ptr: s32);
 
     /// Gets an item from the account storage
     get-item: func(index: f32, result-ptr: s32);

--- a/sdk/base/wit/miden.wit
+++ b/sdk/base/wit/miden.wit
@@ -27,19 +27,16 @@ interface core-types {
 
     /// Unique identifier of an account.
     ///
-    /// Account ID consists of 1 field element (~64 bits). This field element uniquely identifies a
-    /// single account and also specifies the type of the underlying account. Specifically:
-    /// - The two most significant bits of the ID specify the type of the account:
-    ///  - 00 - regular account with updatable code.
-    ///  - 01 - regular account with immutable code.
-    ///  - 10 - fungible asset faucet with immutable code.
-    ///  - 11 - non-fungible asset faucet with immutable code.
-    ///  - The third most significant bit of the ID specifies whether the account data is stored on-chain:
-    ///  - 0 - full account data is stored on-chain.
-    ///  - 1 - only the account hash is stored on-chain which serves as a commitment to the account state.
-    /// As such the three most significant bits fully describes the type of the account.
+    /// # Layout
+    ///
+    /// An `AccountId` consists of two field elements, where the first is called the prefix and the
+    /// second is called the suffix. It is laid out as follows:
+    ///
+    /// prefix: [hash (56 bits) | storage mode (2 bits) | type (2 bits) | version (4 bits)]
+    /// suffix: [zero bit | hash (55 bits) | 8 zero bits]
     record account-id {
-        inner: felt
+        prefix: felt,
+	suffix: felt
     }
 
     /// Creates a new account ID from a field element.

--- a/sdk/base/wit/miden.wit
+++ b/sdk/base/wit/miden.wit
@@ -35,7 +35,7 @@ interface core-types {
     /// prefix: [hash (56 bits) | storage mode (2 bits) | type (2 bits) | version (4 bits)]
     /// suffix: [zero bit | hash (55 bits) | 8 zero bits]
     record account-id {
-        prefix: felt,
+    	prefix: felt,
 	suffix: felt
     }
 

--- a/tests/integration/expected/abi_transform_tx_kernel_get_id.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_id.hir
@@ -1,21 +1,86 @@
 builtin.component root_ns:root@1.0.0 {
     builtin.module public @abi_transform_tx_kernel_get_id {
-        private builtin.function @miden_base_sys::bindings::account::extern_account_get_id() -> felt {
-        ^block3:
-            v0 = hir.exec @miden/account/get_id() : felt
-            builtin.ret v0;
+        private builtin.function @miden_base_sys::bindings::account::extern_account_get_id(v0: i32) {
+        ^block3(v0: i32):
+            v1, v2 = hir.exec @miden/account/get_id() : felt, felt
+            v3 = hir.bitcast v0 : u32;
+            v4 = hir.int_to_ptr v3 : ptr<byte, felt>;
+            hir.store v4, v1;
+            v5 = arith.constant 4 : u32;
+            v6 = arith.add v3, v5 : u32 #[overflow = checked];
+            v7 = hir.int_to_ptr v6 : ptr<byte, felt>;
+            hir.store v7, v2;
+            builtin.ret ;
         };
 
-        public builtin.function @entrypoint() -> felt {
-        ^block8:
-            v3 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::get_id() : felt
-            builtin.ret v3;
+        public builtin.function @entrypoint(v8: i32) {
+        ^block8(v8: i32):
+            v10 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/__stack_pointer : ptr<byte, u8>
+            v11 = hir.bitcast v10 : ptr<byte, i32>;
+            v12 = hir.load v11 : i32;
+            v13 = arith.constant 16 : i32;
+            v14 = arith.sub v12, v13 : i32 #[overflow = wrapping];
+            v15 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/__stack_pointer : ptr<byte, u8>
+            v16 = hir.bitcast v15 : ptr<byte, i32>;
+            hir.store v16, v14;
+            v17 = arith.constant 8 : i32;
+            v18 = arith.add v14, v17 : i32 #[overflow = wrapping];
+            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::get_id(v18)
+            v20 = arith.constant 8 : u32;
+            v19 = hir.bitcast v14 : u32;
+            v21 = arith.add v19, v20 : u32 #[overflow = checked];
+            v61 = arith.constant 8 : u32;
+            v23 = arith.mod v21, v61 : u32;
+            hir.assertz v23 #[code = 250];
+            v24 = hir.int_to_ptr v21 : ptr<byte, i64>;
+            v25 = hir.load v24 : i64;
+            v26 = hir.bitcast v8 : u32;
+            v27 = arith.constant 4 : u32;
+            v28 = arith.mod v26, v27 : u32;
+            hir.assertz v28 #[code = 250];
+            v29 = hir.int_to_ptr v26 : ptr<byte, i64>;
+            hir.store v29, v25;
+            v60 = arith.constant 16 : i32;
+            v31 = arith.add v14, v60 : i32 #[overflow = wrapping];
+            v32 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/__stack_pointer : ptr<byte, u8>
+            v33 = hir.bitcast v32 : ptr<byte, i32>;
+            hir.store v33, v31;
+            builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::account::get_id() -> felt {
-        ^block10:
-            v5 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::extern_account_get_id() : felt
-            builtin.ret v5;
+        private builtin.function @miden_base_sys::bindings::account::get_id(v34: i32) {
+        ^block10(v34: i32):
+            v36 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/__stack_pointer : ptr<byte, u8>
+            v37 = hir.bitcast v36 : ptr<byte, i32>;
+            v38 = hir.load v37 : i32;
+            v39 = arith.constant 16 : i32;
+            v40 = arith.sub v38, v39 : i32 #[overflow = wrapping];
+            v41 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/__stack_pointer : ptr<byte, u8>
+            v42 = hir.bitcast v41 : ptr<byte, i32>;
+            hir.store v42, v40;
+            v43 = arith.constant 8 : i32;
+            v44 = arith.add v40, v43 : i32 #[overflow = wrapping];
+            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::extern_account_get_id(v44)
+            v46 = arith.constant 8 : u32;
+            v45 = hir.bitcast v40 : u32;
+            v47 = arith.add v45, v46 : u32 #[overflow = checked];
+            v48 = arith.constant 4 : u32;
+            v49 = arith.mod v47, v48 : u32;
+            hir.assertz v49 #[code = 250];
+            v50 = hir.int_to_ptr v47 : ptr<byte, i64>;
+            v51 = hir.load v50 : i64;
+            v52 = hir.bitcast v34 : u32;
+            v63 = arith.constant 8 : u32;
+            v54 = arith.mod v52, v63 : u32;
+            hir.assertz v54 #[code = 250];
+            v55 = hir.int_to_ptr v52 : ptr<byte, i64>;
+            hir.store v55, v51;
+            v62 = arith.constant 16 : i32;
+            v57 = arith.add v40, v62 : i32 #[overflow = wrapping];
+            v58 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_id/__stack_pointer : ptr<byte, u8>
+            v59 = hir.bitcast v58 : ptr<byte, i32>;
+            hir.store v59, v57;
+            builtin.ret ;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {

--- a/tests/integration/expected/abi_transform_tx_kernel_get_id.wat
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_id.wat
@@ -1,15 +1,49 @@
 (module $abi_transform_tx_kernel_get_id.wasm
-  (type (;0;) (func (result f32)))
+  (type (;0;) (func (param i32)))
   (import "miden:core-base/account@1.0.0" "get-id" (func $miden_base_sys::bindings::account::extern_account_get_id (;0;) (type 0)))
   (table (;0;) 1 1 funcref)
   (memory (;0;) 16)
   (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
   (export "memory" (memory 0))
   (export "entrypoint" (func $entrypoint))
-  (func $entrypoint (;1;) (type 0) (result f32)
+  (func $entrypoint (;1;) (type 0) (param i32)
+    (local i32)
+    global.get $__stack_pointer
+    i32.const 16
+    i32.sub
+    local.tee 1
+    global.set $__stack_pointer
+    local.get 1
+    i32.const 8
+    i32.add
     call $miden_base_sys::bindings::account::get_id
+    local.get 0
+    local.get 1
+    i64.load offset=8
+    i64.store align=4
+    local.get 1
+    i32.const 16
+    i32.add
+    global.set $__stack_pointer
   )
-  (func $miden_base_sys::bindings::account::get_id (;2;) (type 0) (result f32)
+  (func $miden_base_sys::bindings::account::get_id (;2;) (type 0) (param i32)
+    (local i32)
+    global.get $__stack_pointer
+    i32.const 16
+    i32.sub
+    local.tee 1
+    global.set $__stack_pointer
+    local.get 1
+    i32.const 8
+    i32.add
     call $miden_base_sys::bindings::account::extern_account_get_id
+    local.get 0
+    local.get 1
+    i64.load offset=8 align=4
+    i64.store
+    local.get 1
+    i32.const 16
+    i32.add
+    global.set $__stack_pointer
   )
 )

--- a/tests/integration/expected/examples/p2id.hir
+++ b/tests/integration/expected/examples/p2id.hir
@@ -6,22 +6,29 @@ builtin.component miden:base/note-script@1.0.0 {
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::account::extern_account_get_id() -> felt {
-        ^block8:
-            v4 = hir.exec @miden/account/get_id() : felt
-            builtin.ret v4;
+        private builtin.function @miden_base_sys::bindings::account::extern_account_get_id(v4: i32) {
+        ^block8(v4: i32):
+            v5, v6 = hir.exec @miden/account/get_id() : felt, felt
+            v7 = hir.bitcast v4 : u32;
+            v8 = hir.int_to_ptr v7 : ptr<byte, felt>;
+            hir.store v8, v5;
+            v9 = arith.constant 4 : u32;
+            v10 = arith.add v7, v9 : u32 #[overflow = checked];
+            v11 = hir.int_to_ptr v10 : ptr<byte, felt>;
+            hir.store v11, v6;
+            builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::note::extern_note_get_inputs(v6: i32) -> i32 {
-        ^block12(v6: i32):
-            v7, v8 = hir.exec @miden/note/get_inputs(v6) : i32, i32
-            builtin.ret v7;
+        private builtin.function @miden_base_sys::bindings::note::extern_note_get_inputs(v12: i32) -> i32 {
+        ^block12(v12: i32):
+            v13, v14 = hir.exec @miden/note/get_inputs(v12) : i32, i32
+            builtin.ret v13;
         };
 
-        private builtin.function @miden_base_sys::bindings::note::extern_note_get_assets(v10: i32) -> i32 {
-        ^block15(v10: i32):
-            v11, v12 = hir.exec @miden/note/get_assets(v10) : i32, i32
-            builtin.ret v11;
+        private builtin.function @miden_base_sys::bindings::note::extern_note_get_assets(v16: i32) -> i32 {
+        ^block15(v16: i32):
+            v17, v18 = hir.exec @miden/note/get_assets(v16) : i32, i32
+            builtin.ret v17;
         };
 
         private builtin.function @__wasm_call_ctors() {
@@ -34,232 +41,276 @@ builtin.component miden:base/note-script@1.0.0 {
             builtin.ret ;
         };
 
-        private builtin.function @__rustc::__rust_alloc(v14: i32, v15: i32) -> i32 {
-        ^block23(v14: i32, v15: i32):
-            v17 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v18 = hir.bitcast v17 : ptr<byte, i32>;
-            v19 = hir.load v18 : i32;
-            v20 = arith.constant 1048696 : i32;
-            v21 = arith.add v19, v20 : i32 #[overflow = wrapping];
-            v22 = hir.exec @miden:base/note-script@1.0.0/p2id/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v21, v15, v14) : i32
-            builtin.ret v22;
+        private builtin.function @__rustc::__rust_alloc(v20: i32, v21: i32) -> i32 {
+        ^block23(v20: i32, v21: i32):
+            v23 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v24 = hir.bitcast v23 : ptr<byte, i32>;
+            v25 = hir.load v24 : i32;
+            v26 = arith.constant 1048696 : i32;
+            v27 = arith.add v25, v26 : i32 #[overflow = wrapping];
+            v28 = hir.exec @miden:base/note-script@1.0.0/p2id/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v27, v21, v20) : i32
+            builtin.ret v28;
         };
 
-        private builtin.function @__rustc::__rust_dealloc(v23: i32, v24: i32, v25: i32) {
-        ^block25(v23: i32, v24: i32, v25: i32):
+        private builtin.function @__rustc::__rust_dealloc(v29: i32, v30: i32, v31: i32) {
+        ^block25(v29: i32, v30: i32, v31: i32):
             builtin.ret ;
         };
 
-        private builtin.function @__rustc::__rust_alloc_zeroed(v26: i32, v27: i32) -> i32 {
-        ^block27(v26: i32, v27: i32):
-            v29 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v30 = hir.bitcast v29 : ptr<byte, i32>;
-            v31 = hir.load v30 : i32;
-            v32 = arith.constant 1048696 : i32;
-            v33 = arith.add v31, v32 : i32 #[overflow = wrapping];
-            v34 = hir.exec @miden:base/note-script@1.0.0/p2id/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v33, v27, v26) : i32
-            v796 = arith.constant 0 : i32;
-            v35 = arith.constant 0 : i32;
-            v36 = arith.eq v34, v35 : i1;
-            v37 = arith.zext v36 : u32;
-            v38 = hir.bitcast v37 : i32;
-            v40 = arith.neq v38, v796 : i1;
-            scf.if v40{
+        private builtin.function @__rustc::__rust_alloc_zeroed(v32: i32, v33: i32) -> i32 {
+        ^block27(v32: i32, v33: i32):
+            v35 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v36 = hir.bitcast v35 : ptr<byte, i32>;
+            v37 = hir.load v36 : i32;
+            v38 = arith.constant 1048696 : i32;
+            v39 = arith.add v37, v38 : i32 #[overflow = wrapping];
+            v40 = hir.exec @miden:base/note-script@1.0.0/p2id/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v39, v33, v32) : i32
+            v847 = arith.constant 0 : i32;
+            v41 = arith.constant 0 : i32;
+            v42 = arith.eq v40, v41 : i1;
+            v43 = arith.zext v42 : u32;
+            v44 = hir.bitcast v43 : i32;
+            v46 = arith.neq v44, v847 : i1;
+            scf.if v46{
             ^block29:
                 scf.yield ;
             } else {
             ^block30:
-                v794 = arith.constant 0 : i32;
-                v795 = arith.constant 0 : i32;
-                v42 = arith.eq v26, v795 : i1;
-                v43 = arith.zext v42 : u32;
-                v44 = hir.bitcast v43 : i32;
-                v46 = arith.neq v44, v794 : i1;
-                scf.if v46{
+                v845 = arith.constant 0 : i32;
+                v846 = arith.constant 0 : i32;
+                v48 = arith.eq v32, v846 : i1;
+                v49 = arith.zext v48 : u32;
+                v50 = hir.bitcast v49 : i32;
+                v52 = arith.neq v50, v845 : i1;
+                scf.if v52{
                 ^block106:
                     scf.yield ;
                 } else {
                 ^block31:
-                    v788 = arith.constant 0 : u8;
-                    v49 = hir.bitcast v26 : u32;
-                    v50 = hir.bitcast v34 : u32;
-                    v51 = hir.int_to_ptr v50 : ptr<byte, u8>;
-                    hir.mem_set v51, v49, v788;
+                    v839 = arith.constant 0 : u8;
+                    v55 = hir.bitcast v32 : u32;
+                    v56 = hir.bitcast v40 : u32;
+                    v57 = hir.int_to_ptr v56 : ptr<byte, u8>;
+                    hir.mem_set v57, v55, v839;
                     scf.yield ;
                 };
                 scf.yield ;
             };
-            builtin.ret v34;
+            builtin.ret v40;
         };
 
         public builtin.function @miden:base/note-script@1.0.0#note-script() {
         ^block32:
-            v56 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v57 = hir.bitcast v56 : ptr<byte, i32>;
-            v58 = hir.load v57 : i32;
-            v59 = arith.constant 32 : i32;
-            v60 = arith.sub v58, v59 : i32 #[overflow = wrapping];
-            v61 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v62 = hir.bitcast v61 : ptr<byte, i32>;
-            hir.store v62, v60;
+            v62 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v63 = hir.bitcast v62 : ptr<byte, i32>;
+            v64 = hir.load v63 : i32;
+            v65 = arith.constant 48 : i32;
+            v66 = arith.sub v64, v65 : i32 #[overflow = wrapping];
+            v67 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v68 = hir.bitcast v67 : ptr<byte, i32>;
+            hir.store v68, v66;
             hir.exec @miden:base/note-script@1.0.0/p2id/wit_bindgen_rt::run_ctors_once()
-            hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::get_inputs(v60)
-            v64 = arith.constant 8 : u32;
-            v63 = hir.bitcast v60 : u32;
-            v65 = arith.add v63, v64 : u32 #[overflow = checked];
-            v66 = arith.constant 4 : u32;
-            v67 = arith.mod v65, v66 : u32;
-            hir.assertz v67 #[code = 250];
-            v68 = hir.int_to_ptr v65 : ptr<byte, i32>;
-            v69 = hir.load v68 : i32;
-            v910 = arith.constant 0 : i32;
-            v53 = arith.constant 0 : i32;
-            v71 = arith.eq v69, v53 : i1;
-            v72 = arith.zext v71 : u32;
-            v73 = hir.bitcast v72 : i32;
-            v75 = arith.neq v73, v910 : i1;
-            cf.cond_br v75 ^block34, ^block35;
-        ^block34:
-            ub.unreachable ;
-        ^block35:
-            v909 = arith.constant 4 : u32;
-            v76 = hir.bitcast v60 : u32;
-            v78 = arith.add v76, v909 : u32 #[overflow = checked];
-            v908 = arith.constant 4 : u32;
-            v80 = arith.mod v78, v908 : u32;
-            hir.assertz v80 #[code = 250];
-            v81 = hir.int_to_ptr v78 : ptr<byte, i32>;
-            v82 = hir.load v81 : i32;
-            v83 = hir.bitcast v82 : u32;
-            v907 = arith.constant 4 : u32;
-            v85 = arith.mod v83, v907 : u32;
-            hir.assertz v85 #[code = 250];
-            v86 = hir.int_to_ptr v83 : ptr<byte, felt>;
-            v87 = hir.load v86 : felt;
-            v88 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::account::get_id() : felt
-            hir.assert_eq v88, v87;
-            v89 = arith.constant 12 : i32;
-            v90 = arith.add v60, v89 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::get_assets(v90)
-            v92 = arith.constant 20 : u32;
-            v91 = hir.bitcast v60 : u32;
-            v93 = arith.add v91, v92 : u32 #[overflow = checked];
-            v906 = arith.constant 4 : u32;
-            v95 = arith.mod v93, v906 : u32;
-            hir.assertz v95 #[code = 250];
-            v96 = hir.int_to_ptr v93 : ptr<byte, i32>;
-            v97 = hir.load v96 : i32;
-            v102 = arith.constant 12 : u32;
-            v101 = hir.bitcast v60 : u32;
-            v103 = arith.add v101, v102 : u32 #[overflow = checked];
-            v905 = arith.constant 4 : u32;
-            v105 = arith.mod v103, v905 : u32;
-            hir.assertz v105 #[code = 250];
-            v106 = hir.int_to_ptr v103 : ptr<byte, i32>;
-            v107 = hir.load v106 : i32;
-            v109 = arith.constant 16 : u32;
-            v108 = hir.bitcast v60 : u32;
-            v110 = arith.add v108, v109 : u32 #[overflow = checked];
-            v904 = arith.constant 4 : u32;
-            v112 = arith.mod v110, v904 : u32;
-            hir.assertz v112 #[code = 250];
-            v113 = hir.int_to_ptr v110 : ptr<byte, i32>;
-            v114 = hir.load v113 : i32;
-            v903 = arith.constant 4 : u32;
-            v100 = arith.shl v97, v903 : i32;
-            v866, v867, v868, v869, v870, v871, v872, v873 = scf.while v100, v114, v60, v114, v107 : i32, i32, i32, i32, i32, i32, i32, i32 {
-            ^block117(v874: i32, v875: i32, v876: i32, v877: i32, v878: i32):
-                v901 = arith.constant 0 : i32;
-                v902 = arith.constant 0 : i32;
-                v117 = arith.eq v874, v902 : i1;
-                v118 = arith.zext v117 : u32;
-                v119 = hir.bitcast v118 : i32;
-                v121 = arith.neq v119, v901 : i1;
-                v859, v860 = scf.if v121 : i32, i32 {
-                ^block116:
-                    v807 = ub.poison i32 : i32;
-                    scf.yield v807, v807;
-                } else {
-                ^block39:
-                    v123 = hir.bitcast v875 : u32;
-                    v900 = arith.constant 4 : u32;
-                    v125 = arith.mod v123, v900 : u32;
-                    hir.assertz v125 #[code = 250];
-                    v126 = hir.int_to_ptr v123 : ptr<byte, felt>;
-                    v127 = hir.load v126 : felt;
-                    v899 = arith.constant 4 : u32;
-                    v128 = hir.bitcast v875 : u32;
-                    v130 = arith.add v128, v899 : u32 #[overflow = checked];
-                    v898 = arith.constant 4 : u32;
-                    v132 = arith.mod v130, v898 : u32;
-                    hir.assertz v132 #[code = 250];
-                    v133 = hir.int_to_ptr v130 : ptr<byte, felt>;
-                    v134 = hir.load v133 : felt;
-                    v897 = arith.constant 8 : u32;
-                    v135 = hir.bitcast v875 : u32;
-                    v137 = arith.add v135, v897 : u32 #[overflow = checked];
-                    v896 = arith.constant 4 : u32;
-                    v139 = arith.mod v137, v896 : u32;
-                    hir.assertz v139 #[code = 250];
-                    v140 = hir.int_to_ptr v137 : ptr<byte, felt>;
-                    v141 = hir.load v140 : felt;
-                    v895 = arith.constant 12 : u32;
-                    v142 = hir.bitcast v875 : u32;
-                    v144 = arith.add v142, v895 : u32 #[overflow = checked];
-                    v894 = arith.constant 4 : u32;
-                    v146 = arith.mod v144, v894 : u32;
-                    hir.assertz v146 #[code = 250];
-                    v147 = hir.int_to_ptr v144 : ptr<byte, felt>;
-                    v148 = hir.load v147 : felt;
-                    hir.exec @miden:base/note-script@1.0.0/p2id/p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7(v127, v134, v141, v148)
-                    v170 = arith.constant 16 : i32;
-                    v152 = arith.add v875, v170 : i32 #[overflow = wrapping];
-                    v149 = arith.constant -16 : i32;
-                    v150 = arith.add v874, v149 : i32 #[overflow = wrapping];
-                    scf.yield v150, v152;
+            v69 = arith.constant 16 : i32;
+            v70 = arith.add v66, v69 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::get_inputs(v70)
+            v72 = arith.constant 24 : u32;
+            v71 = hir.bitcast v66 : u32;
+            v73 = arith.add v71, v72 : u32 #[overflow = checked];
+            v74 = arith.constant 4 : u32;
+            v75 = arith.mod v73, v74 : u32;
+            hir.assertz v75 #[code = 250];
+            v76 = hir.int_to_ptr v73 : ptr<byte, i32>;
+            v77 = hir.load v76 : i32;
+            v78 = hir.cast v77 : u32;
+            v904 = scf.index_switch v78 : u32 
+            case 0 {
+            ^block109:
+                v944 = arith.constant 1 : u32;
+                scf.yield v944;
+            }
+            case 1 {
+            ^block110:
+                v943 = arith.constant 1 : u32;
+                scf.yield v943;
+            }
+            default {
+            ^block34:
+                v80 = arith.constant 20 : u32;
+                v79 = hir.bitcast v66 : u32;
+                v81 = arith.add v79, v80 : u32 #[overflow = checked];
+                v972 = arith.constant 4 : u32;
+                v83 = arith.mod v81, v972 : u32;
+                hir.assertz v83 #[code = 250];
+                v84 = hir.int_to_ptr v81 : ptr<byte, i32>;
+                v85 = hir.load v84 : i32;
+                v971 = arith.constant 4 : u32;
+                v86 = hir.bitcast v85 : u32;
+                v88 = arith.add v86, v971 : u32 #[overflow = checked];
+                v970 = arith.constant 4 : u32;
+                v90 = arith.mod v88, v970 : u32;
+                hir.assertz v90 #[code = 250];
+                v91 = hir.int_to_ptr v88 : ptr<byte, felt>;
+                v92 = hir.load v91 : felt;
+                v93 = hir.bitcast v85 : u32;
+                v969 = arith.constant 4 : u32;
+                v95 = arith.mod v93, v969 : u32;
+                hir.assertz v95 #[code = 250];
+                v96 = hir.int_to_ptr v93 : ptr<byte, felt>;
+                v97 = hir.load v96 : felt;
+                v98 = arith.constant 8 : i32;
+                v99 = arith.add v66, v98 : i32 #[overflow = wrapping];
+                hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::account::get_id(v99)
+                v101 = arith.constant 12 : u32;
+                v100 = hir.bitcast v66 : u32;
+                v102 = arith.add v100, v101 : u32 #[overflow = checked];
+                v968 = arith.constant 4 : u32;
+                v104 = arith.mod v102, v968 : u32;
+                hir.assertz v104 #[code = 250];
+                v105 = hir.int_to_ptr v102 : ptr<byte, felt>;
+                v106 = hir.load v105 : felt;
+                v108 = arith.constant 8 : u32;
+                v107 = hir.bitcast v66 : u32;
+                v109 = arith.add v107, v108 : u32 #[overflow = checked];
+                v967 = arith.constant 4 : u32;
+                v111 = arith.mod v109, v967 : u32;
+                hir.assertz v111 #[code = 250];
+                v112 = hir.int_to_ptr v109 : ptr<byte, felt>;
+                v113 = hir.load v112 : felt;
+                hir.assert_eq v113, v97;
+                hir.assert_eq v106, v92;
+                v114 = arith.constant 28 : i32;
+                v115 = arith.add v66, v114 : i32 #[overflow = wrapping];
+                hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::get_assets(v115)
+                v117 = arith.constant 36 : u32;
+                v116 = hir.bitcast v66 : u32;
+                v118 = arith.add v116, v117 : u32 #[overflow = checked];
+                v966 = arith.constant 4 : u32;
+                v120 = arith.mod v118, v966 : u32;
+                hir.assertz v120 #[code = 250];
+                v121 = hir.int_to_ptr v118 : ptr<byte, i32>;
+                v122 = hir.load v121 : i32;
+                v127 = arith.constant 28 : u32;
+                v126 = hir.bitcast v66 : u32;
+                v128 = arith.add v126, v127 : u32 #[overflow = checked];
+                v965 = arith.constant 4 : u32;
+                v130 = arith.mod v128, v965 : u32;
+                hir.assertz v130 #[code = 250];
+                v131 = hir.int_to_ptr v128 : ptr<byte, i32>;
+                v132 = hir.load v131 : i32;
+                v134 = arith.constant 32 : u32;
+                v133 = hir.bitcast v66 : u32;
+                v135 = arith.add v133, v134 : u32 #[overflow = checked];
+                v964 = arith.constant 4 : u32;
+                v137 = arith.mod v135, v964 : u32;
+                hir.assertz v137 #[code = 250];
+                v138 = hir.int_to_ptr v135 : ptr<byte, i32>;
+                v139 = hir.load v138 : i32;
+                v963 = arith.constant 4 : u32;
+                v125 = arith.shl v122, v963 : i32;
+                v921, v922, v923, v924, v925, v926, v927, v928 = scf.while v125, v139, v66, v139, v132 : i32, i32, i32, i32, i32, i32, i32, i32 {
+                ^block120(v929: i32, v930: i32, v931: i32, v932: i32, v933: i32):
+                    v962 = arith.constant 0 : i32;
+                    v59 = arith.constant 0 : i32;
+                    v142 = arith.eq v929, v59 : i1;
+                    v143 = arith.zext v142 : u32;
+                    v144 = hir.bitcast v143 : i32;
+                    v146 = arith.neq v144, v962 : i1;
+                    v914, v915 = scf.if v146 : i32, i32 {
+                    ^block119:
+                        v858 = ub.poison i32 : i32;
+                        scf.yield v858, v858;
+                    } else {
+                    ^block39:
+                        v148 = hir.bitcast v930 : u32;
+                        v961 = arith.constant 4 : u32;
+                        v150 = arith.mod v148, v961 : u32;
+                        hir.assertz v150 #[code = 250];
+                        v151 = hir.int_to_ptr v148 : ptr<byte, felt>;
+                        v152 = hir.load v151 : felt;
+                        v960 = arith.constant 4 : u32;
+                        v153 = hir.bitcast v930 : u32;
+                        v155 = arith.add v153, v960 : u32 #[overflow = checked];
+                        v959 = arith.constant 4 : u32;
+                        v157 = arith.mod v155, v959 : u32;
+                        hir.assertz v157 #[code = 250];
+                        v158 = hir.int_to_ptr v155 : ptr<byte, felt>;
+                        v159 = hir.load v158 : felt;
+                        v958 = arith.constant 8 : u32;
+                        v160 = hir.bitcast v930 : u32;
+                        v162 = arith.add v160, v958 : u32 #[overflow = checked];
+                        v957 = arith.constant 4 : u32;
+                        v164 = arith.mod v162, v957 : u32;
+                        hir.assertz v164 #[code = 250];
+                        v165 = hir.int_to_ptr v162 : ptr<byte, felt>;
+                        v166 = hir.load v165 : felt;
+                        v956 = arith.constant 12 : u32;
+                        v167 = hir.bitcast v930 : u32;
+                        v169 = arith.add v167, v956 : u32 #[overflow = checked];
+                        v955 = arith.constant 4 : u32;
+                        v171 = arith.mod v169, v955 : u32;
+                        hir.assertz v171 #[code = 250];
+                        v172 = hir.int_to_ptr v169 : ptr<byte, felt>;
+                        v173 = hir.load v172 : felt;
+                        hir.exec @miden:base/note-script@1.0.0/p2id/p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7(v152, v159, v166, v173)
+                        v954 = arith.constant 16 : i32;
+                        v177 = arith.add v930, v954 : i32 #[overflow = wrapping];
+                        v174 = arith.constant -16 : i32;
+                        v175 = arith.add v929, v174 : i32 #[overflow = wrapping];
+                        scf.yield v175, v177;
+                    };
+                    v951 = ub.poison i32 : i32;
+                    v918 = cf.select v146, v951, v933 : i32;
+                    v952 = ub.poison i32 : i32;
+                    v917 = cf.select v146, v952, v932 : i32;
+                    v953 = ub.poison i32 : i32;
+                    v916 = cf.select v146, v953, v931 : i32;
+                    v857 = arith.constant 1 : u32;
+                    v849 = arith.constant 0 : u32;
+                    v920 = cf.select v146, v849, v857 : u32;
+                    v902 = arith.trunc v920 : i1;
+                    scf.condition v902, v914, v915, v916, v917, v918, v931, v932, v933;
+                } do {
+                ^block121(v934: i32, v935: i32, v936: i32, v937: i32, v938: i32, v939: i32, v940: i32, v941: i32):
+                    scf.yield v934, v935, v936, v937, v938;
                 };
-                v891 = ub.poison i32 : i32;
-                v863 = cf.select v121, v891, v878 : i32;
-                v892 = ub.poison i32 : i32;
-                v862 = cf.select v121, v892, v877 : i32;
-                v893 = ub.poison i32 : i32;
-                v861 = cf.select v121, v893, v876 : i32;
-                v806 = arith.constant 1 : u32;
-                v798 = arith.constant 0 : u32;
-                v865 = cf.select v121, v798, v806 : u32;
-                v851 = arith.trunc v865 : i1;
-                scf.condition v851, v859, v860, v861, v862, v863, v876, v877, v878;
-            } do {
-            ^block118(v879: i32, v880: i32, v881: i32, v882: i32, v883: i32, v884: i32, v885: i32, v886: i32):
-                scf.yield v879, v880, v881, v882, v883;
+                v181 = arith.constant 44 : u32;
+                v180 = hir.bitcast v926 : u32;
+                v182 = arith.add v180, v181 : u32 #[overflow = checked];
+                v950 = arith.constant 4 : u32;
+                v184 = arith.mod v182, v950 : u32;
+                hir.assertz v184 #[code = 250];
+                v185 = hir.int_to_ptr v182 : ptr<byte, i32>;
+                hir.store v185, v927;
+                v188 = arith.constant 40 : u32;
+                v187 = hir.bitcast v926 : u32;
+                v189 = arith.add v187, v188 : u32 #[overflow = checked];
+                v949 = arith.constant 4 : u32;
+                v191 = arith.mod v189, v949 : u32;
+                hir.assertz v191 #[code = 250];
+                v192 = hir.int_to_ptr v189 : ptr<byte, i32>;
+                hir.store v192, v928;
+                v948 = arith.constant 16 : i32;
+                v193 = arith.constant 40 : i32;
+                v194 = arith.add v926, v193 : i32 #[overflow = wrapping];
+                hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v194, v948, v948)
+                v123 = arith.constant 4 : i32;
+                v947 = arith.constant 16 : i32;
+                v198 = arith.add v926, v947 : i32 #[overflow = wrapping];
+                hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v198, v123, v123)
+                v946 = arith.constant 48 : i32;
+                v202 = arith.add v926, v946 : i32 #[overflow = wrapping];
+                v203 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+                v204 = hir.bitcast v203 : ptr<byte, i32>;
+                hir.store v204, v202;
+                v945 = arith.constant 0 : u32;
+                scf.yield v945;
             };
-            v156 = arith.constant 28 : u32;
-            v155 = hir.bitcast v871 : u32;
-            v157 = arith.add v155, v156 : u32 #[overflow = checked];
-            v890 = arith.constant 4 : u32;
-            v159 = arith.mod v157, v890 : u32;
-            hir.assertz v159 #[code = 250];
-            v160 = hir.int_to_ptr v157 : ptr<byte, i32>;
-            hir.store v160, v872;
-            v163 = arith.constant 24 : u32;
-            v162 = hir.bitcast v871 : u32;
-            v164 = arith.add v162, v163 : u32 #[overflow = checked];
-            v889 = arith.constant 4 : u32;
-            v166 = arith.mod v164, v889 : u32;
-            hir.assertz v166 #[code = 250];
-            v167 = hir.int_to_ptr v164 : ptr<byte, i32>;
-            hir.store v167, v873;
-            v888 = arith.constant 16 : i32;
-            v168 = arith.constant 24 : i32;
-            v169 = arith.add v871, v168 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v169, v888, v888)
-            v98 = arith.constant 4 : i32;
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v871, v98, v98)
-            v887 = arith.constant 32 : i32;
-            v175 = arith.add v871, v887 : i32 #[overflow = wrapping];
-            v176 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v177 = hir.bitcast v176 : ptr<byte, i32>;
-            hir.store v177, v175;
+            v942 = arith.constant 0 : u32;
+            v913 = arith.eq v904, v942 : i1;
+            cf.cond_br v913 ^block112, ^block35;
+        ^block35:
+            ub.unreachable ;
+        ^block112:
             builtin.ret ;
         };
 
@@ -270,851 +321,880 @@ builtin.component miden:base/note-script@1.0.0 {
 
         private builtin.function @wit_bindgen_rt::run_ctors_once() {
         ^block42:
-            v179 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v180 = hir.bitcast v179 : ptr<byte, i32>;
-            v181 = hir.load v180 : i32;
-            v182 = arith.constant 1048700 : i32;
-            v183 = arith.add v181, v182 : i32 #[overflow = wrapping];
-            v184 = hir.bitcast v183 : u32;
-            v185 = hir.int_to_ptr v184 : ptr<byte, u8>;
-            v186 = hir.load v185 : u8;
-            v178 = arith.constant 0 : i32;
-            v187 = arith.zext v186 : u32;
-            v188 = hir.bitcast v187 : i32;
-            v190 = arith.neq v188, v178 : i1;
-            scf.if v190{
+            v206 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v207 = hir.bitcast v206 : ptr<byte, i32>;
+            v208 = hir.load v207 : i32;
+            v209 = arith.constant 1048700 : i32;
+            v210 = arith.add v208, v209 : i32 #[overflow = wrapping];
+            v211 = hir.bitcast v210 : u32;
+            v212 = hir.int_to_ptr v211 : ptr<byte, u8>;
+            v213 = hir.load v212 : u8;
+            v205 = arith.constant 0 : i32;
+            v214 = arith.zext v213 : u32;
+            v215 = hir.bitcast v214 : i32;
+            v217 = arith.neq v215, v205 : i1;
+            scf.if v217{
             ^block44:
                 scf.yield ;
             } else {
             ^block45:
-                v191 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-                v192 = hir.bitcast v191 : ptr<byte, i32>;
-                v193 = hir.load v192 : i32;
+                v218 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+                v219 = hir.bitcast v218 : ptr<byte, i32>;
+                v220 = hir.load v219 : i32;
                 hir.exec @miden:base/note-script@1.0.0/p2id/__wasm_call_ctors()
-                v912 = arith.constant 1 : u8;
-                v914 = arith.constant 1048700 : i32;
-                v195 = arith.add v193, v914 : i32 #[overflow = wrapping];
-                v199 = hir.bitcast v195 : u32;
-                v200 = hir.int_to_ptr v199 : ptr<byte, u8>;
-                hir.store v200, v912;
+                v974 = arith.constant 1 : u8;
+                v976 = arith.constant 1048700 : i32;
+                v222 = arith.add v220, v976 : i32 #[overflow = wrapping];
+                v226 = hir.bitcast v222 : u32;
+                v227 = hir.int_to_ptr v226 : ptr<byte, u8>;
+                hir.store v227, v974;
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v201: i32, v202: i32, v203: i32) -> i32 {
-        ^block46(v201: i32, v202: i32, v203: i32):
-            v206 = arith.constant 16 : i32;
-            v205 = arith.constant 0 : i32;
-            v916 = arith.constant 16 : u32;
-            v208 = hir.bitcast v202 : u32;
-            v210 = arith.gt v208, v916 : i1;
-            v211 = arith.zext v210 : u32;
-            v212 = hir.bitcast v211 : i32;
-            v214 = arith.neq v212, v205 : i1;
-            v215 = cf.select v214, v202, v206 : i32;
-            v955 = arith.constant 0 : i32;
-            v216 = arith.constant -1 : i32;
-            v217 = arith.add v215, v216 : i32 #[overflow = wrapping];
-            v218 = arith.band v215, v217 : i32;
-            v220 = arith.neq v218, v955 : i1;
-            v925, v926 = scf.if v220 : i32, u32 {
-            ^block122:
-                v917 = arith.constant 0 : u32;
-                v921 = ub.poison i32 : i32;
-                scf.yield v921, v917;
+        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v228: i32, v229: i32, v230: i32) -> i32 {
+        ^block46(v228: i32, v229: i32, v230: i32):
+            v233 = arith.constant 16 : i32;
+            v232 = arith.constant 0 : i32;
+            v978 = arith.constant 16 : u32;
+            v235 = hir.bitcast v229 : u32;
+            v237 = arith.gt v235, v978 : i1;
+            v238 = arith.zext v237 : u32;
+            v239 = hir.bitcast v238 : i32;
+            v241 = arith.neq v239, v232 : i1;
+            v242 = cf.select v241, v229, v233 : i32;
+            v1017 = arith.constant 0 : i32;
+            v243 = arith.constant -1 : i32;
+            v244 = arith.add v242, v243 : i32 #[overflow = wrapping];
+            v245 = arith.band v242, v244 : i32;
+            v247 = arith.neq v245, v1017 : i1;
+            v987, v988 = scf.if v247 : i32, u32 {
+            ^block125:
+                v979 = arith.constant 0 : u32;
+                v983 = ub.poison i32 : i32;
+                scf.yield v983, v979;
             } else {
             ^block49:
-                v222 = hir.exec @miden:base/note-script@1.0.0/p2id/core::ptr::alignment::Alignment::max(v202, v215) : i32
-                v954 = arith.constant 0 : i32;
-                v221 = arith.constant -2147483648 : i32;
-                v223 = arith.sub v221, v222 : i32 #[overflow = wrapping];
-                v225 = hir.bitcast v223 : u32;
-                v224 = hir.bitcast v203 : u32;
-                v226 = arith.gt v224, v225 : i1;
-                v227 = arith.zext v226 : u32;
-                v228 = hir.bitcast v227 : i32;
-                v230 = arith.neq v228, v954 : i1;
-                v940 = scf.if v230 : i32 {
-                ^block121:
-                    v953 = ub.poison i32 : i32;
-                    scf.yield v953;
+                v249 = hir.exec @miden:base/note-script@1.0.0/p2id/core::ptr::alignment::Alignment::max(v229, v242) : i32
+                v1016 = arith.constant 0 : i32;
+                v248 = arith.constant -2147483648 : i32;
+                v250 = arith.sub v248, v249 : i32 #[overflow = wrapping];
+                v252 = hir.bitcast v250 : u32;
+                v251 = hir.bitcast v230 : u32;
+                v253 = arith.gt v251, v252 : i1;
+                v254 = arith.zext v253 : u32;
+                v255 = hir.bitcast v254 : i32;
+                v257 = arith.neq v255, v1016 : i1;
+                v1002 = scf.if v257 : i32 {
+                ^block124:
+                    v1015 = ub.poison i32 : i32;
+                    scf.yield v1015;
                 } else {
                 ^block50:
-                    v951 = arith.constant 0 : i32;
-                    v236 = arith.sub v951, v222 : i32 #[overflow = wrapping];
-                    v952 = arith.constant -1 : i32;
-                    v232 = arith.add v203, v222 : i32 #[overflow = wrapping];
-                    v234 = arith.add v232, v952 : i32 #[overflow = wrapping];
-                    v237 = arith.band v234, v236 : i32;
-                    v238 = hir.bitcast v201 : u32;
-                    v239 = arith.constant 4 : u32;
-                    v240 = arith.mod v238, v239 : u32;
-                    hir.assertz v240 #[code = 250];
-                    v241 = hir.int_to_ptr v238 : ptr<byte, i32>;
-                    v242 = hir.load v241 : i32;
-                    v950 = arith.constant 0 : i32;
-                    v244 = arith.neq v242, v950 : i1;
-                    scf.if v244{
-                    ^block120:
+                    v1013 = arith.constant 0 : i32;
+                    v263 = arith.sub v1013, v249 : i32 #[overflow = wrapping];
+                    v1014 = arith.constant -1 : i32;
+                    v259 = arith.add v230, v249 : i32 #[overflow = wrapping];
+                    v261 = arith.add v259, v1014 : i32 #[overflow = wrapping];
+                    v264 = arith.band v261, v263 : i32;
+                    v265 = hir.bitcast v228 : u32;
+                    v266 = arith.constant 4 : u32;
+                    v267 = arith.mod v265, v266 : u32;
+                    hir.assertz v267 #[code = 250];
+                    v268 = hir.int_to_ptr v265 : ptr<byte, i32>;
+                    v269 = hir.load v268 : i32;
+                    v1012 = arith.constant 0 : i32;
+                    v271 = arith.neq v269, v1012 : i1;
+                    scf.if v271{
+                    ^block123:
                         scf.yield ;
                     } else {
                     ^block52:
-                        v245 = hir.exec @intrinsics/mem/heap_base() : i32
-                        v246 = hir.mem_size  : u32;
-                        v252 = hir.bitcast v201 : u32;
-                        v949 = arith.constant 4 : u32;
-                        v254 = arith.mod v252, v949 : u32;
-                        hir.assertz v254 #[code = 250];
-                        v948 = arith.constant 16 : u32;
-                        v247 = hir.bitcast v246 : i32;
-                        v250 = arith.shl v247, v948 : i32;
-                        v251 = arith.add v245, v250 : i32 #[overflow = wrapping];
-                        v255 = hir.int_to_ptr v252 : ptr<byte, i32>;
-                        hir.store v255, v251;
+                        v272 = hir.exec @intrinsics/mem/heap_base() : i32
+                        v273 = hir.mem_size  : u32;
+                        v279 = hir.bitcast v228 : u32;
+                        v1011 = arith.constant 4 : u32;
+                        v281 = arith.mod v279, v1011 : u32;
+                        hir.assertz v281 #[code = 250];
+                        v1010 = arith.constant 16 : u32;
+                        v274 = hir.bitcast v273 : i32;
+                        v277 = arith.shl v274, v1010 : i32;
+                        v278 = arith.add v272, v277 : i32 #[overflow = wrapping];
+                        v282 = hir.int_to_ptr v279 : ptr<byte, i32>;
+                        hir.store v282, v278;
                         scf.yield ;
                     };
-                    v258 = hir.bitcast v201 : u32;
-                    v947 = arith.constant 4 : u32;
-                    v260 = arith.mod v258, v947 : u32;
-                    hir.assertz v260 #[code = 250];
-                    v261 = hir.int_to_ptr v258 : ptr<byte, i32>;
-                    v262 = hir.load v261 : i32;
-                    v946 = arith.constant 0 : i32;
-                    v266 = hir.bitcast v237 : u32;
-                    v256 = arith.constant 268435456 : i32;
-                    v263 = arith.sub v256, v262 : i32 #[overflow = wrapping];
-                    v265 = hir.bitcast v263 : u32;
-                    v267 = arith.lt v265, v266 : i1;
-                    v268 = arith.zext v267 : u32;
-                    v269 = hir.bitcast v268 : i32;
-                    v271 = arith.neq v269, v946 : i1;
-                    v939 = scf.if v271 : i32 {
+                    v285 = hir.bitcast v228 : u32;
+                    v1009 = arith.constant 4 : u32;
+                    v287 = arith.mod v285, v1009 : u32;
+                    hir.assertz v287 #[code = 250];
+                    v288 = hir.int_to_ptr v285 : ptr<byte, i32>;
+                    v289 = hir.load v288 : i32;
+                    v1008 = arith.constant 0 : i32;
+                    v293 = hir.bitcast v264 : u32;
+                    v283 = arith.constant 268435456 : i32;
+                    v290 = arith.sub v283, v289 : i32 #[overflow = wrapping];
+                    v292 = hir.bitcast v290 : u32;
+                    v294 = arith.lt v292, v293 : i1;
+                    v295 = arith.zext v294 : u32;
+                    v296 = hir.bitcast v295 : i32;
+                    v298 = arith.neq v296, v1008 : i1;
+                    v1001 = scf.if v298 : i32 {
                     ^block53:
-                        v945 = arith.constant 0 : i32;
-                        scf.yield v945;
+                        v1007 = arith.constant 0 : i32;
+                        scf.yield v1007;
                     } else {
                     ^block54:
-                        v273 = hir.bitcast v201 : u32;
-                        v944 = arith.constant 4 : u32;
-                        v275 = arith.mod v273, v944 : u32;
-                        hir.assertz v275 #[code = 250];
-                        v272 = arith.add v262, v237 : i32 #[overflow = wrapping];
-                        v276 = hir.int_to_ptr v273 : ptr<byte, i32>;
-                        hir.store v276, v272;
-                        v278 = arith.add v262, v222 : i32 #[overflow = wrapping];
-                        scf.yield v278;
+                        v300 = hir.bitcast v228 : u32;
+                        v1006 = arith.constant 4 : u32;
+                        v302 = arith.mod v300, v1006 : u32;
+                        hir.assertz v302 #[code = 250];
+                        v299 = arith.add v289, v264 : i32 #[overflow = wrapping];
+                        v303 = hir.int_to_ptr v300 : ptr<byte, i32>;
+                        hir.store v303, v299;
+                        v305 = arith.add v289, v249 : i32 #[overflow = wrapping];
+                        scf.yield v305;
                     };
-                    scf.yield v939;
+                    scf.yield v1001;
                 };
-                v922 = arith.constant 1 : u32;
-                v943 = arith.constant 0 : u32;
-                v941 = cf.select v230, v943, v922 : u32;
-                scf.yield v940, v941;
+                v984 = arith.constant 1 : u32;
+                v1005 = arith.constant 0 : u32;
+                v1003 = cf.select v257, v1005, v984 : u32;
+                scf.yield v1002, v1003;
             };
-            v942 = arith.constant 0 : u32;
-            v938 = arith.eq v926, v942 : i1;
-            cf.cond_br v938 ^block48, ^block124(v925);
+            v1004 = arith.constant 0 : u32;
+            v1000 = arith.eq v988, v1004 : i1;
+            cf.cond_br v1000 ^block48, ^block127(v987);
         ^block48:
             ub.unreachable ;
-        ^block124(v918: i32):
-            builtin.ret v918;
+        ^block127(v980: i32):
+            builtin.ret v980;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v281: i32, v282: i32, v283: i32, v284: i32) {
-        ^block55(v281: i32, v282: i32, v283: i32, v284: i32):
-            v286 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v287 = hir.bitcast v286 : ptr<byte, i32>;
-            v288 = hir.load v287 : i32;
-            v289 = arith.constant 16 : i32;
-            v290 = arith.sub v288, v289 : i32 #[overflow = wrapping];
-            v291 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v292 = hir.bitcast v291 : ptr<byte, i32>;
-            hir.store v292, v290;
-            v285 = arith.constant 0 : i32;
-            v295 = arith.constant 256 : i32;
-            v293 = arith.constant 4 : i32;
-            v294 = arith.add v290, v293 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v294, v295, v285, v282, v283)
-            v298 = arith.constant 8 : u32;
-            v297 = hir.bitcast v290 : u32;
-            v299 = arith.add v297, v298 : u32 #[overflow = checked];
-            v300 = arith.constant 4 : u32;
-            v301 = arith.mod v299, v300 : u32;
-            hir.assertz v301 #[code = 250];
-            v302 = hir.int_to_ptr v299 : ptr<byte, i32>;
-            v303 = hir.load v302 : i32;
-            v966 = arith.constant 4 : u32;
-            v304 = hir.bitcast v290 : u32;
-            v306 = arith.add v304, v966 : u32 #[overflow = checked];
-            v965 = arith.constant 4 : u32;
-            v308 = arith.mod v306, v965 : u32;
-            hir.assertz v308 #[code = 250];
-            v309 = hir.int_to_ptr v306 : ptr<byte, i32>;
-            v310 = hir.load v309 : i32;
-            v964 = arith.constant 0 : i32;
-            v311 = arith.constant 1 : i32;
-            v312 = arith.neq v310, v311 : i1;
-            v313 = arith.zext v312 : u32;
-            v314 = hir.bitcast v313 : i32;
-            v316 = arith.neq v314, v964 : i1;
-            cf.cond_br v316 ^block57, ^block58;
-        ^block57:
-            v325 = arith.constant 12 : u32;
-            v324 = hir.bitcast v290 : u32;
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v308: i32, v309: i32, v310: i32, v311: i32) {
+        ^block55(v308: i32, v309: i32, v310: i32, v311: i32):
+            v313 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v314 = hir.bitcast v313 : ptr<byte, i32>;
+            v315 = hir.load v314 : i32;
+            v316 = arith.constant 16 : i32;
+            v317 = arith.sub v315, v316 : i32 #[overflow = wrapping];
+            v318 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v319 = hir.bitcast v318 : ptr<byte, i32>;
+            hir.store v319, v317;
+            v312 = arith.constant 0 : i32;
+            v322 = arith.constant 256 : i32;
+            v320 = arith.constant 4 : i32;
+            v321 = arith.add v317, v320 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v321, v322, v312, v309, v310)
+            v325 = arith.constant 8 : u32;
+            v324 = hir.bitcast v317 : u32;
             v326 = arith.add v324, v325 : u32 #[overflow = checked];
-            v963 = arith.constant 4 : u32;
-            v328 = arith.mod v326, v963 : u32;
+            v327 = arith.constant 4 : u32;
+            v328 = arith.mod v326, v327 : u32;
             hir.assertz v328 #[code = 250];
             v329 = hir.int_to_ptr v326 : ptr<byte, i32>;
             v330 = hir.load v329 : i32;
-            v962 = arith.constant 4 : u32;
-            v331 = hir.bitcast v281 : u32;
-            v333 = arith.add v331, v962 : u32 #[overflow = checked];
-            v961 = arith.constant 4 : u32;
-            v335 = arith.mod v333, v961 : u32;
+            v1028 = arith.constant 4 : u32;
+            v331 = hir.bitcast v317 : u32;
+            v333 = arith.add v331, v1028 : u32 #[overflow = checked];
+            v1027 = arith.constant 4 : u32;
+            v335 = arith.mod v333, v1027 : u32;
             hir.assertz v335 #[code = 250];
             v336 = hir.int_to_ptr v333 : ptr<byte, i32>;
-            hir.store v336, v330;
-            v337 = hir.bitcast v281 : u32;
-            v960 = arith.constant 4 : u32;
-            v339 = arith.mod v337, v960 : u32;
-            hir.assertz v339 #[code = 250];
-            v340 = hir.int_to_ptr v337 : ptr<byte, i32>;
-            hir.store v340, v303;
-            v959 = arith.constant 16 : i32;
-            v342 = arith.add v290, v959 : i32 #[overflow = wrapping];
-            v343 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v344 = hir.bitcast v343 : ptr<byte, i32>;
-            hir.store v344, v342;
+            v337 = hir.load v336 : i32;
+            v1026 = arith.constant 0 : i32;
+            v338 = arith.constant 1 : i32;
+            v339 = arith.neq v337, v338 : i1;
+            v340 = arith.zext v339 : u32;
+            v341 = hir.bitcast v340 : i32;
+            v343 = arith.neq v341, v1026 : i1;
+            cf.cond_br v343 ^block57, ^block58;
+        ^block57:
+            v352 = arith.constant 12 : u32;
+            v351 = hir.bitcast v317 : u32;
+            v353 = arith.add v351, v352 : u32 #[overflow = checked];
+            v1025 = arith.constant 4 : u32;
+            v355 = arith.mod v353, v1025 : u32;
+            hir.assertz v355 #[code = 250];
+            v356 = hir.int_to_ptr v353 : ptr<byte, i32>;
+            v357 = hir.load v356 : i32;
+            v1024 = arith.constant 4 : u32;
+            v358 = hir.bitcast v308 : u32;
+            v360 = arith.add v358, v1024 : u32 #[overflow = checked];
+            v1023 = arith.constant 4 : u32;
+            v362 = arith.mod v360, v1023 : u32;
+            hir.assertz v362 #[code = 250];
+            v363 = hir.int_to_ptr v360 : ptr<byte, i32>;
+            hir.store v363, v357;
+            v364 = hir.bitcast v308 : u32;
+            v1022 = arith.constant 4 : u32;
+            v366 = arith.mod v364, v1022 : u32;
+            hir.assertz v366 #[code = 250];
+            v367 = hir.int_to_ptr v364 : ptr<byte, i32>;
+            hir.store v367, v330;
+            v1021 = arith.constant 16 : i32;
+            v369 = arith.add v317, v1021 : i32 #[overflow = wrapping];
+            v370 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v371 = hir.bitcast v370 : ptr<byte, i32>;
+            hir.store v371, v369;
             builtin.ret ;
         ^block58:
-            v958 = arith.constant 12 : u32;
-            v317 = hir.bitcast v290 : u32;
-            v319 = arith.add v317, v958 : u32 #[overflow = checked];
-            v957 = arith.constant 4 : u32;
-            v321 = arith.mod v319, v957 : u32;
-            hir.assertz v321 #[code = 250];
-            v322 = hir.int_to_ptr v319 : ptr<byte, i32>;
-            v323 = hir.load v322 : i32;
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::handle_error(v303, v323, v284)
+            v1020 = arith.constant 12 : u32;
+            v344 = hir.bitcast v317 : u32;
+            v346 = arith.add v344, v1020 : u32 #[overflow = checked];
+            v1019 = arith.constant 4 : u32;
+            v348 = arith.mod v346, v1019 : u32;
+            hir.assertz v348 #[code = 250];
+            v349 = hir.int_to_ptr v346 : ptr<byte, i32>;
+            v350 = hir.load v349 : i32;
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::handle_error(v330, v350, v311)
             ub.unreachable ;
         };
 
-        private builtin.function @miden_base_sys::bindings::account::get_id() -> felt {
-        ^block59:
-            v346 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::account::extern_account_get_id() : felt
-            builtin.ret v346;
-        };
-
-        private builtin.function @miden_base_sys::bindings::note::get_inputs(v347: i32) {
-        ^block61(v347: i32):
-            v349 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v350 = hir.bitcast v349 : ptr<byte, i32>;
-            v351 = hir.load v350 : i32;
-            v352 = arith.constant 16 : i32;
-            v353 = arith.sub v351, v352 : i32 #[overflow = wrapping];
-            v354 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v355 = hir.bitcast v354 : ptr<byte, i32>;
-            hir.store v355, v353;
-            v360 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v361 = hir.bitcast v360 : ptr<byte, i32>;
-            v362 = hir.load v361 : i32;
-            v363 = arith.constant 1048664 : i32;
-            v364 = arith.add v362, v363 : i32 #[overflow = wrapping];
-            v358 = arith.constant 4 : i32;
-            v356 = arith.constant 8 : i32;
-            v357 = arith.add v353, v356 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v357, v358, v358, v364)
-            v366 = arith.constant 8 : u32;
-            v365 = hir.bitcast v353 : u32;
-            v367 = arith.add v365, v366 : u32 #[overflow = checked];
-            v368 = arith.constant 4 : u32;
-            v369 = arith.mod v367, v368 : u32;
-            hir.assertz v369 #[code = 250];
-            v370 = hir.int_to_ptr v367 : ptr<byte, i32>;
-            v371 = hir.load v370 : i32;
-            v373 = arith.constant 12 : u32;
-            v372 = hir.bitcast v353 : u32;
-            v374 = arith.add v372, v373 : u32 #[overflow = checked];
-            v974 = arith.constant 4 : u32;
-            v376 = arith.mod v374, v974 : u32;
-            hir.assertz v376 #[code = 250];
-            v377 = hir.int_to_ptr v374 : ptr<byte, i32>;
-            v378 = hir.load v377 : i32;
-            v967 = arith.constant 2 : u32;
-            v380 = hir.bitcast v378 : u32;
-            v382 = arith.shr v380, v967 : u32;
-            v383 = hir.bitcast v382 : i32;
-            v384 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_inputs(v383) : i32
-            v973 = arith.constant 8 : u32;
-            v385 = hir.bitcast v347 : u32;
-            v387 = arith.add v385, v973 : u32 #[overflow = checked];
-            v972 = arith.constant 4 : u32;
-            v389 = arith.mod v387, v972 : u32;
-            hir.assertz v389 #[code = 250];
-            v390 = hir.int_to_ptr v387 : ptr<byte, i32>;
-            hir.store v390, v384;
-            v971 = arith.constant 4 : u32;
-            v391 = hir.bitcast v347 : u32;
-            v393 = arith.add v391, v971 : u32 #[overflow = checked];
-            v970 = arith.constant 4 : u32;
-            v395 = arith.mod v393, v970 : u32;
-            hir.assertz v395 #[code = 250];
-            v396 = hir.int_to_ptr v393 : ptr<byte, i32>;
-            hir.store v396, v378;
-            v397 = hir.bitcast v347 : u32;
-            v969 = arith.constant 4 : u32;
-            v399 = arith.mod v397, v969 : u32;
-            hir.assertz v399 #[code = 250];
-            v400 = hir.int_to_ptr v397 : ptr<byte, i32>;
-            hir.store v400, v371;
-            v968 = arith.constant 16 : i32;
-            v402 = arith.add v353, v968 : i32 #[overflow = wrapping];
-            v403 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v404 = hir.bitcast v403 : ptr<byte, i32>;
-            hir.store v404, v402;
+        private builtin.function @miden_base_sys::bindings::account::get_id(v372: i32) {
+        ^block59(v372: i32):
+            v374 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v375 = hir.bitcast v374 : ptr<byte, i32>;
+            v376 = hir.load v375 : i32;
+            v377 = arith.constant 16 : i32;
+            v378 = arith.sub v376, v377 : i32 #[overflow = wrapping];
+            v379 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v380 = hir.bitcast v379 : ptr<byte, i32>;
+            hir.store v380, v378;
+            v381 = arith.constant 8 : i32;
+            v382 = arith.add v378, v381 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::account::extern_account_get_id(v382)
+            v384 = arith.constant 8 : u32;
+            v383 = hir.bitcast v378 : u32;
+            v385 = arith.add v383, v384 : u32 #[overflow = checked];
+            v386 = arith.constant 4 : u32;
+            v387 = arith.mod v385, v386 : u32;
+            hir.assertz v387 #[code = 250];
+            v388 = hir.int_to_ptr v385 : ptr<byte, i64>;
+            v389 = hir.load v388 : i64;
+            v390 = hir.bitcast v372 : u32;
+            v1030 = arith.constant 8 : u32;
+            v392 = arith.mod v390, v1030 : u32;
+            hir.assertz v392 #[code = 250];
+            v393 = hir.int_to_ptr v390 : ptr<byte, i64>;
+            hir.store v393, v389;
+            v1029 = arith.constant 16 : i32;
+            v395 = arith.add v378, v1029 : i32 #[overflow = wrapping];
+            v396 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v397 = hir.bitcast v396 : ptr<byte, i32>;
+            hir.store v397, v395;
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::note::get_assets(v405: i32) {
-        ^block63(v405: i32):
-            v407 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v408 = hir.bitcast v407 : ptr<byte, i32>;
-            v409 = hir.load v408 : i32;
-            v410 = arith.constant 16 : i32;
-            v411 = arith.sub v409, v410 : i32 #[overflow = wrapping];
-            v412 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v413 = hir.bitcast v412 : ptr<byte, i32>;
-            hir.store v413, v411;
-            v418 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v419 = hir.bitcast v418 : ptr<byte, i32>;
-            v420 = hir.load v419 : i32;
-            v421 = arith.constant 1048680 : i32;
-            v422 = arith.add v420, v421 : i32 #[overflow = wrapping];
-            v983 = arith.constant 16 : i32;
-            v414 = arith.constant 8 : i32;
-            v415 = arith.add v411, v414 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v415, v983, v983, v422)
-            v424 = arith.constant 8 : u32;
-            v423 = hir.bitcast v411 : u32;
+        private builtin.function @miden_base_sys::bindings::note::get_inputs(v398: i32) {
+        ^block61(v398: i32):
+            v400 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v401 = hir.bitcast v400 : ptr<byte, i32>;
+            v402 = hir.load v401 : i32;
+            v403 = arith.constant 16 : i32;
+            v404 = arith.sub v402, v403 : i32 #[overflow = wrapping];
+            v405 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v406 = hir.bitcast v405 : ptr<byte, i32>;
+            hir.store v406, v404;
+            v411 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v412 = hir.bitcast v411 : ptr<byte, i32>;
+            v413 = hir.load v412 : i32;
+            v414 = arith.constant 1048664 : i32;
+            v415 = arith.add v413, v414 : i32 #[overflow = wrapping];
+            v409 = arith.constant 4 : i32;
+            v407 = arith.constant 8 : i32;
+            v408 = arith.add v404, v407 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v408, v409, v409, v415)
+            v417 = arith.constant 8 : u32;
+            v416 = hir.bitcast v404 : u32;
+            v418 = arith.add v416, v417 : u32 #[overflow = checked];
+            v419 = arith.constant 4 : u32;
+            v420 = arith.mod v418, v419 : u32;
+            hir.assertz v420 #[code = 250];
+            v421 = hir.int_to_ptr v418 : ptr<byte, i32>;
+            v422 = hir.load v421 : i32;
+            v424 = arith.constant 12 : u32;
+            v423 = hir.bitcast v404 : u32;
             v425 = arith.add v423, v424 : u32 #[overflow = checked];
-            v426 = arith.constant 4 : u32;
-            v427 = arith.mod v425, v426 : u32;
+            v1038 = arith.constant 4 : u32;
+            v427 = arith.mod v425, v1038 : u32;
             hir.assertz v427 #[code = 250];
             v428 = hir.int_to_ptr v425 : ptr<byte, i32>;
             v429 = hir.load v428 : i32;
-            v431 = arith.constant 12 : u32;
-            v430 = hir.bitcast v411 : u32;
-            v432 = arith.add v430, v431 : u32 #[overflow = checked];
-            v982 = arith.constant 4 : u32;
-            v434 = arith.mod v432, v982 : u32;
-            hir.assertz v434 #[code = 250];
-            v435 = hir.int_to_ptr v432 : ptr<byte, i32>;
-            v436 = hir.load v435 : i32;
-            v975 = arith.constant 2 : u32;
-            v438 = hir.bitcast v436 : u32;
-            v440 = arith.shr v438, v975 : u32;
-            v441 = hir.bitcast v440 : i32;
-            v442 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_assets(v441) : i32
-            v981 = arith.constant 8 : u32;
-            v443 = hir.bitcast v405 : u32;
-            v445 = arith.add v443, v981 : u32 #[overflow = checked];
-            v980 = arith.constant 4 : u32;
-            v447 = arith.mod v445, v980 : u32;
-            hir.assertz v447 #[code = 250];
-            v448 = hir.int_to_ptr v445 : ptr<byte, i32>;
-            hir.store v448, v442;
-            v979 = arith.constant 4 : u32;
-            v449 = hir.bitcast v405 : u32;
-            v451 = arith.add v449, v979 : u32 #[overflow = checked];
-            v978 = arith.constant 4 : u32;
-            v453 = arith.mod v451, v978 : u32;
-            hir.assertz v453 #[code = 250];
-            v454 = hir.int_to_ptr v451 : ptr<byte, i32>;
-            hir.store v454, v436;
-            v455 = hir.bitcast v405 : u32;
-            v977 = arith.constant 4 : u32;
-            v457 = arith.mod v455, v977 : u32;
-            hir.assertz v457 #[code = 250];
-            v458 = hir.int_to_ptr v455 : ptr<byte, i32>;
-            hir.store v458, v429;
-            v976 = arith.constant 16 : i32;
-            v460 = arith.add v411, v976 : i32 #[overflow = wrapping];
-            v461 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v462 = hir.bitcast v461 : ptr<byte, i32>;
-            hir.store v462, v460;
+            v1031 = arith.constant 2 : u32;
+            v431 = hir.bitcast v429 : u32;
+            v433 = arith.shr v431, v1031 : u32;
+            v434 = hir.bitcast v433 : i32;
+            v435 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_inputs(v434) : i32
+            v1037 = arith.constant 8 : u32;
+            v436 = hir.bitcast v398 : u32;
+            v438 = arith.add v436, v1037 : u32 #[overflow = checked];
+            v1036 = arith.constant 4 : u32;
+            v440 = arith.mod v438, v1036 : u32;
+            hir.assertz v440 #[code = 250];
+            v441 = hir.int_to_ptr v438 : ptr<byte, i32>;
+            hir.store v441, v435;
+            v1035 = arith.constant 4 : u32;
+            v442 = hir.bitcast v398 : u32;
+            v444 = arith.add v442, v1035 : u32 #[overflow = checked];
+            v1034 = arith.constant 4 : u32;
+            v446 = arith.mod v444, v1034 : u32;
+            hir.assertz v446 #[code = 250];
+            v447 = hir.int_to_ptr v444 : ptr<byte, i32>;
+            hir.store v447, v429;
+            v448 = hir.bitcast v398 : u32;
+            v1033 = arith.constant 4 : u32;
+            v450 = arith.mod v448, v1033 : u32;
+            hir.assertz v450 #[code = 250];
+            v451 = hir.int_to_ptr v448 : ptr<byte, i32>;
+            hir.store v451, v422;
+            v1032 = arith.constant 16 : i32;
+            v453 = arith.add v404, v1032 : i32 #[overflow = wrapping];
+            v454 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v455 = hir.bitcast v454 : ptr<byte, i32>;
+            hir.store v455, v453;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v463: i32, v464: i32, v465: i32) {
-        ^block65(v463: i32, v464: i32, v465: i32):
-            v467 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v468 = hir.bitcast v467 : ptr<byte, i32>;
-            v469 = hir.load v468 : i32;
-            v470 = arith.constant 16 : i32;
-            v471 = arith.sub v469, v470 : i32 #[overflow = wrapping];
-            v472 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v473 = hir.bitcast v472 : ptr<byte, i32>;
-            hir.store v473, v471;
-            v474 = arith.constant 4 : i32;
-            v475 = arith.add v471, v474 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::current_memory(v475, v463, v464, v465)
-            v477 = arith.constant 8 : u32;
-            v476 = hir.bitcast v471 : u32;
-            v478 = arith.add v476, v477 : u32 #[overflow = checked];
-            v479 = arith.constant 4 : u32;
-            v480 = arith.mod v478, v479 : u32;
-            hir.assertz v480 #[code = 250];
-            v481 = hir.int_to_ptr v478 : ptr<byte, i32>;
-            v482 = hir.load v481 : i32;
-            v990 = arith.constant 0 : i32;
-            v466 = arith.constant 0 : i32;
-            v484 = arith.eq v482, v466 : i1;
-            v485 = arith.zext v484 : u32;
-            v486 = hir.bitcast v485 : i32;
-            v488 = arith.neq v486, v990 : i1;
-            scf.if v488{
-            ^block130:
+        private builtin.function @miden_base_sys::bindings::note::get_assets(v456: i32) {
+        ^block63(v456: i32):
+            v458 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v459 = hir.bitcast v458 : ptr<byte, i32>;
+            v460 = hir.load v459 : i32;
+            v461 = arith.constant 16 : i32;
+            v462 = arith.sub v460, v461 : i32 #[overflow = wrapping];
+            v463 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v464 = hir.bitcast v463 : ptr<byte, i32>;
+            hir.store v464, v462;
+            v469 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v470 = hir.bitcast v469 : ptr<byte, i32>;
+            v471 = hir.load v470 : i32;
+            v472 = arith.constant 1048680 : i32;
+            v473 = arith.add v471, v472 : i32 #[overflow = wrapping];
+            v1047 = arith.constant 16 : i32;
+            v465 = arith.constant 8 : i32;
+            v466 = arith.add v462, v465 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v466, v1047, v1047, v473)
+            v475 = arith.constant 8 : u32;
+            v474 = hir.bitcast v462 : u32;
+            v476 = arith.add v474, v475 : u32 #[overflow = checked];
+            v477 = arith.constant 4 : u32;
+            v478 = arith.mod v476, v477 : u32;
+            hir.assertz v478 #[code = 250];
+            v479 = hir.int_to_ptr v476 : ptr<byte, i32>;
+            v480 = hir.load v479 : i32;
+            v482 = arith.constant 12 : u32;
+            v481 = hir.bitcast v462 : u32;
+            v483 = arith.add v481, v482 : u32 #[overflow = checked];
+            v1046 = arith.constant 4 : u32;
+            v485 = arith.mod v483, v1046 : u32;
+            hir.assertz v485 #[code = 250];
+            v486 = hir.int_to_ptr v483 : ptr<byte, i32>;
+            v487 = hir.load v486 : i32;
+            v1039 = arith.constant 2 : u32;
+            v489 = hir.bitcast v487 : u32;
+            v491 = arith.shr v489, v1039 : u32;
+            v492 = hir.bitcast v491 : i32;
+            v493 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_assets(v492) : i32
+            v1045 = arith.constant 8 : u32;
+            v494 = hir.bitcast v456 : u32;
+            v496 = arith.add v494, v1045 : u32 #[overflow = checked];
+            v1044 = arith.constant 4 : u32;
+            v498 = arith.mod v496, v1044 : u32;
+            hir.assertz v498 #[code = 250];
+            v499 = hir.int_to_ptr v496 : ptr<byte, i32>;
+            hir.store v499, v493;
+            v1043 = arith.constant 4 : u32;
+            v500 = hir.bitcast v456 : u32;
+            v502 = arith.add v500, v1043 : u32 #[overflow = checked];
+            v1042 = arith.constant 4 : u32;
+            v504 = arith.mod v502, v1042 : u32;
+            hir.assertz v504 #[code = 250];
+            v505 = hir.int_to_ptr v502 : ptr<byte, i32>;
+            hir.store v505, v487;
+            v506 = hir.bitcast v456 : u32;
+            v1041 = arith.constant 4 : u32;
+            v508 = arith.mod v506, v1041 : u32;
+            hir.assertz v508 #[code = 250];
+            v509 = hir.int_to_ptr v506 : ptr<byte, i32>;
+            hir.store v509, v480;
+            v1040 = arith.constant 16 : i32;
+            v511 = arith.add v462, v1040 : i32 #[overflow = wrapping];
+            v512 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v513 = hir.bitcast v512 : ptr<byte, i32>;
+            hir.store v513, v511;
+            builtin.ret ;
+        };
+
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v514: i32, v515: i32, v516: i32) {
+        ^block65(v514: i32, v515: i32, v516: i32):
+            v518 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v519 = hir.bitcast v518 : ptr<byte, i32>;
+            v520 = hir.load v519 : i32;
+            v521 = arith.constant 16 : i32;
+            v522 = arith.sub v520, v521 : i32 #[overflow = wrapping];
+            v523 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v524 = hir.bitcast v523 : ptr<byte, i32>;
+            hir.store v524, v522;
+            v525 = arith.constant 4 : i32;
+            v526 = arith.add v522, v525 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::current_memory(v526, v514, v515, v516)
+            v528 = arith.constant 8 : u32;
+            v527 = hir.bitcast v522 : u32;
+            v529 = arith.add v527, v528 : u32 #[overflow = checked];
+            v530 = arith.constant 4 : u32;
+            v531 = arith.mod v529, v530 : u32;
+            hir.assertz v531 #[code = 250];
+            v532 = hir.int_to_ptr v529 : ptr<byte, i32>;
+            v533 = hir.load v532 : i32;
+            v1054 = arith.constant 0 : i32;
+            v517 = arith.constant 0 : i32;
+            v535 = arith.eq v533, v517 : i1;
+            v536 = arith.zext v535 : u32;
+            v537 = hir.bitcast v536 : i32;
+            v539 = arith.neq v537, v1054 : i1;
+            scf.if v539{
+            ^block133:
                 scf.yield ;
             } else {
             ^block68:
-                v989 = arith.constant 4 : u32;
-                v489 = hir.bitcast v471 : u32;
-                v491 = arith.add v489, v989 : u32 #[overflow = checked];
-                v988 = arith.constant 4 : u32;
-                v493 = arith.mod v491, v988 : u32;
-                hir.assertz v493 #[code = 250];
-                v494 = hir.int_to_ptr v491 : ptr<byte, i32>;
-                v495 = hir.load v494 : i32;
-                v497 = arith.constant 12 : u32;
-                v496 = hir.bitcast v471 : u32;
-                v498 = arith.add v496, v497 : u32 #[overflow = checked];
-                v987 = arith.constant 4 : u32;
-                v500 = arith.mod v498, v987 : u32;
-                hir.assertz v500 #[code = 250];
-                v501 = hir.int_to_ptr v498 : ptr<byte, i32>;
-                v502 = hir.load v501 : i32;
-                hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v495, v482, v502)
+                v1053 = arith.constant 4 : u32;
+                v540 = hir.bitcast v522 : u32;
+                v542 = arith.add v540, v1053 : u32 #[overflow = checked];
+                v1052 = arith.constant 4 : u32;
+                v544 = arith.mod v542, v1052 : u32;
+                hir.assertz v544 #[code = 250];
+                v545 = hir.int_to_ptr v542 : ptr<byte, i32>;
+                v546 = hir.load v545 : i32;
+                v548 = arith.constant 12 : u32;
+                v547 = hir.bitcast v522 : u32;
+                v549 = arith.add v547, v548 : u32 #[overflow = checked];
+                v1051 = arith.constant 4 : u32;
+                v551 = arith.mod v549, v1051 : u32;
+                hir.assertz v551 #[code = 250];
+                v552 = hir.int_to_ptr v549 : ptr<byte, i32>;
+                v553 = hir.load v552 : i32;
+                hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v546, v533, v553)
                 scf.yield ;
             };
-            v986 = arith.constant 16 : i32;
-            v505 = arith.add v471, v986 : i32 #[overflow = wrapping];
-            v506 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v507 = hir.bitcast v506 : ptr<byte, i32>;
-            hir.store v507, v505;
+            v1050 = arith.constant 16 : i32;
+            v556 = arith.add v522, v1050 : i32 #[overflow = wrapping];
+            v557 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v558 = hir.bitcast v557 : ptr<byte, i32>;
+            hir.store v558, v556;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v508: i32, v509: i32, v510: i32, v511: i32, v512: i32) {
-        ^block69(v508: i32, v509: i32, v510: i32, v511: i32, v512: i32):
-            v515 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v516 = hir.bitcast v515 : ptr<byte, i32>;
-            v517 = hir.load v516 : i32;
-            v518 = arith.constant 16 : i32;
-            v519 = arith.sub v517, v518 : i32 #[overflow = wrapping];
-            v520 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v521 = hir.bitcast v520 : ptr<byte, i32>;
-            hir.store v521, v519;
-            v531 = hir.bitcast v509 : u32;
-            v532 = arith.zext v531 : u64;
-            v533 = hir.bitcast v532 : i64;
-            v513 = arith.constant 0 : i32;
-            v526 = arith.sub v513, v511 : i32 #[overflow = wrapping];
-            v523 = arith.constant -1 : i32;
-            v522 = arith.add v511, v512 : i32 #[overflow = wrapping];
-            v524 = arith.add v522, v523 : i32 #[overflow = wrapping];
-            v527 = arith.band v524, v526 : i32;
-            v528 = hir.bitcast v527 : u32;
-            v529 = arith.zext v528 : u64;
-            v530 = hir.bitcast v529 : i64;
-            v534 = arith.mul v530, v533 : i64 #[overflow = wrapping];
-            v1094 = arith.constant 0 : i32;
-            v535 = arith.constant 32 : i64;
-            v537 = hir.cast v535 : u32;
-            v536 = hir.bitcast v534 : u64;
-            v538 = arith.shr v536, v537 : u64;
-            v539 = hir.bitcast v538 : i64;
-            v540 = arith.trunc v539 : i32;
-            v542 = arith.neq v540, v1094 : i1;
-            v1006, v1007, v1008, v1009, v1010, v1011 = scf.if v542 : i32, i32, i32, i32, i32, u32 {
-            ^block132:
-                v991 = arith.constant 0 : u32;
-                v998 = ub.poison i32 : i32;
-                scf.yield v508, v519, v998, v998, v998, v991;
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v559: i32, v560: i32, v561: i32, v562: i32, v563: i32) {
+        ^block69(v559: i32, v560: i32, v561: i32, v562: i32, v563: i32):
+            v566 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v567 = hir.bitcast v566 : ptr<byte, i32>;
+            v568 = hir.load v567 : i32;
+            v569 = arith.constant 16 : i32;
+            v570 = arith.sub v568, v569 : i32 #[overflow = wrapping];
+            v571 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v572 = hir.bitcast v571 : ptr<byte, i32>;
+            hir.store v572, v570;
+            v582 = hir.bitcast v560 : u32;
+            v583 = arith.zext v582 : u64;
+            v584 = hir.bitcast v583 : i64;
+            v564 = arith.constant 0 : i32;
+            v577 = arith.sub v564, v562 : i32 #[overflow = wrapping];
+            v574 = arith.constant -1 : i32;
+            v573 = arith.add v562, v563 : i32 #[overflow = wrapping];
+            v575 = arith.add v573, v574 : i32 #[overflow = wrapping];
+            v578 = arith.band v575, v577 : i32;
+            v579 = hir.bitcast v578 : u32;
+            v580 = arith.zext v579 : u64;
+            v581 = hir.bitcast v580 : i64;
+            v585 = arith.mul v581, v584 : i64 #[overflow = wrapping];
+            v1158 = arith.constant 0 : i32;
+            v586 = arith.constant 32 : i64;
+            v588 = hir.cast v586 : u32;
+            v587 = hir.bitcast v585 : u64;
+            v589 = arith.shr v587, v588 : u64;
+            v590 = hir.bitcast v589 : i64;
+            v591 = arith.trunc v590 : i32;
+            v593 = arith.neq v591, v1158 : i1;
+            v1070, v1071, v1072, v1073, v1074, v1075 = scf.if v593 : i32, i32, i32, i32, i32, u32 {
+            ^block135:
+                v1055 = arith.constant 0 : u32;
+                v1062 = ub.poison i32 : i32;
+                scf.yield v559, v570, v1062, v1062, v1062, v1055;
             } else {
             ^block74:
-                v543 = arith.trunc v534 : i32;
-                v1093 = arith.constant 0 : i32;
-                v544 = arith.constant -2147483648 : i32;
-                v545 = arith.sub v544, v511 : i32 #[overflow = wrapping];
-                v547 = hir.bitcast v545 : u32;
-                v546 = hir.bitcast v543 : u32;
-                v548 = arith.lte v546, v547 : i1;
-                v549 = arith.zext v548 : u32;
-                v550 = hir.bitcast v549 : i32;
-                v552 = arith.neq v550, v1093 : i1;
-                v1054 = scf.if v552 : i32 {
+                v594 = arith.trunc v585 : i32;
+                v1157 = arith.constant 0 : i32;
+                v595 = arith.constant -2147483648 : i32;
+                v596 = arith.sub v595, v562 : i32 #[overflow = wrapping];
+                v598 = hir.bitcast v596 : u32;
+                v597 = hir.bitcast v594 : u32;
+                v599 = arith.lte v597, v598 : i1;
+                v600 = arith.zext v599 : u32;
+                v601 = hir.bitcast v600 : i32;
+                v603 = arith.neq v601, v1157 : i1;
+                v1118 = scf.if v603 : i32 {
                 ^block72:
-                    v1092 = arith.constant 0 : i32;
-                    v563 = arith.neq v543, v1092 : i1;
-                    v1053 = scf.if v563 : i32 {
+                    v1156 = arith.constant 0 : i32;
+                    v614 = arith.neq v594, v1156 : i1;
+                    v1117 = scf.if v614 : i32 {
                     ^block76:
-                        v1091 = arith.constant 0 : i32;
-                        v579 = arith.neq v510, v1091 : i1;
-                        v1052 = scf.if v579 : i32 {
+                        v1155 = arith.constant 0 : i32;
+                        v630 = arith.neq v561, v1155 : i1;
+                        v1116 = scf.if v630 : i32 {
                         ^block79:
-                            v561 = arith.constant 1 : i32;
-                            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v519, v511, v543, v561)
-                            v590 = hir.bitcast v519 : u32;
-                            v635 = arith.constant 4 : u32;
-                            v592 = arith.mod v590, v635 : u32;
-                            hir.assertz v592 #[code = 250];
-                            v593 = hir.int_to_ptr v590 : ptr<byte, i32>;
-                            v594 = hir.load v593 : i32;
-                            scf.yield v594;
+                            v612 = arith.constant 1 : i32;
+                            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v570, v562, v594, v612)
+                            v641 = hir.bitcast v570 : u32;
+                            v686 = arith.constant 4 : u32;
+                            v643 = arith.mod v641, v686 : u32;
+                            hir.assertz v643 #[code = 250];
+                            v644 = hir.int_to_ptr v641 : ptr<byte, i32>;
+                            v645 = hir.load v644 : i32;
+                            scf.yield v645;
                         } else {
                         ^block80:
-                            v580 = arith.constant 8 : i32;
-                            v581 = arith.add v519, v580 : i32 #[overflow = wrapping];
-                            hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v581, v511, v543)
-                            v565 = arith.constant 8 : u32;
-                            v582 = hir.bitcast v519 : u32;
-                            v584 = arith.add v582, v565 : u32 #[overflow = checked];
-                            v1090 = arith.constant 4 : u32;
-                            v586 = arith.mod v584, v1090 : u32;
-                            hir.assertz v586 #[code = 250];
-                            v587 = hir.int_to_ptr v584 : ptr<byte, i32>;
-                            v588 = hir.load v587 : i32;
-                            scf.yield v588;
+                            v631 = arith.constant 8 : i32;
+                            v632 = arith.add v570, v631 : i32 #[overflow = wrapping];
+                            hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v632, v562, v594)
+                            v616 = arith.constant 8 : u32;
+                            v633 = hir.bitcast v570 : u32;
+                            v635 = arith.add v633, v616 : u32 #[overflow = checked];
+                            v1154 = arith.constant 4 : u32;
+                            v637 = arith.mod v635, v1154 : u32;
+                            hir.assertz v637 #[code = 250];
+                            v638 = hir.int_to_ptr v635 : ptr<byte, i32>;
+                            v639 = hir.load v638 : i32;
+                            scf.yield v639;
                         };
-                        v1088 = arith.constant 0 : i32;
-                        v1089 = arith.constant 0 : i32;
-                        v597 = arith.eq v1052, v1089 : i1;
-                        v598 = arith.zext v597 : u32;
-                        v599 = hir.bitcast v598 : i32;
-                        v601 = arith.neq v599, v1088 : i1;
-                        scf.if v601{
+                        v1152 = arith.constant 0 : i32;
+                        v1153 = arith.constant 0 : i32;
+                        v648 = arith.eq v1116, v1153 : i1;
+                        v649 = arith.zext v648 : u32;
+                        v650 = hir.bitcast v649 : i32;
+                        v652 = arith.neq v650, v1152 : i1;
+                        scf.if v652{
                         ^block81:
-                            v1087 = arith.constant 8 : u32;
-                            v618 = hir.bitcast v508 : u32;
-                            v620 = arith.add v618, v1087 : u32 #[overflow = checked];
-                            v1086 = arith.constant 4 : u32;
-                            v622 = arith.mod v620, v1086 : u32;
-                            hir.assertz v622 #[code = 250];
-                            v623 = hir.int_to_ptr v620 : ptr<byte, i32>;
-                            hir.store v623, v543;
-                            v1085 = arith.constant 4 : u32;
-                            v625 = hir.bitcast v508 : u32;
-                            v627 = arith.add v625, v1085 : u32 #[overflow = checked];
-                            v1084 = arith.constant 4 : u32;
-                            v629 = arith.mod v627, v1084 : u32;
-                            hir.assertz v629 #[code = 250];
-                            v630 = hir.int_to_ptr v627 : ptr<byte, i32>;
-                            hir.store v630, v511;
+                            v1151 = arith.constant 8 : u32;
+                            v669 = hir.bitcast v559 : u32;
+                            v671 = arith.add v669, v1151 : u32 #[overflow = checked];
+                            v1150 = arith.constant 4 : u32;
+                            v673 = arith.mod v671, v1150 : u32;
+                            hir.assertz v673 #[code = 250];
+                            v674 = hir.int_to_ptr v671 : ptr<byte, i32>;
+                            hir.store v674, v594;
+                            v1149 = arith.constant 4 : u32;
+                            v676 = hir.bitcast v559 : u32;
+                            v678 = arith.add v676, v1149 : u32 #[overflow = checked];
+                            v1148 = arith.constant 4 : u32;
+                            v680 = arith.mod v678, v1148 : u32;
+                            hir.assertz v680 #[code = 250];
+                            v681 = hir.int_to_ptr v678 : ptr<byte, i32>;
+                            hir.store v681, v562;
                             scf.yield ;
                         } else {
                         ^block82:
-                            v1083 = arith.constant 8 : u32;
-                            v603 = hir.bitcast v508 : u32;
-                            v605 = arith.add v603, v1083 : u32 #[overflow = checked];
-                            v1082 = arith.constant 4 : u32;
-                            v607 = arith.mod v605, v1082 : u32;
-                            hir.assertz v607 #[code = 250];
-                            v608 = hir.int_to_ptr v605 : ptr<byte, i32>;
-                            hir.store v608, v1052;
-                            v1081 = arith.constant 4 : u32;
-                            v610 = hir.bitcast v508 : u32;
-                            v612 = arith.add v610, v1081 : u32 #[overflow = checked];
-                            v1080 = arith.constant 4 : u32;
-                            v614 = arith.mod v612, v1080 : u32;
-                            hir.assertz v614 #[code = 250];
-                            v615 = hir.int_to_ptr v612 : ptr<byte, i32>;
-                            hir.store v615, v509;
+                            v1147 = arith.constant 8 : u32;
+                            v654 = hir.bitcast v559 : u32;
+                            v656 = arith.add v654, v1147 : u32 #[overflow = checked];
+                            v1146 = arith.constant 4 : u32;
+                            v658 = arith.mod v656, v1146 : u32;
+                            hir.assertz v658 #[code = 250];
+                            v659 = hir.int_to_ptr v656 : ptr<byte, i32>;
+                            hir.store v659, v1116;
+                            v1145 = arith.constant 4 : u32;
+                            v661 = hir.bitcast v559 : u32;
+                            v663 = arith.add v661, v1145 : u32 #[overflow = checked];
+                            v1144 = arith.constant 4 : u32;
+                            v665 = arith.mod v663, v1144 : u32;
+                            hir.assertz v665 #[code = 250];
+                            v666 = hir.int_to_ptr v663 : ptr<byte, i32>;
+                            hir.store v666, v560;
                             scf.yield ;
                         };
-                        v1078 = arith.constant 0 : i32;
-                        v1079 = arith.constant 1 : i32;
-                        v1051 = cf.select v601, v1079, v1078 : i32;
-                        scf.yield v1051;
+                        v1142 = arith.constant 0 : i32;
+                        v1143 = arith.constant 1 : i32;
+                        v1115 = cf.select v652, v1143, v1142 : i32;
+                        scf.yield v1115;
                     } else {
                     ^block77:
-                        v1077 = arith.constant 8 : u32;
-                        v564 = hir.bitcast v508 : u32;
-                        v566 = arith.add v564, v1077 : u32 #[overflow = checked];
-                        v1076 = arith.constant 4 : u32;
-                        v568 = arith.mod v566, v1076 : u32;
-                        hir.assertz v568 #[code = 250];
-                        v569 = hir.int_to_ptr v566 : ptr<byte, i32>;
-                        hir.store v569, v511;
-                        v1075 = arith.constant 4 : u32;
-                        v572 = hir.bitcast v508 : u32;
-                        v574 = arith.add v572, v1075 : u32 #[overflow = checked];
-                        v1074 = arith.constant 4 : u32;
-                        v576 = arith.mod v574, v1074 : u32;
-                        hir.assertz v576 #[code = 250];
-                        v1073 = arith.constant 0 : i32;
-                        v577 = hir.int_to_ptr v574 : ptr<byte, i32>;
-                        hir.store v577, v1073;
-                        v1072 = arith.constant 0 : i32;
-                        scf.yield v1072;
+                        v1141 = arith.constant 8 : u32;
+                        v615 = hir.bitcast v559 : u32;
+                        v617 = arith.add v615, v1141 : u32 #[overflow = checked];
+                        v1140 = arith.constant 4 : u32;
+                        v619 = arith.mod v617, v1140 : u32;
+                        hir.assertz v619 #[code = 250];
+                        v620 = hir.int_to_ptr v617 : ptr<byte, i32>;
+                        hir.store v620, v562;
+                        v1139 = arith.constant 4 : u32;
+                        v623 = hir.bitcast v559 : u32;
+                        v625 = arith.add v623, v1139 : u32 #[overflow = checked];
+                        v1138 = arith.constant 4 : u32;
+                        v627 = arith.mod v625, v1138 : u32;
+                        hir.assertz v627 #[code = 250];
+                        v1137 = arith.constant 0 : i32;
+                        v628 = hir.int_to_ptr v625 : ptr<byte, i32>;
+                        hir.store v628, v1137;
+                        v1136 = arith.constant 0 : i32;
+                        scf.yield v1136;
                     };
-                    scf.yield v1053;
+                    scf.yield v1117;
                 } else {
                 ^block75:
-                    v1071 = ub.poison i32 : i32;
-                    scf.yield v1071;
+                    v1135 = ub.poison i32 : i32;
+                    scf.yield v1135;
                 };
-                v1066 = arith.constant 0 : u32;
-                v999 = arith.constant 1 : u32;
-                v1059 = cf.select v552, v999, v1066 : u32;
-                v1067 = ub.poison i32 : i32;
-                v1058 = cf.select v552, v519, v1067 : i32;
-                v1068 = ub.poison i32 : i32;
-                v1057 = cf.select v552, v508, v1068 : i32;
-                v1069 = ub.poison i32 : i32;
-                v1056 = cf.select v552, v1069, v519 : i32;
-                v1070 = ub.poison i32 : i32;
-                v1055 = cf.select v552, v1070, v508 : i32;
-                scf.yield v1055, v1056, v1057, v1054, v1058, v1059;
+                v1130 = arith.constant 0 : u32;
+                v1063 = arith.constant 1 : u32;
+                v1123 = cf.select v603, v1063, v1130 : u32;
+                v1131 = ub.poison i32 : i32;
+                v1122 = cf.select v603, v570, v1131 : i32;
+                v1132 = ub.poison i32 : i32;
+                v1121 = cf.select v603, v559, v1132 : i32;
+                v1133 = ub.poison i32 : i32;
+                v1120 = cf.select v603, v1133, v570 : i32;
+                v1134 = ub.poison i32 : i32;
+                v1119 = cf.select v603, v1134, v559 : i32;
+                scf.yield v1119, v1120, v1121, v1118, v1122, v1123;
             };
-            v1012, v1013, v1014 = scf.index_switch v1011 : i32, i32, i32 
+            v1076, v1077, v1078 = scf.index_switch v1075 : i32, i32, i32 
             case 0 {
             ^block73:
-                v1065 = arith.constant 4 : u32;
-                v555 = hir.bitcast v1006 : u32;
-                v557 = arith.add v555, v1065 : u32 #[overflow = checked];
-                v1064 = arith.constant 4 : u32;
-                v559 = arith.mod v557, v1064 : u32;
-                hir.assertz v559 #[code = 250];
-                v1063 = arith.constant 0 : i32;
-                v560 = hir.int_to_ptr v557 : ptr<byte, i32>;
-                hir.store v560, v1063;
-                v1062 = arith.constant 1 : i32;
-                scf.yield v1006, v1062, v1007;
+                v1129 = arith.constant 4 : u32;
+                v606 = hir.bitcast v1070 : u32;
+                v608 = arith.add v606, v1129 : u32 #[overflow = checked];
+                v1128 = arith.constant 4 : u32;
+                v610 = arith.mod v608, v1128 : u32;
+                hir.assertz v610 #[code = 250];
+                v1127 = arith.constant 0 : i32;
+                v611 = hir.int_to_ptr v608 : ptr<byte, i32>;
+                hir.store v611, v1127;
+                v1126 = arith.constant 1 : i32;
+                scf.yield v1070, v1126, v1071;
             }
             default {
-            ^block136:
-                scf.yield v1008, v1009, v1010;
-            };
-            v634 = hir.bitcast v1012 : u32;
-            v1061 = arith.constant 4 : u32;
-            v636 = arith.mod v634, v1061 : u32;
-            hir.assertz v636 #[code = 250];
-            v637 = hir.int_to_ptr v634 : ptr<byte, i32>;
-            hir.store v637, v1013;
-            v1060 = arith.constant 16 : i32;
-            v642 = arith.add v1014, v1060 : i32 #[overflow = wrapping];
-            v643 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v644 = hir.bitcast v643 : ptr<byte, i32>;
-            hir.store v644, v642;
-            builtin.ret ;
-        };
-
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v645: i32, v646: i32, v647: i32) {
-        ^block83(v645: i32, v646: i32, v647: i32):
-            v649 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v650 = hir.bitcast v649 : ptr<byte, i32>;
-            v651 = hir.load v650 : i32;
-            v652 = arith.constant 16 : i32;
-            v653 = arith.sub v651, v652 : i32 #[overflow = wrapping];
-            v654 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v655 = hir.bitcast v654 : ptr<byte, i32>;
-            hir.store v655, v653;
-            v648 = arith.constant 0 : i32;
-            v656 = arith.constant 8 : i32;
-            v657 = arith.add v653, v656 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v657, v646, v647, v648)
-            v660 = arith.constant 12 : u32;
-            v659 = hir.bitcast v653 : u32;
-            v661 = arith.add v659, v660 : u32 #[overflow = checked];
-            v662 = arith.constant 4 : u32;
-            v663 = arith.mod v661, v662 : u32;
-            hir.assertz v663 #[code = 250];
-            v664 = hir.int_to_ptr v661 : ptr<byte, i32>;
-            v665 = hir.load v664 : i32;
-            v667 = arith.constant 8 : u32;
-            v666 = hir.bitcast v653 : u32;
-            v668 = arith.add v666, v667 : u32 #[overflow = checked];
-            v1099 = arith.constant 4 : u32;
-            v670 = arith.mod v668, v1099 : u32;
-            hir.assertz v670 #[code = 250];
-            v671 = hir.int_to_ptr v668 : ptr<byte, i32>;
-            v672 = hir.load v671 : i32;
-            v673 = hir.bitcast v645 : u32;
-            v1098 = arith.constant 4 : u32;
-            v675 = arith.mod v673, v1098 : u32;
-            hir.assertz v675 #[code = 250];
-            v676 = hir.int_to_ptr v673 : ptr<byte, i32>;
-            hir.store v676, v672;
-            v1097 = arith.constant 4 : u32;
-            v677 = hir.bitcast v645 : u32;
-            v679 = arith.add v677, v1097 : u32 #[overflow = checked];
-            v1096 = arith.constant 4 : u32;
-            v681 = arith.mod v679, v1096 : u32;
-            hir.assertz v681 #[code = 250];
-            v682 = hir.int_to_ptr v679 : ptr<byte, i32>;
-            hir.store v682, v665;
-            v1095 = arith.constant 16 : i32;
-            v684 = arith.add v653, v1095 : i32 #[overflow = wrapping];
-            v685 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v686 = hir.bitcast v685 : ptr<byte, i32>;
-            hir.store v686, v684;
-            builtin.ret ;
-        };
-
-        private builtin.function @alloc::alloc::Global::alloc_impl(v687: i32, v688: i32, v689: i32, v690: i32) {
-        ^block85(v687: i32, v688: i32, v689: i32, v690: i32):
-            v1115 = arith.constant 0 : i32;
-            v691 = arith.constant 0 : i32;
-            v692 = arith.eq v689, v691 : i1;
-            v693 = arith.zext v692 : u32;
-            v694 = hir.bitcast v693 : i32;
-            v696 = arith.neq v694, v1115 : i1;
-            v1111 = scf.if v696 : i32 {
             ^block139:
-                scf.yield v688;
+                scf.yield v1072, v1073, v1074;
+            };
+            v685 = hir.bitcast v1076 : u32;
+            v1125 = arith.constant 4 : u32;
+            v687 = arith.mod v685, v1125 : u32;
+            hir.assertz v687 #[code = 250];
+            v688 = hir.int_to_ptr v685 : ptr<byte, i32>;
+            hir.store v688, v1077;
+            v1124 = arith.constant 16 : i32;
+            v693 = arith.add v1078, v1124 : i32 #[overflow = wrapping];
+            v694 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v695 = hir.bitcast v694 : ptr<byte, i32>;
+            hir.store v695, v693;
+            builtin.ret ;
+        };
+
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v696: i32, v697: i32, v698: i32) {
+        ^block83(v696: i32, v697: i32, v698: i32):
+            v700 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v701 = hir.bitcast v700 : ptr<byte, i32>;
+            v702 = hir.load v701 : i32;
+            v703 = arith.constant 16 : i32;
+            v704 = arith.sub v702, v703 : i32 #[overflow = wrapping];
+            v705 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v706 = hir.bitcast v705 : ptr<byte, i32>;
+            hir.store v706, v704;
+            v699 = arith.constant 0 : i32;
+            v707 = arith.constant 8 : i32;
+            v708 = arith.add v704, v707 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v708, v697, v698, v699)
+            v711 = arith.constant 12 : u32;
+            v710 = hir.bitcast v704 : u32;
+            v712 = arith.add v710, v711 : u32 #[overflow = checked];
+            v713 = arith.constant 4 : u32;
+            v714 = arith.mod v712, v713 : u32;
+            hir.assertz v714 #[code = 250];
+            v715 = hir.int_to_ptr v712 : ptr<byte, i32>;
+            v716 = hir.load v715 : i32;
+            v718 = arith.constant 8 : u32;
+            v717 = hir.bitcast v704 : u32;
+            v719 = arith.add v717, v718 : u32 #[overflow = checked];
+            v1163 = arith.constant 4 : u32;
+            v721 = arith.mod v719, v1163 : u32;
+            hir.assertz v721 #[code = 250];
+            v722 = hir.int_to_ptr v719 : ptr<byte, i32>;
+            v723 = hir.load v722 : i32;
+            v724 = hir.bitcast v696 : u32;
+            v1162 = arith.constant 4 : u32;
+            v726 = arith.mod v724, v1162 : u32;
+            hir.assertz v726 #[code = 250];
+            v727 = hir.int_to_ptr v724 : ptr<byte, i32>;
+            hir.store v727, v723;
+            v1161 = arith.constant 4 : u32;
+            v728 = hir.bitcast v696 : u32;
+            v730 = arith.add v728, v1161 : u32 #[overflow = checked];
+            v1160 = arith.constant 4 : u32;
+            v732 = arith.mod v730, v1160 : u32;
+            hir.assertz v732 #[code = 250];
+            v733 = hir.int_to_ptr v730 : ptr<byte, i32>;
+            hir.store v733, v716;
+            v1159 = arith.constant 16 : i32;
+            v735 = arith.add v704, v1159 : i32 #[overflow = wrapping];
+            v736 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v737 = hir.bitcast v736 : ptr<byte, i32>;
+            hir.store v737, v735;
+            builtin.ret ;
+        };
+
+        private builtin.function @alloc::alloc::Global::alloc_impl(v738: i32, v739: i32, v740: i32, v741: i32) {
+        ^block85(v738: i32, v739: i32, v740: i32, v741: i32):
+            v1179 = arith.constant 0 : i32;
+            v742 = arith.constant 0 : i32;
+            v743 = arith.eq v740, v742 : i1;
+            v744 = arith.zext v743 : u32;
+            v745 = hir.bitcast v744 : i32;
+            v747 = arith.neq v745, v1179 : i1;
+            v1175 = scf.if v747 : i32 {
+            ^block142:
+                scf.yield v739;
             } else {
             ^block88:
                 hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v1114 = arith.constant 0 : i32;
-                v698 = arith.neq v690, v1114 : i1;
-                v1110 = scf.if v698 : i32 {
+                v1178 = arith.constant 0 : i32;
+                v749 = arith.neq v741, v1178 : i1;
+                v1174 = scf.if v749 : i32 {
                 ^block89:
-                    v700 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v689, v688) : i32
-                    scf.yield v700;
+                    v751 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v740, v739) : i32
+                    scf.yield v751;
                 } else {
                 ^block90:
-                    v699 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v689, v688) : i32
-                    scf.yield v699;
+                    v750 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v740, v739) : i32
+                    scf.yield v750;
                 };
-                scf.yield v1110;
+                scf.yield v1174;
             };
-            v704 = arith.constant 4 : u32;
-            v703 = hir.bitcast v687 : u32;
-            v705 = arith.add v703, v704 : u32 #[overflow = checked];
-            v1113 = arith.constant 4 : u32;
-            v707 = arith.mod v705, v1113 : u32;
-            hir.assertz v707 #[code = 250];
-            v708 = hir.int_to_ptr v705 : ptr<byte, i32>;
-            hir.store v708, v689;
-            v710 = hir.bitcast v687 : u32;
-            v1112 = arith.constant 4 : u32;
-            v712 = arith.mod v710, v1112 : u32;
-            hir.assertz v712 #[code = 250];
-            v713 = hir.int_to_ptr v710 : ptr<byte, i32>;
-            hir.store v713, v1111;
-            builtin.ret ;
-        };
-
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v714: i32, v715: i32, v716: i32, v717: i32) {
-        ^block91(v714: i32, v715: i32, v716: i32, v717: i32):
-            v1141 = arith.constant 0 : i32;
-            v718 = arith.constant 0 : i32;
-            v722 = arith.eq v717, v718 : i1;
-            v723 = arith.zext v722 : u32;
-            v724 = hir.bitcast v723 : i32;
-            v726 = arith.neq v724, v1141 : i1;
-            v1128, v1129 = scf.if v726 : i32, i32 {
-            ^block143:
-                v1140 = arith.constant 0 : i32;
-                v720 = arith.constant 4 : i32;
-                scf.yield v720, v1140;
-            } else {
-            ^block94:
-                v727 = hir.bitcast v715 : u32;
-                v762 = arith.constant 4 : u32;
-                v729 = arith.mod v727, v762 : u32;
-                hir.assertz v729 #[code = 250];
-                v730 = hir.int_to_ptr v727 : ptr<byte, i32>;
-                v731 = hir.load v730 : i32;
-                v1138 = arith.constant 0 : i32;
-                v1139 = arith.constant 0 : i32;
-                v733 = arith.eq v731, v1139 : i1;
-                v734 = arith.zext v733 : u32;
-                v735 = hir.bitcast v734 : i32;
-                v737 = arith.neq v735, v1138 : i1;
-                v1126 = scf.if v737 : i32 {
-                ^block142:
-                    v1137 = arith.constant 0 : i32;
-                    scf.yield v1137;
-                } else {
-                ^block95:
-                    v1136 = arith.constant 4 : u32;
-                    v738 = hir.bitcast v714 : u32;
-                    v740 = arith.add v738, v1136 : u32 #[overflow = checked];
-                    v1135 = arith.constant 4 : u32;
-                    v742 = arith.mod v740, v1135 : u32;
-                    hir.assertz v742 #[code = 250];
-                    v743 = hir.int_to_ptr v740 : ptr<byte, i32>;
-                    hir.store v743, v716;
-                    v1134 = arith.constant 4 : u32;
-                    v744 = hir.bitcast v715 : u32;
-                    v746 = arith.add v744, v1134 : u32 #[overflow = checked];
-                    v1133 = arith.constant 4 : u32;
-                    v748 = arith.mod v746, v1133 : u32;
-                    hir.assertz v748 #[code = 250];
-                    v749 = hir.int_to_ptr v746 : ptr<byte, i32>;
-                    v750 = hir.load v749 : i32;
-                    v751 = hir.bitcast v714 : u32;
-                    v1132 = arith.constant 4 : u32;
-                    v753 = arith.mod v751, v1132 : u32;
-                    hir.assertz v753 #[code = 250];
-                    v754 = hir.int_to_ptr v751 : ptr<byte, i32>;
-                    hir.store v754, v750;
-                    v755 = arith.mul v731, v717 : i32 #[overflow = wrapping];
-                    scf.yield v755;
-                };
-                v756 = arith.constant 8 : i32;
-                v1131 = arith.constant 4 : i32;
-                v1127 = cf.select v737, v1131, v756 : i32;
-                scf.yield v1127, v1126;
-            };
-            v759 = arith.add v714, v1128 : i32 #[overflow = wrapping];
-            v761 = hir.bitcast v759 : u32;
-            v1130 = arith.constant 4 : u32;
-            v763 = arith.mod v761, v1130 : u32;
+            v755 = arith.constant 4 : u32;
+            v754 = hir.bitcast v738 : u32;
+            v756 = arith.add v754, v755 : u32 #[overflow = checked];
+            v1177 = arith.constant 4 : u32;
+            v758 = arith.mod v756, v1177 : u32;
+            hir.assertz v758 #[code = 250];
+            v759 = hir.int_to_ptr v756 : ptr<byte, i32>;
+            hir.store v759, v740;
+            v761 = hir.bitcast v738 : u32;
+            v1176 = arith.constant 4 : u32;
+            v763 = arith.mod v761, v1176 : u32;
             hir.assertz v763 #[code = 250];
             v764 = hir.int_to_ptr v761 : ptr<byte, i32>;
-            hir.store v764, v1129;
+            hir.store v764, v1175;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v765: i32, v766: i32, v767: i32) {
-        ^block96(v765: i32, v766: i32, v767: i32):
-            v1143 = arith.constant 0 : i32;
-            v768 = arith.constant 0 : i32;
-            v769 = arith.eq v767, v768 : i1;
-            v770 = arith.zext v769 : u32;
-            v771 = hir.bitcast v770 : i32;
-            v773 = arith.neq v771, v1143 : i1;
-            scf.if v773{
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v765: i32, v766: i32, v767: i32, v768: i32) {
+        ^block91(v765: i32, v766: i32, v767: i32, v768: i32):
+            v1205 = arith.constant 0 : i32;
+            v769 = arith.constant 0 : i32;
+            v773 = arith.eq v768, v769 : i1;
+            v774 = arith.zext v773 : u32;
+            v775 = hir.bitcast v774 : i32;
+            v777 = arith.neq v775, v1205 : i1;
+            v1192, v1193 = scf.if v777 : i32, i32 {
+            ^block146:
+                v1204 = arith.constant 0 : i32;
+                v771 = arith.constant 4 : i32;
+                scf.yield v771, v1204;
+            } else {
+            ^block94:
+                v778 = hir.bitcast v766 : u32;
+                v813 = arith.constant 4 : u32;
+                v780 = arith.mod v778, v813 : u32;
+                hir.assertz v780 #[code = 250];
+                v781 = hir.int_to_ptr v778 : ptr<byte, i32>;
+                v782 = hir.load v781 : i32;
+                v1202 = arith.constant 0 : i32;
+                v1203 = arith.constant 0 : i32;
+                v784 = arith.eq v782, v1203 : i1;
+                v785 = arith.zext v784 : u32;
+                v786 = hir.bitcast v785 : i32;
+                v788 = arith.neq v786, v1202 : i1;
+                v1190 = scf.if v788 : i32 {
+                ^block145:
+                    v1201 = arith.constant 0 : i32;
+                    scf.yield v1201;
+                } else {
+                ^block95:
+                    v1200 = arith.constant 4 : u32;
+                    v789 = hir.bitcast v765 : u32;
+                    v791 = arith.add v789, v1200 : u32 #[overflow = checked];
+                    v1199 = arith.constant 4 : u32;
+                    v793 = arith.mod v791, v1199 : u32;
+                    hir.assertz v793 #[code = 250];
+                    v794 = hir.int_to_ptr v791 : ptr<byte, i32>;
+                    hir.store v794, v767;
+                    v1198 = arith.constant 4 : u32;
+                    v795 = hir.bitcast v766 : u32;
+                    v797 = arith.add v795, v1198 : u32 #[overflow = checked];
+                    v1197 = arith.constant 4 : u32;
+                    v799 = arith.mod v797, v1197 : u32;
+                    hir.assertz v799 #[code = 250];
+                    v800 = hir.int_to_ptr v797 : ptr<byte, i32>;
+                    v801 = hir.load v800 : i32;
+                    v802 = hir.bitcast v765 : u32;
+                    v1196 = arith.constant 4 : u32;
+                    v804 = arith.mod v802, v1196 : u32;
+                    hir.assertz v804 #[code = 250];
+                    v805 = hir.int_to_ptr v802 : ptr<byte, i32>;
+                    hir.store v805, v801;
+                    v806 = arith.mul v782, v768 : i32 #[overflow = wrapping];
+                    scf.yield v806;
+                };
+                v807 = arith.constant 8 : i32;
+                v1195 = arith.constant 4 : i32;
+                v1191 = cf.select v788, v1195, v807 : i32;
+                scf.yield v1191, v1190;
+            };
+            v810 = arith.add v765, v1192 : i32 #[overflow = wrapping];
+            v812 = hir.bitcast v810 : u32;
+            v1194 = arith.constant 4 : u32;
+            v814 = arith.mod v812, v1194 : u32;
+            hir.assertz v814 #[code = 250];
+            v815 = hir.int_to_ptr v812 : ptr<byte, i32>;
+            hir.store v815, v1193;
+            builtin.ret ;
+        };
+
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v816: i32, v817: i32, v818: i32) {
+        ^block96(v816: i32, v817: i32, v818: i32):
+            v1207 = arith.constant 0 : i32;
+            v819 = arith.constant 0 : i32;
+            v820 = arith.eq v818, v819 : i1;
+            v821 = arith.zext v820 : u32;
+            v822 = hir.bitcast v821 : i32;
+            v824 = arith.neq v822, v1207 : i1;
+            scf.if v824{
             ^block98:
                 scf.yield ;
             } else {
             ^block99:
-                hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_dealloc(v765, v767, v766)
+                hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_dealloc(v816, v818, v817)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::handle_error(v774: i32, v775: i32, v776: i32) {
-        ^block100(v774: i32, v775: i32, v776: i32):
+        private builtin.function @alloc::raw_vec::handle_error(v825: i32, v826: i32, v827: i32) {
+        ^block100(v825: i32, v826: i32, v827: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v777: i32, v778: i32) -> i32 {
-        ^block102(v777: i32, v778: i32):
-            v785 = arith.constant 0 : i32;
-            v781 = hir.bitcast v778 : u32;
-            v780 = hir.bitcast v777 : u32;
-            v782 = arith.gt v780, v781 : i1;
-            v783 = arith.zext v782 : u32;
-            v784 = hir.bitcast v783 : i32;
-            v786 = arith.neq v784, v785 : i1;
-            v787 = cf.select v786, v777, v778 : i32;
-            builtin.ret v787;
+        private builtin.function @core::ptr::alignment::Alignment::max(v828: i32, v829: i32) -> i32 {
+        ^block102(v828: i32, v829: i32):
+            v836 = arith.constant 0 : i32;
+            v832 = hir.bitcast v829 : u32;
+            v831 = hir.bitcast v828 : u32;
+            v833 = arith.gt v831, v832 : i1;
+            v834 = arith.zext v833 : u32;
+            v835 = hir.bitcast v834 : i32;
+            v837 = arith.neq v835, v836 : i1;
+            v838 = cf.select v837, v828, v829 : i32;
+            builtin.ret v838;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -50,6 +50,27 @@ proc.miden_base_sys::bindings::account::extern_account_get_id
     exec.::miden::account::get_id
     trace.252
     nop
+    movup.2
+    dup.0
+    movup.2
+    swap.1
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
+    push.4
+    add
+    u32assert
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::store_felt
+    trace.252
+    nop
 end
 
 proc.miden_base_sys::bindings::note::extern_note_get_inputs
@@ -201,7 +222,7 @@ export.miden:base/note-script@1.0.0#note-script
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.32
+    push.48
     u32wrapping_sub
     push.1114272
     dup.1
@@ -218,13 +239,16 @@ export.miden:base/note-script@1.0.0#note-script
     exec.::miden:base/note-script@1.0.0::p2id::wit_bindgen_rt::run_ctors_once
     trace.252
     nop
-    dup.0
+    push.16
+    dup.1
+    swap.1
+    u32wrapping_add
     trace.240
     nop
     exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::note::get_inputs
     trace.252
     nop
-    push.8
+    push.24
     dup.1
     add
     u32assert
@@ -241,62 +265,24 @@ export.miden:base/note-script@1.0.0#note-script
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.0
-    push.0
-    movup.2
-    swap.1
-    eq
-    neq
+    dup.0
+    push.2147483648
+    u32lte
+    assert
+    dup.0
+    push.1
+    u32lte
     if.true
-        drop
-        push.0
-        assert
+        eq.0
+        if.true
+            drop
+            push.1
+        else
+            drop
+            push.1
+        end
     else
-        push.4
-        dup.1
-        add
-        u32assert
-        push.4
-        dup.1
-        swap.1
-        u32mod
-        u32assert
-        assertz
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::load_sw
-        trace.252
-        nop
-        push.4
-        dup.1
-        swap.1
-        u32mod
-        u32assert
-        assertz
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::load_felt
-        trace.252
-        nop
-        trace.240
-        nop
-        exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::account::get_id
-        trace.252
-        nop
-        assert_eq
-        push.12
-        dup.1
-        swap.1
-        u32wrapping_add
-        trace.240
-        nop
-        exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::note::get_assets
-        trace.252
-        nop
+        drop
         push.20
         dup.1
         add
@@ -314,7 +300,110 @@ export.miden:base/note-script@1.0.0#note-script
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
+        push.4
+        dup.1
+        add
+        u32assert
+        push.4
+        dup.1
+        swap.1
+        u32mod
+        u32assert
+        assertz
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_felt
+        trace.252
+        nop
+        swap.1
+        push.4
+        dup.1
+        swap.1
+        u32mod
+        u32assert
+        assertz
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_felt
+        trace.252
+        nop
+        push.8
+        dup.3
+        swap.1
+        u32wrapping_add
+        trace.240
+        nop
+        exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::account::get_id
+        trace.252
+        nop
         push.12
+        dup.3
+        add
+        u32assert
+        push.4
+        dup.1
+        swap.1
+        u32mod
+        u32assert
+        assertz
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_felt
+        trace.252
+        nop
+        push.8
+        dup.4
+        add
+        u32assert
+        push.4
+        dup.1
+        swap.1
+        u32mod
+        u32assert
+        assertz
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_felt
+        trace.252
+        nop
+        movup.2
+        assert_eq
+        assert_eq
+        push.28
+        dup.1
+        swap.1
+        u32wrapping_add
+        trace.240
+        nop
+        exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::note::get_assets
+        trace.252
+        nop
+        push.36
+        dup.1
+        add
+        u32assert
+        push.4
+        dup.1
+        swap.1
+        u32mod
+        u32assert
+        assertz
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
+        push.28
         dup.2
         add
         u32assert
@@ -331,7 +420,7 @@ export.miden:base/note-script@1.0.0#note-script
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        push.16
+        push.32
         dup.3
         add
         u32assert
@@ -501,7 +590,7 @@ export.miden:base/note-script@1.0.0#note-script
         drop
         drop
         drop
-        push.28
+        push.44
         dup.1
         add
         u32assert
@@ -520,7 +609,7 @@ export.miden:base/note-script@1.0.0#note-script
         exec.::intrinsics::mem::store_sw
         trace.252
         nop
-        push.24
+        push.40
         dup.1
         add
         u32assert
@@ -540,7 +629,7 @@ export.miden:base/note-script@1.0.0#note-script
         trace.252
         nop
         push.16
-        push.24
+        push.40
         dup.2
         swap.1
         u32wrapping_add
@@ -553,7 +642,10 @@ export.miden:base/note-script@1.0.0#note-script
         trace.252
         nop
         push.4
-        dup.1
+        push.16
+        dup.2
+        swap.1
+        u32wrapping_add
         dup.1
         swap.2
         swap.1
@@ -562,7 +654,7 @@ export.miden:base/note-script@1.0.0#note-script
         exec.::miden:base/note-script@1.0.0::p2id::alloc::raw_vec::RawVecInner<A>::deallocate
         trace.252
         nop
-        push.32
+        push.48
         u32wrapping_add
         push.1114272
         u32divmod.4
@@ -572,6 +664,15 @@ export.miden:base/note-script@1.0.0#note-script
         exec.::intrinsics::mem::store_sw
         trace.252
         nop
+        push.0
+    end
+    push.0
+    eq
+    if.true
+        nop
+    else
+        push.0
+        assert
     end
 end
 
@@ -1001,9 +1102,74 @@ proc.alloc::raw_vec::RawVecInner<A>::with_capacity_in
 end
 
 proc.miden_base_sys::bindings::account::get_id
+    push.1114272
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
+    push.16
+    u32wrapping_sub
+    push.1114272
+    dup.1
+    swap.1
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::store_sw
+    trace.252
+    nop
+    push.8
+    dup.1
+    swap.1
+    u32wrapping_add
     trace.240
     nop
     exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::account::extern_account_get_id
+    trace.252
+    nop
+    push.8
+    dup.1
+    add
+    u32assert
+    push.4
+    dup.1
+    swap.1
+    u32mod
+    u32assert
+    assertz
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::load_dw
+    trace.252
+    nop
+    movup.3
+    push.8
+    dup.1
+    swap.1
+    u32mod
+    u32assert
+    assertz
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::store_dw
+    trace.252
+    nop
+    push.16
+    u32wrapping_add
+    push.1114272
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::store_sw
     trace.252
     nop
 end

--- a/tests/integration/expected/examples/p2id.wat
+++ b/tests/integration/expected/examples/p2id.wat
@@ -37,7 +37,7 @@
   (import "miden:core-intrinsics/intrinsics-felt@1.0.0" (instance (;3;) (type 4)))
   (type (;5;)
     (instance
-      (type (;0;) (func (result f32)))
+      (type (;0;) (func (param "result-ptr" s32)))
       (export (;0;) "get-id" (func (type 0)))
     )
   )
@@ -54,15 +54,14 @@
     (type (;0;) (func (param f32 f32)))
     (type (;1;) (func (param f32 f32 f32 f32)))
     (type (;2;) (func (result i32)))
-    (type (;3;) (func (result f32)))
+    (type (;3;) (func (param i32)))
     (type (;4;) (func (param i32) (result i32)))
     (type (;5;) (func))
     (type (;6;) (func (param i32 i32) (result i32)))
     (type (;7;) (func (param i32 i32 i32)))
     (type (;8;) (func (param i32 i32 i32) (result i32)))
     (type (;9;) (func (param i32 i32 i32 i32)))
-    (type (;10;) (func (param i32)))
-    (type (;11;) (func (param i32 i32 i32 i32 i32)))
+    (type (;10;) (func (param i32 i32 i32 i32 i32)))
     (import "miden:core-intrinsics/intrinsics-felt@1.0.0" "assert-eq" (func $miden_stdlib_sys::intrinsics::felt::extern_assert_eq (;0;) (type 0)))
     (import "miden:basic-wallet/basic-wallet@1.0.0" "receive-asset" (func $p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7 (;1;) (type 1)))
     (import "miden:core-intrinsics/intrinsics-mem@1.0.0" "heap-base" (func $miden_sdk_alloc::heap_base (;2;) (type 2)))
@@ -109,91 +108,110 @@
       local.get 1
     )
     (func $miden:base/note-script@1.0.0#note-script (;11;) (type 5)
-      (local i32 f32 i32 i32 i32 i32)
+      (local i32 i32 f32 f32 f32 i32 i32 i32)
       global.get $__stack_pointer
-      i32.const 32
+      i32.const 48
       i32.sub
       local.tee 0
       global.set $__stack_pointer
       call $wit_bindgen_rt::run_ctors_once
       local.get 0
+      i32.const 16
+      i32.add
       call $miden_base_sys::bindings::note::get_inputs
       block ;; label = @1
-        local.get 0
-        i32.load offset=8
-        i32.eqz
-        br_if 0 (;@1;)
-        local.get 0
-        i32.load offset=4
-        f32.load
-        local.set 1
-        call $miden_base_sys::bindings::account::get_id
-        local.get 1
-        call $miden_stdlib_sys::intrinsics::felt::extern_assert_eq
-        local.get 0
-        i32.const 12
-        i32.add
-        call $miden_base_sys::bindings::note::get_assets
-        local.get 0
-        i32.load offset=20
-        i32.const 4
-        i32.shl
-        local.set 2
-        local.get 0
-        i32.load offset=12
-        local.set 3
-        local.get 0
-        i32.load offset=16
-        local.tee 4
-        local.set 5
         block ;; label = @2
-          loop ;; label = @3
-            local.get 2
-            i32.eqz
-            br_if 1 (;@2;)
-            local.get 5
-            f32.load
-            local.get 5
-            f32.load offset=4
-            local.get 5
-            f32.load offset=8
-            local.get 5
-            f32.load offset=12
-            call $p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7
-            local.get 2
-            i32.const -16
-            i32.add
-            local.set 2
-            local.get 5
-            i32.const 16
-            i32.add
-            local.set 5
-            br 0 (;@3;)
-          end
+          local.get 0
+          i32.load offset=24
+          br_table 0 (;@2;) 0 (;@2;) 1 (;@1;)
         end
-        local.get 0
-        local.get 4
-        i32.store offset=28
-        local.get 0
-        local.get 3
-        i32.store offset=24
-        local.get 0
-        i32.const 24
-        i32.add
-        i32.const 16
-        i32.const 16
-        call $alloc::raw_vec::RawVecInner<A>::deallocate
-        local.get 0
-        i32.const 4
-        i32.const 4
-        call $alloc::raw_vec::RawVecInner<A>::deallocate
-        local.get 0
-        i32.const 32
-        i32.add
-        global.set $__stack_pointer
-        return
+        unreachable
       end
-      unreachable
+      local.get 0
+      i32.load offset=20
+      local.tee 1
+      f32.load offset=4
+      local.set 2
+      local.get 1
+      f32.load
+      local.set 3
+      local.get 0
+      i32.const 8
+      i32.add
+      call $miden_base_sys::bindings::account::get_id
+      local.get 0
+      f32.load offset=12
+      local.set 4
+      local.get 0
+      f32.load offset=8
+      local.get 3
+      call $miden_stdlib_sys::intrinsics::felt::extern_assert_eq
+      local.get 4
+      local.get 2
+      call $miden_stdlib_sys::intrinsics::felt::extern_assert_eq
+      local.get 0
+      i32.const 28
+      i32.add
+      call $miden_base_sys::bindings::note::get_assets
+      local.get 0
+      i32.load offset=36
+      i32.const 4
+      i32.shl
+      local.set 5
+      local.get 0
+      i32.load offset=28
+      local.set 6
+      local.get 0
+      i32.load offset=32
+      local.tee 7
+      local.set 1
+      block ;; label = @1
+        loop ;; label = @2
+          local.get 5
+          i32.eqz
+          br_if 1 (;@1;)
+          local.get 1
+          f32.load
+          local.get 1
+          f32.load offset=4
+          local.get 1
+          f32.load offset=8
+          local.get 1
+          f32.load offset=12
+          call $p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7
+          local.get 5
+          i32.const -16
+          i32.add
+          local.set 5
+          local.get 1
+          i32.const 16
+          i32.add
+          local.set 1
+          br 0 (;@2;)
+        end
+      end
+      local.get 0
+      local.get 7
+      i32.store offset=44
+      local.get 0
+      local.get 6
+      i32.store offset=40
+      local.get 0
+      i32.const 40
+      i32.add
+      i32.const 16
+      i32.const 16
+      call $alloc::raw_vec::RawVecInner<A>::deallocate
+      local.get 0
+      i32.const 16
+      i32.add
+      i32.const 4
+      i32.const 4
+      call $alloc::raw_vec::RawVecInner<A>::deallocate
+      local.get 0
+      i32.const 48
+      i32.add
+      global.set $__stack_pointer
     )
     (func $__rustc::__rust_no_alloc_shim_is_unstable_v2 (;12;) (type 5)
       return
@@ -331,10 +349,27 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::account::get_id (;16;) (type 3) (result f32)
+    (func $miden_base_sys::bindings::account::get_id (;16;) (type 3) (param i32)
+      (local i32)
+      global.get $__stack_pointer
+      i32.const 16
+      i32.sub
+      local.tee 1
+      global.set $__stack_pointer
+      local.get 1
+      i32.const 8
+      i32.add
       call $miden_base_sys::bindings::account::extern_account_get_id
+      local.get 0
+      local.get 1
+      i64.load offset=8 align=4
+      i64.store
+      local.get 1
+      i32.const 16
+      i32.add
+      global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::note::get_inputs (;17;) (type 10) (param i32)
+    (func $miden_base_sys::bindings::note::get_inputs (;17;) (type 3) (param i32)
       (local i32 i32 i32)
       global.get $__stack_pointer
       i32.const 16
@@ -372,7 +407,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::note::get_assets (;18;) (type 10) (param i32)
+    (func $miden_base_sys::bindings::note::get_assets (;18;) (type 3) (param i32)
       (local i32 i32 i32)
       global.get $__stack_pointer
       i32.const 16
@@ -442,7 +477,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;20;) (type 11) (param i32 i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;20;) (type 10) (param i32 i32 i32 i32 i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16

--- a/tests/integration/src/rust_masm_tests/abi_transform/tx_kernel.rs
+++ b/tests/integration/src/rust_masm_tests/abi_transform/tx_kernel.rs
@@ -75,7 +75,7 @@ end
 
 #[test]
 fn test_get_id() {
-    let main_fn = "() -> Felt { miden::account::get_id().into() }";
+    let main_fn = "() -> AccountId { miden::account::get_id() }";
     let artifact_name = "abi_transform_tx_kernel_get_id";
     let config = WasmTranslationConfig::default();
     let test_builder =

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -104,6 +104,8 @@ pub struct NewCommand {
 
 use std::{fs, io::Write};
 
+use crate::utils::set_default_test_compiler;
+
 impl NewCommand {
     pub fn exec(self) -> anyhow::Result<PathBuf> {
         let name = self
@@ -228,10 +230,4 @@ pub fn write_wit_file(path: &PathBuf, content: &str) -> anyhow::Result<()> {
     let mut file = fs::File::create(path)?;
     file.write_all(content.as_bytes())?;
     Ok(())
-}
-
-fn set_default_test_compiler(define: &mut Vec<String>) {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let compiler_path = Path::new(&manifest_dir).parent().unwrap().parent().unwrap();
-    define.push(format!("compiler_path={}", compiler_path.display()));
 }

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -28,6 +28,7 @@ mod dependencies;
 mod non_component;
 mod outputs;
 mod target;
+mod utils;
 
 pub use cargo_component::core::terminal::{Color, Terminal, Verbosity};
 pub use outputs::{BuildOutput, CommandOutput};

--- a/tools/cargo-miden/src/utils.rs
+++ b/tools/cargo-miden/src/utils.rs
@@ -1,0 +1,12 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) fn set_default_test_compiler(define: &mut Vec<String>) {
+    let compiler_path = compiler_path();
+    define.push(format!("compiler_path={}", compiler_path.display()));
+}
+
+pub(crate) fn compiler_path() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let compiler_path = Path::new(&manifest_dir).parent().unwrap().parent().unwrap();
+    compiler_path.to_path_buf()
+}

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -33,7 +33,7 @@ fn new_project_args(project_name: &str, template: &str) -> Vec<String> {
 // that depend on the current directory
 
 #[test]
-fn test_all_templates() {
+fn test_all_templates_and_examples() {
     let _ = env_logger::Builder::from_env("MIDENC_TRACE")
         .is_test(true)
         .format_timestamp(None)


### PR DESCRIPTION
Close #616

This PR:
- Updates Miden SDK `AccountId` type and `account::get_id()` for two felts (prefix and suffix) account ids;
- Uses local compiler path in `ExampleCommand` under tests;
