### PR TITLE
fix: add `incr_nonce()` call in every basic-wallet example function

### DIFF
--- a/examples/basic-wallet/src/lib.rs
+++ b/examples/basic-wallet/src/lib.rs
@@ -31,10 +31,12 @@ struct MyAccount;
 impl basic_wallet::Guest for MyAccount {
     fn receive_asset(asset: Asset) {
         miden::account::add_asset(asset);
+        miden::account::incr_nonce(1);
     }
 
     fn send_asset(asset: Asset, tag: Tag, note_type: NoteType, recipient: Recipient) {
         let asset = miden::account::remove_asset(asset);
         miden::tx::create_note(asset, tag, note_type, recipient);
+        miden::account::incr_nonce(1);
     }
 }

--- a/tests/integration/expected/examples/basic_wallet.hir
+++ b/tests/integration/expected/examples/basic_wallet.hir
@@ -42,333 +42,349 @@ builtin.component miden:basic-wallet/basic-wallet@1.0.0 {
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::tx::extern_tx_create_note(v40: felt, v41: felt, v42: felt, v43: felt, v44: felt, v45: felt, v46: felt, v47: felt, v48: felt, v49: felt) -> felt {
-        ^block9(v40: felt, v41: felt, v42: felt, v43: felt, v44: felt, v45: felt, v46: felt, v47: felt, v48: felt, v49: felt):
-            v50 = hir.exec @miden/tx/create_note(v40, v41, v42, v43, v44, v45, v46, v47, v48, v49) : felt
-            builtin.ret v50;
-        };
-
-        private builtin.function @__wasm_call_ctors() {
-        ^block14:
+        private builtin.function @miden_base_sys::bindings::account::extern_account_incr_nonce(v40: i32) {
+        ^block9(v40: i32):
+            hir.exec @miden/account/incr_nonce(v40)
             builtin.ret ;
         };
 
-        private builtin.function @basic_wallet::bindings::__link_custom_section_describing_imports() {
+        private builtin.function @miden_base_sys::bindings::tx::extern_tx_create_note(v41: felt, v42: felt, v43: felt, v44: felt, v45: felt, v46: felt, v47: felt, v48: felt, v49: felt, v50: felt) -> felt {
+        ^block11(v41: felt, v42: felt, v43: felt, v44: felt, v45: felt, v46: felt, v47: felt, v48: felt, v49: felt, v50: felt):
+            v51 = hir.exec @miden/tx/create_note(v41, v42, v43, v44, v45, v46, v47, v48, v49, v50) : felt
+            builtin.ret v51;
+        };
+
+        private builtin.function @__wasm_call_ctors() {
         ^block16:
             builtin.ret ;
         };
 
-        public builtin.function @miden:basic-wallet/basic-wallet@1.0.0#receive-asset(v52: felt, v53: felt, v54: felt, v55: felt) {
-        ^block18(v52: felt, v53: felt, v54: felt, v55: felt):
-            v57 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
-            v58 = hir.bitcast v57 : ptr<byte, i32>;
-            v59 = hir.load v58 : i32;
-            v60 = arith.constant 32 : i32;
-            v61 = arith.sub v59, v60 : i32 #[overflow = wrapping];
-            v62 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
-            v63 = hir.bitcast v62 : ptr<byte, i32>;
-            hir.store v63, v61;
-            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/wit_bindgen_rt::run_ctors_once()
-            v65 = arith.constant 12 : u32;
-            v64 = hir.bitcast v61 : u32;
-            v66 = arith.add v64, v65 : u32 #[overflow = checked];
-            v67 = arith.constant 4 : u32;
-            v68 = arith.mod v66, v67 : u32;
-            hir.assertz v68 #[code = 250];
-            v69 = hir.int_to_ptr v66 : ptr<byte, felt>;
-            hir.store v69, v55;
-            v71 = arith.constant 8 : u32;
-            v70 = hir.bitcast v61 : u32;
-            v72 = arith.add v70, v71 : u32 #[overflow = checked];
-            v322 = arith.constant 4 : u32;
-            v74 = arith.mod v72, v322 : u32;
-            hir.assertz v74 #[code = 250];
-            v75 = hir.int_to_ptr v72 : ptr<byte, felt>;
-            hir.store v75, v54;
-            v321 = arith.constant 4 : u32;
-            v76 = hir.bitcast v61 : u32;
-            v78 = arith.add v76, v321 : u32 #[overflow = checked];
-            v320 = arith.constant 4 : u32;
-            v80 = arith.mod v78, v320 : u32;
-            hir.assertz v80 #[code = 250];
-            v81 = hir.int_to_ptr v78 : ptr<byte, felt>;
-            hir.store v81, v53;
-            v82 = hir.bitcast v61 : u32;
-            v319 = arith.constant 4 : u32;
-            v84 = arith.mod v82, v319 : u32;
-            hir.assertz v84 #[code = 250];
-            v85 = hir.int_to_ptr v82 : ptr<byte, felt>;
-            hir.store v85, v52;
-            v86 = arith.constant 16 : i32;
-            v87 = arith.add v61, v86 : i32 #[overflow = wrapping];
-            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::add_asset(v87, v61)
-            v318 = arith.constant 32 : i32;
-            v89 = arith.add v61, v318 : i32 #[overflow = wrapping];
-            v90 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
-            v91 = hir.bitcast v90 : ptr<byte, i32>;
-            hir.store v91, v89;
+        private builtin.function @basic_wallet::bindings::__link_custom_section_describing_imports() {
+        ^block18:
             builtin.ret ;
         };
 
-        public builtin.function @miden:basic-wallet/basic-wallet@1.0.0#send-asset(v92: felt, v93: felt, v94: felt, v95: felt, v96: felt, v97: felt, v98: felt, v99: felt, v100: felt, v101: felt) {
-        ^block20(v92: felt, v93: felt, v94: felt, v95: felt, v96: felt, v97: felt, v98: felt, v99: felt, v100: felt, v101: felt):
-            v103 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
-            v104 = hir.bitcast v103 : ptr<byte, i32>;
-            v105 = hir.load v104 : i32;
-            v106 = arith.constant 48 : i32;
-            v107 = arith.sub v105, v106 : i32 #[overflow = wrapping];
-            v108 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
-            v109 = hir.bitcast v108 : ptr<byte, i32>;
-            hir.store v109, v107;
+        public builtin.function @miden:basic-wallet/basic-wallet@1.0.0#receive-asset(v53: felt, v54: felt, v55: felt, v56: felt) {
+        ^block20(v53: felt, v54: felt, v55: felt, v56: felt):
+            v58 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
+            v59 = hir.bitcast v58 : ptr<byte, i32>;
+            v60 = hir.load v59 : i32;
+            v61 = arith.constant 32 : i32;
+            v62 = arith.sub v60, v61 : i32 #[overflow = wrapping];
+            v63 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
+            v64 = hir.bitcast v63 : ptr<byte, i32>;
+            hir.store v64, v62;
             hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/wit_bindgen_rt::run_ctors_once()
-            v111 = arith.constant 12 : u32;
-            v110 = hir.bitcast v107 : u32;
-            v112 = arith.add v110, v111 : u32 #[overflow = checked];
-            v113 = arith.constant 4 : u32;
-            v114 = arith.mod v112, v113 : u32;
-            hir.assertz v114 #[code = 250];
-            v115 = hir.int_to_ptr v112 : ptr<byte, felt>;
-            hir.store v115, v95;
-            v117 = arith.constant 8 : u32;
-            v116 = hir.bitcast v107 : u32;
-            v118 = arith.add v116, v117 : u32 #[overflow = checked];
-            v332 = arith.constant 4 : u32;
-            v120 = arith.mod v118, v332 : u32;
-            hir.assertz v120 #[code = 250];
-            v121 = hir.int_to_ptr v118 : ptr<byte, felt>;
-            hir.store v121, v94;
-            v331 = arith.constant 4 : u32;
-            v122 = hir.bitcast v107 : u32;
-            v124 = arith.add v122, v331 : u32 #[overflow = checked];
-            v330 = arith.constant 4 : u32;
-            v126 = arith.mod v124, v330 : u32;
-            hir.assertz v126 #[code = 250];
-            v127 = hir.int_to_ptr v124 : ptr<byte, felt>;
-            hir.store v127, v93;
-            v128 = hir.bitcast v107 : u32;
-            v329 = arith.constant 4 : u32;
-            v130 = arith.mod v128, v329 : u32;
-            hir.assertz v130 #[code = 250];
-            v131 = hir.int_to_ptr v128 : ptr<byte, felt>;
-            hir.store v131, v92;
-            v133 = arith.constant 28 : u32;
-            v132 = hir.bitcast v107 : u32;
-            v134 = arith.add v132, v133 : u32 #[overflow = checked];
-            v328 = arith.constant 4 : u32;
-            v136 = arith.mod v134, v328 : u32;
-            hir.assertz v136 #[code = 250];
-            v137 = hir.int_to_ptr v134 : ptr<byte, felt>;
-            hir.store v137, v101;
-            v139 = arith.constant 24 : u32;
-            v138 = hir.bitcast v107 : u32;
-            v140 = arith.add v138, v139 : u32 #[overflow = checked];
-            v327 = arith.constant 4 : u32;
-            v142 = arith.mod v140, v327 : u32;
-            hir.assertz v142 #[code = 250];
-            v143 = hir.int_to_ptr v140 : ptr<byte, felt>;
-            hir.store v143, v100;
-            v145 = arith.constant 20 : u32;
-            v144 = hir.bitcast v107 : u32;
-            v146 = arith.add v144, v145 : u32 #[overflow = checked];
+            v66 = arith.constant 12 : u32;
+            v65 = hir.bitcast v62 : u32;
+            v67 = arith.add v65, v66 : u32 #[overflow = checked];
+            v68 = arith.constant 4 : u32;
+            v69 = arith.mod v67, v68 : u32;
+            hir.assertz v69 #[code = 250];
+            v70 = hir.int_to_ptr v67 : ptr<byte, felt>;
+            hir.store v70, v56;
+            v72 = arith.constant 8 : u32;
+            v71 = hir.bitcast v62 : u32;
+            v73 = arith.add v71, v72 : u32 #[overflow = checked];
             v326 = arith.constant 4 : u32;
-            v148 = arith.mod v146, v326 : u32;
-            hir.assertz v148 #[code = 250];
-            v149 = hir.int_to_ptr v146 : ptr<byte, felt>;
-            hir.store v149, v99;
-            v151 = arith.constant 16 : u32;
-            v150 = hir.bitcast v107 : u32;
-            v152 = arith.add v150, v151 : u32 #[overflow = checked];
+            v75 = arith.mod v73, v326 : u32;
+            hir.assertz v75 #[code = 250];
+            v76 = hir.int_to_ptr v73 : ptr<byte, felt>;
+            hir.store v76, v55;
             v325 = arith.constant 4 : u32;
-            v154 = arith.mod v152, v325 : u32;
-            hir.assertz v154 #[code = 250];
-            v155 = hir.int_to_ptr v152 : ptr<byte, felt>;
-            hir.store v155, v98;
-            v156 = arith.constant 32 : i32;
-            v157 = arith.add v107, v156 : i32 #[overflow = wrapping];
-            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::remove_asset(v157, v107)
-            v160 = arith.constant 16 : i32;
-            v161 = arith.add v107, v160 : i32 #[overflow = wrapping];
-            v324 = arith.constant 32 : i32;
-            v159 = arith.add v107, v324 : i32 #[overflow = wrapping];
-            v162 = hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::tx::create_note(v159, v96, v97, v161) : felt
-            v323 = arith.constant 48 : i32;
-            v164 = arith.add v107, v323 : i32 #[overflow = wrapping];
-            v165 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
-            v166 = hir.bitcast v165 : ptr<byte, i32>;
-            hir.store v166, v164;
+            v77 = hir.bitcast v62 : u32;
+            v79 = arith.add v77, v325 : u32 #[overflow = checked];
+            v324 = arith.constant 4 : u32;
+            v81 = arith.mod v79, v324 : u32;
+            hir.assertz v81 #[code = 250];
+            v82 = hir.int_to_ptr v79 : ptr<byte, felt>;
+            hir.store v82, v54;
+            v83 = hir.bitcast v62 : u32;
+            v323 = arith.constant 4 : u32;
+            v85 = arith.mod v83, v323 : u32;
+            hir.assertz v85 #[code = 250];
+            v86 = hir.int_to_ptr v83 : ptr<byte, felt>;
+            hir.store v86, v53;
+            v87 = arith.constant 16 : i32;
+            v88 = arith.add v62, v87 : i32 #[overflow = wrapping];
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::add_asset(v88, v62)
+            v89 = arith.constant 1 : i32;
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::incr_nonce(v89)
+            v322 = arith.constant 32 : i32;
+            v91 = arith.add v62, v322 : i32 #[overflow = wrapping];
+            v92 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
+            v93 = hir.bitcast v92 : ptr<byte, i32>;
+            hir.store v93, v91;
+            builtin.ret ;
+        };
+
+        public builtin.function @miden:basic-wallet/basic-wallet@1.0.0#send-asset(v94: felt, v95: felt, v96: felt, v97: felt, v98: felt, v99: felt, v100: felt, v101: felt, v102: felt, v103: felt) {
+        ^block22(v94: felt, v95: felt, v96: felt, v97: felt, v98: felt, v99: felt, v100: felt, v101: felt, v102: felt, v103: felt):
+            v105 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
+            v106 = hir.bitcast v105 : ptr<byte, i32>;
+            v107 = hir.load v106 : i32;
+            v108 = arith.constant 48 : i32;
+            v109 = arith.sub v107, v108 : i32 #[overflow = wrapping];
+            v110 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
+            v111 = hir.bitcast v110 : ptr<byte, i32>;
+            hir.store v111, v109;
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/wit_bindgen_rt::run_ctors_once()
+            v113 = arith.constant 12 : u32;
+            v112 = hir.bitcast v109 : u32;
+            v114 = arith.add v112, v113 : u32 #[overflow = checked];
+            v115 = arith.constant 4 : u32;
+            v116 = arith.mod v114, v115 : u32;
+            hir.assertz v116 #[code = 250];
+            v117 = hir.int_to_ptr v114 : ptr<byte, felt>;
+            hir.store v117, v97;
+            v119 = arith.constant 8 : u32;
+            v118 = hir.bitcast v109 : u32;
+            v120 = arith.add v118, v119 : u32 #[overflow = checked];
+            v336 = arith.constant 4 : u32;
+            v122 = arith.mod v120, v336 : u32;
+            hir.assertz v122 #[code = 250];
+            v123 = hir.int_to_ptr v120 : ptr<byte, felt>;
+            hir.store v123, v96;
+            v335 = arith.constant 4 : u32;
+            v124 = hir.bitcast v109 : u32;
+            v126 = arith.add v124, v335 : u32 #[overflow = checked];
+            v334 = arith.constant 4 : u32;
+            v128 = arith.mod v126, v334 : u32;
+            hir.assertz v128 #[code = 250];
+            v129 = hir.int_to_ptr v126 : ptr<byte, felt>;
+            hir.store v129, v95;
+            v130 = hir.bitcast v109 : u32;
+            v333 = arith.constant 4 : u32;
+            v132 = arith.mod v130, v333 : u32;
+            hir.assertz v132 #[code = 250];
+            v133 = hir.int_to_ptr v130 : ptr<byte, felt>;
+            hir.store v133, v94;
+            v135 = arith.constant 28 : u32;
+            v134 = hir.bitcast v109 : u32;
+            v136 = arith.add v134, v135 : u32 #[overflow = checked];
+            v332 = arith.constant 4 : u32;
+            v138 = arith.mod v136, v332 : u32;
+            hir.assertz v138 #[code = 250];
+            v139 = hir.int_to_ptr v136 : ptr<byte, felt>;
+            hir.store v139, v103;
+            v141 = arith.constant 24 : u32;
+            v140 = hir.bitcast v109 : u32;
+            v142 = arith.add v140, v141 : u32 #[overflow = checked];
+            v331 = arith.constant 4 : u32;
+            v144 = arith.mod v142, v331 : u32;
+            hir.assertz v144 #[code = 250];
+            v145 = hir.int_to_ptr v142 : ptr<byte, felt>;
+            hir.store v145, v102;
+            v147 = arith.constant 20 : u32;
+            v146 = hir.bitcast v109 : u32;
+            v148 = arith.add v146, v147 : u32 #[overflow = checked];
+            v330 = arith.constant 4 : u32;
+            v150 = arith.mod v148, v330 : u32;
+            hir.assertz v150 #[code = 250];
+            v151 = hir.int_to_ptr v148 : ptr<byte, felt>;
+            hir.store v151, v101;
+            v153 = arith.constant 16 : u32;
+            v152 = hir.bitcast v109 : u32;
+            v154 = arith.add v152, v153 : u32 #[overflow = checked];
+            v329 = arith.constant 4 : u32;
+            v156 = arith.mod v154, v329 : u32;
+            hir.assertz v156 #[code = 250];
+            v157 = hir.int_to_ptr v154 : ptr<byte, felt>;
+            hir.store v157, v100;
+            v158 = arith.constant 32 : i32;
+            v159 = arith.add v109, v158 : i32 #[overflow = wrapping];
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::remove_asset(v159, v109)
+            v162 = arith.constant 16 : i32;
+            v163 = arith.add v109, v162 : i32 #[overflow = wrapping];
+            v328 = arith.constant 32 : i32;
+            v161 = arith.add v109, v328 : i32 #[overflow = wrapping];
+            v164 = hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::tx::create_note(v161, v98, v99, v163) : felt
+            v165 = arith.constant 1 : i32;
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::incr_nonce(v165)
+            v327 = arith.constant 48 : i32;
+            v167 = arith.add v109, v327 : i32 #[overflow = wrapping];
+            v168 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__stack_pointer : ptr<byte, u8>
+            v169 = hir.bitcast v168 : ptr<byte, i32>;
+            hir.store v169, v167;
             builtin.ret ;
         };
 
         private builtin.function @wit_bindgen_rt::run_ctors_once() {
-        ^block22:
-            v168 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v169 = hir.bitcast v168 : ptr<byte, i32>;
-            v170 = hir.load v169 : i32;
-            v171 = arith.constant 1048616 : i32;
-            v172 = arith.add v170, v171 : i32 #[overflow = wrapping];
-            v173 = hir.bitcast v172 : u32;
-            v174 = hir.int_to_ptr v173 : ptr<byte, u8>;
-            v175 = hir.load v174 : u8;
-            v167 = arith.constant 0 : i32;
-            v176 = arith.zext v175 : u32;
-            v177 = hir.bitcast v176 : i32;
-            v179 = arith.neq v177, v167 : i1;
-            scf.if v179{
-            ^block24:
+        ^block24:
+            v171 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v172 = hir.bitcast v171 : ptr<byte, i32>;
+            v173 = hir.load v172 : i32;
+            v174 = arith.constant 1048616 : i32;
+            v175 = arith.add v173, v174 : i32 #[overflow = wrapping];
+            v176 = hir.bitcast v175 : u32;
+            v177 = hir.int_to_ptr v176 : ptr<byte, u8>;
+            v178 = hir.load v177 : u8;
+            v170 = arith.constant 0 : i32;
+            v179 = arith.zext v178 : u32;
+            v180 = hir.bitcast v179 : i32;
+            v182 = arith.neq v180, v170 : i1;
+            scf.if v182{
+            ^block26:
                 scf.yield ;
             } else {
-            ^block25:
-                v180 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/GOT.data.internal.__memory_base : ptr<byte, u8>
-                v181 = hir.bitcast v180 : ptr<byte, i32>;
-                v182 = hir.load v181 : i32;
+            ^block27:
+                v183 = builtin.global_symbol @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/GOT.data.internal.__memory_base : ptr<byte, u8>
+                v184 = hir.bitcast v183 : ptr<byte, i32>;
+                v185 = hir.load v184 : i32;
                 hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/__wasm_call_ctors()
-                v334 = arith.constant 1 : u8;
-                v336 = arith.constant 1048616 : i32;
-                v184 = arith.add v182, v336 : i32 #[overflow = wrapping];
-                v188 = hir.bitcast v184 : u32;
-                v189 = hir.int_to_ptr v188 : ptr<byte, u8>;
-                hir.store v189, v334;
+                v338 = arith.constant 1 : u8;
+                v340 = arith.constant 1048616 : i32;
+                v187 = arith.add v185, v340 : i32 #[overflow = wrapping];
+                v191 = hir.bitcast v187 : u32;
+                v192 = hir.int_to_ptr v191 : ptr<byte, u8>;
+                hir.store v192, v338;
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::account::add_asset(v190: i32, v191: i32) {
-        ^block26(v190: i32, v191: i32):
-            v192 = hir.bitcast v191 : u32;
-            v193 = arith.constant 4 : u32;
-            v194 = arith.mod v192, v193 : u32;
-            hir.assertz v194 #[code = 250];
-            v195 = hir.int_to_ptr v192 : ptr<byte, felt>;
-            v196 = hir.load v195 : felt;
-            v340 = arith.constant 4 : u32;
-            v197 = hir.bitcast v191 : u32;
-            v199 = arith.add v197, v340 : u32 #[overflow = checked];
-            v339 = arith.constant 4 : u32;
-            v201 = arith.mod v199, v339 : u32;
-            hir.assertz v201 #[code = 250];
-            v202 = hir.int_to_ptr v199 : ptr<byte, felt>;
-            v203 = hir.load v202 : felt;
-            v205 = arith.constant 8 : u32;
-            v204 = hir.bitcast v191 : u32;
-            v206 = arith.add v204, v205 : u32 #[overflow = checked];
-            v338 = arith.constant 4 : u32;
-            v208 = arith.mod v206, v338 : u32;
-            hir.assertz v208 #[code = 250];
-            v209 = hir.int_to_ptr v206 : ptr<byte, felt>;
-            v210 = hir.load v209 : felt;
-            v212 = arith.constant 12 : u32;
-            v211 = hir.bitcast v191 : u32;
-            v213 = arith.add v211, v212 : u32 #[overflow = checked];
-            v337 = arith.constant 4 : u32;
-            v215 = arith.mod v213, v337 : u32;
-            hir.assertz v215 #[code = 250];
-            v216 = hir.int_to_ptr v213 : ptr<byte, felt>;
-            v217 = hir.load v216 : felt;
-            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::extern_account_add_asset(v196, v203, v210, v217, v190)
-            builtin.ret ;
-        };
-
-        private builtin.function @miden_base_sys::bindings::account::remove_asset(v218: i32, v219: i32) {
-        ^block28(v218: i32, v219: i32):
-            v220 = hir.bitcast v219 : u32;
-            v221 = arith.constant 4 : u32;
-            v222 = arith.mod v220, v221 : u32;
-            hir.assertz v222 #[code = 250];
-            v223 = hir.int_to_ptr v220 : ptr<byte, felt>;
-            v224 = hir.load v223 : felt;
+        private builtin.function @miden_base_sys::bindings::account::add_asset(v193: i32, v194: i32) {
+        ^block28(v193: i32, v194: i32):
+            v195 = hir.bitcast v194 : u32;
+            v196 = arith.constant 4 : u32;
+            v197 = arith.mod v195, v196 : u32;
+            hir.assertz v197 #[code = 250];
+            v198 = hir.int_to_ptr v195 : ptr<byte, felt>;
+            v199 = hir.load v198 : felt;
             v344 = arith.constant 4 : u32;
-            v225 = hir.bitcast v219 : u32;
-            v227 = arith.add v225, v344 : u32 #[overflow = checked];
+            v200 = hir.bitcast v194 : u32;
+            v202 = arith.add v200, v344 : u32 #[overflow = checked];
             v343 = arith.constant 4 : u32;
-            v229 = arith.mod v227, v343 : u32;
-            hir.assertz v229 #[code = 250];
-            v230 = hir.int_to_ptr v227 : ptr<byte, felt>;
-            v231 = hir.load v230 : felt;
-            v233 = arith.constant 8 : u32;
-            v232 = hir.bitcast v219 : u32;
-            v234 = arith.add v232, v233 : u32 #[overflow = checked];
+            v204 = arith.mod v202, v343 : u32;
+            hir.assertz v204 #[code = 250];
+            v205 = hir.int_to_ptr v202 : ptr<byte, felt>;
+            v206 = hir.load v205 : felt;
+            v208 = arith.constant 8 : u32;
+            v207 = hir.bitcast v194 : u32;
+            v209 = arith.add v207, v208 : u32 #[overflow = checked];
             v342 = arith.constant 4 : u32;
-            v236 = arith.mod v234, v342 : u32;
-            hir.assertz v236 #[code = 250];
-            v237 = hir.int_to_ptr v234 : ptr<byte, felt>;
-            v238 = hir.load v237 : felt;
-            v240 = arith.constant 12 : u32;
-            v239 = hir.bitcast v219 : u32;
-            v241 = arith.add v239, v240 : u32 #[overflow = checked];
+            v211 = arith.mod v209, v342 : u32;
+            hir.assertz v211 #[code = 250];
+            v212 = hir.int_to_ptr v209 : ptr<byte, felt>;
+            v213 = hir.load v212 : felt;
+            v215 = arith.constant 12 : u32;
+            v214 = hir.bitcast v194 : u32;
+            v216 = arith.add v214, v215 : u32 #[overflow = checked];
             v341 = arith.constant 4 : u32;
-            v243 = arith.mod v241, v341 : u32;
-            hir.assertz v243 #[code = 250];
-            v244 = hir.int_to_ptr v241 : ptr<byte, felt>;
-            v245 = hir.load v244 : felt;
-            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::extern_account_remove_asset(v224, v231, v238, v245, v218)
+            v218 = arith.mod v216, v341 : u32;
+            hir.assertz v218 #[code = 250];
+            v219 = hir.int_to_ptr v216 : ptr<byte, felt>;
+            v220 = hir.load v219 : felt;
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::extern_account_add_asset(v199, v206, v213, v220, v193)
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::tx::create_note(v246: i32, v247: felt, v248: felt, v249: i32) -> felt {
-        ^block30(v246: i32, v247: felt, v248: felt, v249: i32):
-            v251 = hir.bitcast v246 : u32;
-            v252 = arith.constant 4 : u32;
-            v253 = arith.mod v251, v252 : u32;
-            hir.assertz v253 #[code = 250];
-            v254 = hir.int_to_ptr v251 : ptr<byte, felt>;
-            v255 = hir.load v254 : felt;
-            v355 = arith.constant 4 : u32;
-            v256 = hir.bitcast v246 : u32;
-            v258 = arith.add v256, v355 : u32 #[overflow = checked];
-            v354 = arith.constant 4 : u32;
-            v260 = arith.mod v258, v354 : u32;
-            hir.assertz v260 #[code = 250];
-            v261 = hir.int_to_ptr v258 : ptr<byte, felt>;
-            v262 = hir.load v261 : felt;
-            v264 = arith.constant 8 : u32;
-            v263 = hir.bitcast v246 : u32;
-            v265 = arith.add v263, v264 : u32 #[overflow = checked];
-            v353 = arith.constant 4 : u32;
-            v267 = arith.mod v265, v353 : u32;
-            hir.assertz v267 #[code = 250];
-            v268 = hir.int_to_ptr v265 : ptr<byte, felt>;
-            v269 = hir.load v268 : felt;
-            v271 = arith.constant 12 : u32;
-            v270 = hir.bitcast v246 : u32;
-            v272 = arith.add v270, v271 : u32 #[overflow = checked];
-            v352 = arith.constant 4 : u32;
-            v274 = arith.mod v272, v352 : u32;
-            hir.assertz v274 #[code = 250];
-            v275 = hir.int_to_ptr v272 : ptr<byte, felt>;
-            v276 = hir.load v275 : felt;
-            v277 = hir.bitcast v249 : u32;
-            v351 = arith.constant 4 : u32;
-            v279 = arith.mod v277, v351 : u32;
-            hir.assertz v279 #[code = 250];
-            v280 = hir.int_to_ptr v277 : ptr<byte, felt>;
-            v281 = hir.load v280 : felt;
-            v350 = arith.constant 4 : u32;
-            v282 = hir.bitcast v249 : u32;
-            v284 = arith.add v282, v350 : u32 #[overflow = checked];
-            v349 = arith.constant 4 : u32;
-            v286 = arith.mod v284, v349 : u32;
-            hir.assertz v286 #[code = 250];
-            v287 = hir.int_to_ptr v284 : ptr<byte, felt>;
-            v288 = hir.load v287 : felt;
-            v348 = arith.constant 8 : u32;
-            v289 = hir.bitcast v249 : u32;
-            v291 = arith.add v289, v348 : u32 #[overflow = checked];
+        private builtin.function @miden_base_sys::bindings::account::remove_asset(v221: i32, v222: i32) {
+        ^block30(v221: i32, v222: i32):
+            v223 = hir.bitcast v222 : u32;
+            v224 = arith.constant 4 : u32;
+            v225 = arith.mod v223, v224 : u32;
+            hir.assertz v225 #[code = 250];
+            v226 = hir.int_to_ptr v223 : ptr<byte, felt>;
+            v227 = hir.load v226 : felt;
+            v348 = arith.constant 4 : u32;
+            v228 = hir.bitcast v222 : u32;
+            v230 = arith.add v228, v348 : u32 #[overflow = checked];
             v347 = arith.constant 4 : u32;
-            v293 = arith.mod v291, v347 : u32;
-            hir.assertz v293 #[code = 250];
-            v294 = hir.int_to_ptr v291 : ptr<byte, felt>;
-            v295 = hir.load v294 : felt;
-            v346 = arith.constant 12 : u32;
-            v296 = hir.bitcast v249 : u32;
-            v298 = arith.add v296, v346 : u32 #[overflow = checked];
+            v232 = arith.mod v230, v347 : u32;
+            hir.assertz v232 #[code = 250];
+            v233 = hir.int_to_ptr v230 : ptr<byte, felt>;
+            v234 = hir.load v233 : felt;
+            v236 = arith.constant 8 : u32;
+            v235 = hir.bitcast v222 : u32;
+            v237 = arith.add v235, v236 : u32 #[overflow = checked];
+            v346 = arith.constant 4 : u32;
+            v239 = arith.mod v237, v346 : u32;
+            hir.assertz v239 #[code = 250];
+            v240 = hir.int_to_ptr v237 : ptr<byte, felt>;
+            v241 = hir.load v240 : felt;
+            v243 = arith.constant 12 : u32;
+            v242 = hir.bitcast v222 : u32;
+            v244 = arith.add v242, v243 : u32 #[overflow = checked];
             v345 = arith.constant 4 : u32;
-            v300 = arith.mod v298, v345 : u32;
-            hir.assertz v300 #[code = 250];
-            v301 = hir.int_to_ptr v298 : ptr<byte, felt>;
-            v302 = hir.load v301 : felt;
-            v303 = hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::tx::extern_tx_create_note(v255, v262, v269, v276, v247, v248, v281, v288, v295, v302) : felt
-            builtin.ret v303;
+            v246 = arith.mod v244, v345 : u32;
+            hir.assertz v246 #[code = 250];
+            v247 = hir.int_to_ptr v244 : ptr<byte, felt>;
+            v248 = hir.load v247 : felt;
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::extern_account_remove_asset(v227, v234, v241, v248, v221)
+            builtin.ret ;
+        };
+
+        private builtin.function @miden_base_sys::bindings::account::incr_nonce(v249: i32) {
+        ^block32(v249: i32):
+            hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::account::extern_account_incr_nonce(v249)
+            builtin.ret ;
+        };
+
+        private builtin.function @miden_base_sys::bindings::tx::create_note(v250: i32, v251: felt, v252: felt, v253: i32) -> felt {
+        ^block34(v250: i32, v251: felt, v252: felt, v253: i32):
+            v255 = hir.bitcast v250 : u32;
+            v256 = arith.constant 4 : u32;
+            v257 = arith.mod v255, v256 : u32;
+            hir.assertz v257 #[code = 250];
+            v258 = hir.int_to_ptr v255 : ptr<byte, felt>;
+            v259 = hir.load v258 : felt;
+            v359 = arith.constant 4 : u32;
+            v260 = hir.bitcast v250 : u32;
+            v262 = arith.add v260, v359 : u32 #[overflow = checked];
+            v358 = arith.constant 4 : u32;
+            v264 = arith.mod v262, v358 : u32;
+            hir.assertz v264 #[code = 250];
+            v265 = hir.int_to_ptr v262 : ptr<byte, felt>;
+            v266 = hir.load v265 : felt;
+            v268 = arith.constant 8 : u32;
+            v267 = hir.bitcast v250 : u32;
+            v269 = arith.add v267, v268 : u32 #[overflow = checked];
+            v357 = arith.constant 4 : u32;
+            v271 = arith.mod v269, v357 : u32;
+            hir.assertz v271 #[code = 250];
+            v272 = hir.int_to_ptr v269 : ptr<byte, felt>;
+            v273 = hir.load v272 : felt;
+            v275 = arith.constant 12 : u32;
+            v274 = hir.bitcast v250 : u32;
+            v276 = arith.add v274, v275 : u32 #[overflow = checked];
+            v356 = arith.constant 4 : u32;
+            v278 = arith.mod v276, v356 : u32;
+            hir.assertz v278 #[code = 250];
+            v279 = hir.int_to_ptr v276 : ptr<byte, felt>;
+            v280 = hir.load v279 : felt;
+            v281 = hir.bitcast v253 : u32;
+            v355 = arith.constant 4 : u32;
+            v283 = arith.mod v281, v355 : u32;
+            hir.assertz v283 #[code = 250];
+            v284 = hir.int_to_ptr v281 : ptr<byte, felt>;
+            v285 = hir.load v284 : felt;
+            v354 = arith.constant 4 : u32;
+            v286 = hir.bitcast v253 : u32;
+            v288 = arith.add v286, v354 : u32 #[overflow = checked];
+            v353 = arith.constant 4 : u32;
+            v290 = arith.mod v288, v353 : u32;
+            hir.assertz v290 #[code = 250];
+            v291 = hir.int_to_ptr v288 : ptr<byte, felt>;
+            v292 = hir.load v291 : felt;
+            v352 = arith.constant 8 : u32;
+            v293 = hir.bitcast v253 : u32;
+            v295 = arith.add v293, v352 : u32 #[overflow = checked];
+            v351 = arith.constant 4 : u32;
+            v297 = arith.mod v295, v351 : u32;
+            hir.assertz v297 #[code = 250];
+            v298 = hir.int_to_ptr v295 : ptr<byte, felt>;
+            v299 = hir.load v298 : felt;
+            v350 = arith.constant 12 : u32;
+            v300 = hir.bitcast v253 : u32;
+            v302 = arith.add v300, v350 : u32 #[overflow = checked];
+            v349 = arith.constant 4 : u32;
+            v304 = arith.mod v302, v349 : u32;
+            hir.assertz v304 #[code = 250];
+            v305 = hir.int_to_ptr v302 : ptr<byte, felt>;
+            v306 = hir.load v305 : felt;
+            v307 = hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden_base_sys::bindings::tx::extern_tx_create_note(v259, v266, v273, v280, v251, v252, v285, v292, v299, v306) : felt
+            builtin.ret v307;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {
@@ -382,15 +398,15 @@ builtin.component miden:basic-wallet/basic-wallet@1.0.0 {
         builtin.segment @1048576 = 0x00000001000000010000000100000001000000010000000100000001000000010000000100000001;
     };
 
-    public builtin.function @receive-asset(v304: felt, v305: felt, v306: felt, v307: felt) {
-    ^block32(v304: felt, v305: felt, v306: felt, v307: felt):
-        hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden:basic-wallet/basic-wallet@1.0.0#receive-asset(v304, v305, v306, v307)
+    public builtin.function @receive-asset(v308: felt, v309: felt, v310: felt, v311: felt) {
+    ^block36(v308: felt, v309: felt, v310: felt, v311: felt):
+        hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden:basic-wallet/basic-wallet@1.0.0#receive-asset(v308, v309, v310, v311)
         builtin.ret ;
     };
 
-    public builtin.function @send-asset(v308: felt, v309: felt, v310: felt, v311: felt, v312: felt, v313: felt, v314: felt, v315: felt, v316: felt, v317: felt) {
-    ^block34(v308: felt, v309: felt, v310: felt, v311: felt, v312: felt, v313: felt, v314: felt, v315: felt, v316: felt, v317: felt):
-        hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden:basic-wallet/basic-wallet@1.0.0#send-asset(v308, v309, v310, v311, v312, v313, v314, v315, v316, v317)
+    public builtin.function @send-asset(v312: felt, v313: felt, v314: felt, v315: felt, v316: felt, v317: felt, v318: felt, v319: felt, v320: felt, v321: felt) {
+    ^block38(v312: felt, v313: felt, v314: felt, v315: felt, v316: felt, v317: felt, v318: felt, v319: felt, v320: felt, v321: felt):
+        hir.exec @miden:basic-wallet/basic-wallet@1.0.0/basic_wallet/miden:basic-wallet/basic-wallet@1.0.0#send-asset(v312, v313, v314, v315, v316, v317, v318, v319, v320, v321)
         builtin.ret ;
     };
 };

--- a/tests/integration/expected/examples/basic_wallet.masm
+++ b/tests/integration/expected/examples/basic_wallet.masm
@@ -160,6 +160,14 @@ proc.miden_base_sys::bindings::account::extern_account_remove_asset
     nop
 end
 
+proc.miden_base_sys::bindings::account::extern_account_incr_nonce
+    trace.240
+    nop
+    exec.::miden::account::incr_nonce
+    trace.252
+    nop
+end
+
 proc.miden_base_sys::bindings::tx::extern_tx_create_note
     trace.240
     nop
@@ -284,6 +292,12 @@ export.miden:basic-wallet/basic-wallet@1.0.0#receive-asset
     trace.240
     nop
     exec.::miden:basic-wallet/basic-wallet@1.0.0::basic_wallet::miden_base_sys::bindings::account::add_asset
+    trace.252
+    nop
+    push.1
+    trace.240
+    nop
+    exec.::miden:basic-wallet/basic-wallet@1.0.0::basic_wallet::miden_base_sys::bindings::account::incr_nonce
     trace.252
     nop
     push.32
@@ -504,6 +518,12 @@ export.miden:basic-wallet/basic-wallet@1.0.0#send-asset
     trace.252
     nop
     drop
+    push.1
+    trace.240
+    nop
+    exec.::miden:basic-wallet/basic-wallet@1.0.0::basic_wallet::miden_base_sys::bindings::account::incr_nonce
+    trace.252
+    nop
     push.48
     u32wrapping_add
     push.1114176
@@ -734,6 +754,14 @@ proc.miden_base_sys::bindings::account::remove_asset
     trace.240
     nop
     exec.::miden:basic-wallet/basic-wallet@1.0.0::basic_wallet::miden_base_sys::bindings::account::extern_account_remove_asset
+    trace.252
+    nop
+end
+
+proc.miden_base_sys::bindings::account::incr_nonce
+    trace.240
+    nop
+    exec.::miden:basic-wallet/basic-wallet@1.0.0::basic_wallet::miden_base_sys::bindings::account::extern_account_incr_nonce
     trace.252
     nop
 end

--- a/tests/integration/expected/examples/basic_wallet.wat
+++ b/tests/integration/expected/examples/basic_wallet.wat
@@ -4,6 +4,8 @@
       (type (;0;) (func (param "asset0" f32) (param "asset1" f32) (param "asset2" f32) (param "asset3" f32) (param "result-ptr" s32)))
       (export (;0;) "add-asset" (func (type 0)))
       (export (;1;) "remove-asset" (func (type 0)))
+      (type (;1;) (func (param "value" u32)))
+      (export (;2;) "incr-nonce" (func (type 1)))
     )
   )
   (import "miden:core-base/account@1.0.0" (instance (;0;) (type 0)))
@@ -34,15 +36,17 @@
   (import "miden:base/core-types@1.0.0" (instance (;2;) (type 2)))
   (core module (;0;)
     (type (;0;) (func (param f32 f32 f32 f32 i32)))
-    (type (;1;) (func (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32) (result f32)))
-    (type (;2;) (func))
-    (type (;3;) (func (param f32 f32 f32 f32)))
-    (type (;4;) (func (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32)))
-    (type (;5;) (func (param i32 i32)))
-    (type (;6;) (func (param i32 f32 f32 i32) (result f32)))
+    (type (;1;) (func (param i32)))
+    (type (;2;) (func (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32) (result f32)))
+    (type (;3;) (func))
+    (type (;4;) (func (param f32 f32 f32 f32)))
+    (type (;5;) (func (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32)))
+    (type (;6;) (func (param i32 i32)))
+    (type (;7;) (func (param i32 f32 f32 i32) (result f32)))
     (import "miden:core-base/account@1.0.0" "add-asset" (func $miden_base_sys::bindings::account::extern_account_add_asset (;0;) (type 0)))
     (import "miden:core-base/account@1.0.0" "remove-asset" (func $miden_base_sys::bindings::account::extern_account_remove_asset (;1;) (type 0)))
-    (import "miden:core-base/tx@1.0.0" "create-note" (func $miden_base_sys::bindings::tx::extern_tx_create_note (;2;) (type 1)))
+    (import "miden:core-base/account@1.0.0" "incr-nonce" (func $miden_base_sys::bindings::account::extern_account_incr_nonce (;2;) (type 1)))
+    (import "miden:core-base/tx@1.0.0" "create-note" (func $miden_base_sys::bindings::tx::extern_tx_create_note (;3;) (type 2)))
     (table (;0;) 2 2 funcref)
     (memory (;0;) 17)
     (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
@@ -51,9 +55,9 @@
     (export "miden:basic-wallet/basic-wallet@1.0.0#receive-asset" (func $miden:basic-wallet/basic-wallet@1.0.0#receive-asset))
     (export "miden:basic-wallet/basic-wallet@1.0.0#send-asset" (func $miden:basic-wallet/basic-wallet@1.0.0#send-asset))
     (elem (;0;) (i32.const 1) func $basic_wallet::bindings::__link_custom_section_describing_imports)
-    (func $__wasm_call_ctors (;3;) (type 2))
-    (func $basic_wallet::bindings::__link_custom_section_describing_imports (;4;) (type 2))
-    (func $miden:basic-wallet/basic-wallet@1.0.0#receive-asset (;5;) (type 3) (param f32 f32 f32 f32)
+    (func $__wasm_call_ctors (;4;) (type 3))
+    (func $basic_wallet::bindings::__link_custom_section_describing_imports (;5;) (type 3))
+    (func $miden:basic-wallet/basic-wallet@1.0.0#receive-asset (;6;) (type 4) (param f32 f32 f32 f32)
       (local i32)
       global.get $__stack_pointer
       i32.const 32
@@ -78,12 +82,14 @@
       i32.add
       local.get 4
       call $miden_base_sys::bindings::account::add_asset
+      i32.const 1
+      call $miden_base_sys::bindings::account::incr_nonce
       local.get 4
       i32.const 32
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden:basic-wallet/basic-wallet@1.0.0#send-asset (;6;) (type 4) (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32)
+    (func $miden:basic-wallet/basic-wallet@1.0.0#send-asset (;7;) (type 5) (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32)
       (local i32)
       global.get $__stack_pointer
       i32.const 48
@@ -130,12 +136,14 @@
       i32.add
       call $miden_base_sys::bindings::tx::create_note
       drop
+      i32.const 1
+      call $miden_base_sys::bindings::account::incr_nonce
       local.get 10
       i32.const 48
       i32.add
       global.set $__stack_pointer
     )
-    (func $wit_bindgen_rt::run_ctors_once (;7;) (type 2)
+    (func $wit_bindgen_rt::run_ctors_once (;8;) (type 3)
       (local i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
@@ -153,7 +161,7 @@
         i32.store8
       end
     )
-    (func $miden_base_sys::bindings::account::add_asset (;8;) (type 5) (param i32 i32)
+    (func $miden_base_sys::bindings::account::add_asset (;9;) (type 6) (param i32 i32)
       local.get 1
       f32.load
       local.get 1
@@ -165,7 +173,7 @@
       local.get 0
       call $miden_base_sys::bindings::account::extern_account_add_asset
     )
-    (func $miden_base_sys::bindings::account::remove_asset (;9;) (type 5) (param i32 i32)
+    (func $miden_base_sys::bindings::account::remove_asset (;10;) (type 6) (param i32 i32)
       local.get 1
       f32.load
       local.get 1
@@ -177,7 +185,11 @@
       local.get 0
       call $miden_base_sys::bindings::account::extern_account_remove_asset
     )
-    (func $miden_base_sys::bindings::tx::create_note (;10;) (type 6) (param i32 f32 f32 i32) (result f32)
+    (func $miden_base_sys::bindings::account::incr_nonce (;11;) (type 1) (param i32)
+      local.get 0
+      call $miden_base_sys::bindings::account::extern_account_incr_nonce
+    )
+    (func $miden_base_sys::bindings::tx::create_note (;12;) (type 7) (param i32 f32 f32 i32) (result f32)
       local.get 0
       f32.load
       local.get 0
@@ -210,14 +222,17 @@
   (core func (;0;) (canon lower (func 0)))
   (alias export 0 "remove-asset" (func (;1;)))
   (core func (;1;) (canon lower (func 1)))
+  (alias export 0 "incr-nonce" (func (;2;)))
+  (core func (;2;) (canon lower (func 2)))
   (core instance (;0;)
     (export "add-asset" (func 0))
     (export "remove-asset" (func 1))
+    (export "incr-nonce" (func 2))
   )
-  (alias export 1 "create-note" (func (;2;)))
-  (core func (;2;) (canon lower (func 2)))
+  (alias export 1 "create-note" (func (;3;)))
+  (core func (;3;) (canon lower (func 3)))
   (core instance (;1;)
-    (export "create-note" (func 2))
+    (export "create-note" (func 3))
   )
   (core instance (;2;) (instantiate 0
       (with "miden:core-base/account@1.0.0" (instance 0))
@@ -226,11 +241,11 @@
   )
   (alias core export 2 "memory" (core memory (;0;)))
   (type (;8;) (func (param "asset" 3)))
-  (alias core export 2 "miden:basic-wallet/basic-wallet@1.0.0#receive-asset" (core func (;3;)))
-  (func (;3;) (type 8) (canon lift (core func 3)))
+  (alias core export 2 "miden:basic-wallet/basic-wallet@1.0.0#receive-asset" (core func (;4;)))
+  (func (;4;) (type 8) (canon lift (core func 4)))
   (type (;9;) (func (param "core-asset" 3) (param "tag" 4) (param "note-type" 6) (param "recipient" 5)))
-  (alias core export 2 "miden:basic-wallet/basic-wallet@1.0.0#send-asset" (core func (;4;)))
-  (func (;4;) (type 9) (canon lift (core func 4)))
+  (alias core export 2 "miden:basic-wallet/basic-wallet@1.0.0#send-asset" (core func (;5;)))
+  (func (;5;) (type 9) (canon lift (core func 5)))
   (alias export 2 "felt" (type (;10;)))
   (alias export 2 "word" (type (;11;)))
   (alias export 2 "asset" (type (;12;)))
@@ -270,8 +285,8 @@
     (export (;3;) "send-asset" (func 1) (func (type 25)))
   )
   (instance (;3;) (instantiate 0
-      (with "import-func-receive-asset" (func 3))
-      (with "import-func-send-asset" (func 4))
+      (with "import-func-receive-asset" (func 4))
+      (with "import-func-send-asset" (func 5))
       (with "import-type-felt" (type 10))
       (with "import-type-word" (type 11))
       (with "import-type-asset" (type 12))


### PR DESCRIPTION
Close #617 

**This PR is stacked on the #619 and should be merged after it**