### PR TITLE
docs: update toolchain version in documentations

### DIFF
--- a/docs/src/usage/cargo-miden.md
+++ b/docs/src/usage/cargo-miden.md
@@ -11,7 +11,7 @@ a template to spin up a new Miden project in Rust, and takes care of orchestrati
 > make sure you have it installed first:
 >
 > ```bash
-> rustup toolchain install nightly-2025-03-20
+> rustup toolchain install nightly-2025-07-20
 > ```
 >
 > NOTE: You can also use the latest nightly, but the specific nightly shown here is known to

--- a/docs/src/usage/midenc.md
+++ b/docs/src/usage/midenc.md
@@ -17,7 +17,7 @@ hands dirty.
 > make sure you have it installed first:
 >
 > ```bash
-> rustup toolchain install nightly-2025-03-20
+> rustup toolchain install nightly-2025-07-20
 > ```
 >
 > NOTE: You can also use the latest nightly, but the specific nightly shown here is known to

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,7 @@
 [toolchain]
+# REMINDER: After updating the channel, update:
+# - docs/src/usage/cargo-miden.md
+# - docs/src/usage/midenc.md
 channel = "nightly-2025-07-20"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip2"]


### PR DESCRIPTION
Reading the [miden compiler documenation](https://0xmiden.github.io/compiler/), there is a warning message stating that the compiler uses an older rust version from the one it really uses.
This PR updates the documentation and adds a small "reminder" in `rust-toolchain.toml`.