### PR TITLE
fix: HEAP_END to represent the Miden limit in the Rust address space

### DIFF
--- a/sdk/alloc/src/lib.rs
+++ b/sdk/alloc/src/lib.rs
@@ -16,9 +16,11 @@ const PAGE_SIZE: usize = 2usize.pow(16);
 /// We require all allocations to be minimally word-aligned, i.e. 16 byte alignment
 const MIN_ALIGN: usize = 16;
 
-/// The linear memory heap must not spill over into the region reserved for procedure
-/// locals, which begins at 2^30 in Miden's address space.
-const HEAP_END: *mut u8 = (2usize.pow(30) / 4) as *mut u8;
+/// The linear memory heap must not spill over into the region reserved for procedure locals, which
+/// begins at 2^30 in Miden's address space. In Rust address space it should be 2^30 * 4 but since
+/// it overflows the usize which is 32-bit on wasm32 we use u32::MAX. "-1" is to avoid `xor` op in
+/// the compiled Wasm.
+const HEAP_END: *mut u8 = (u32::MAX - 1) as *mut u8;
 
 /// A very simple allocator for Miden SDK-based programs.
 ///

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
@@ -289,7 +289,7 @@ builtin.component root_ns:root@1.0.0 {
                     v191 = hir.load v190 : i32;
                     v733 = arith.constant 0 : i32;
                     v195 = hir.bitcast v166 : u32;
-                    v185 = arith.constant 268435456 : i32;
+                    v185 = arith.constant -2 : i32;
                     v192 = arith.sub v185, v191 : i32 #[overflow = wrapping];
                     v194 = hir.bitcast v192 : u32;
                     v196 = arith.lt v194, v195 : i1;

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -490,7 +490,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             nop
             push.0
             dup.2
-            push.268435456
+            push.4294967294
             dup.3
             u32wrapping_sub
             swap.1

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
@@ -167,7 +167,7 @@
         i32.store
       end
       block ;; label = @2
-        i32.const 268435456
+        i32.const -2
         local.get 0
         i32.load
         local.tee 4

--- a/tests/integration/expected/examples/p2id.hir
+++ b/tests/integration/expected/examples/p2id.hir
@@ -433,7 +433,7 @@ builtin.component miden:base/note-script@1.0.0 {
                     v289 = hir.load v288 : i32;
                     v1008 = arith.constant 0 : i32;
                     v293 = hir.bitcast v264 : u32;
-                    v283 = arith.constant 268435456 : i32;
+                    v283 = arith.constant -2 : i32;
                     v290 = arith.sub v283, v289 : i32 #[overflow = wrapping];
                     v292 = hir.bitcast v290 : u32;
                     v294 = arith.lt v292, v293 : i1;

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -876,7 +876,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             nop
             push.0
             dup.2
-            push.268435456
+            push.4294967294
             dup.3
             u32wrapping_sub
             swap.1

--- a/tests/integration/expected/examples/p2id.wat
+++ b/tests/integration/expected/examples/p2id.wat
@@ -283,7 +283,7 @@
           i32.store
         end
         block ;; label = @2
-          i32.const 268435456
+          i32.const -2
           local.get 0
           i32.load
           local.tee 4

--- a/tests/integration/expected/mem_intrinsics_heap_base.hir
+++ b/tests/integration/expected/mem_intrinsics_heap_base.hir
@@ -140,7 +140,7 @@ builtin.component root_ns:root@1.0.0 {
                     v101 = hir.load v100 : i32;
                     v172 = arith.constant 0 : i32;
                     v105 = hir.bitcast v76 : u32;
-                    v95 = arith.constant 268435456 : i32;
+                    v95 = arith.constant -2 : i32;
                     v102 = arith.sub v95, v101 : i32 #[overflow = wrapping];
                     v104 = hir.bitcast v102 : u32;
                     v106 = arith.lt v104, v105 : i1;

--- a/tests/integration/expected/mem_intrinsics_heap_base.wat
+++ b/tests/integration/expected/mem_intrinsics_heap_base.wat
@@ -97,7 +97,7 @@
         i32.store
       end
       block ;; label = @2
-        i32.const 268435456
+        i32.const -2
         local.get 0
         i32.load
         local.tee 4

--- a/tests/integration/expected/vec_alloc_vec.hir
+++ b/tests/integration/expected/vec_alloc_vec.hir
@@ -225,7 +225,7 @@ builtin.component root_ns:root@1.0.0 {
                     v158 = hir.load v157 : i32;
                     v367 = arith.constant 0 : i32;
                     v162 = hir.bitcast v133 : u32;
-                    v152 = arith.constant 268435456 : i32;
+                    v152 = arith.constant -2 : i32;
                     v159 = arith.sub v152, v158 : i32 #[overflow = wrapping];
                     v161 = hir.bitcast v159 : u32;
                     v163 = arith.lt v161, v162 : i1;

--- a/tests/integration/expected/vec_alloc_vec.masm
+++ b/tests/integration/expected/vec_alloc_vec.masm
@@ -400,7 +400,7 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             nop
             push.0
             dup.2
-            push.268435456
+            push.4294967294
             dup.3
             u32wrapping_sub
             swap.1

--- a/tests/integration/expected/vec_alloc_vec.wat
+++ b/tests/integration/expected/vec_alloc_vec.wat
@@ -144,7 +144,7 @@
         i32.store
       end
       block ;; label = @2
-        i32.const 268435456
+        i32.const -2
         local.get 0
         i32.load
         local.tee 4


### PR DESCRIPTION
The linear memory heap must not spill over into the region reserved for procedure locals, which begins at `2^30` in Miden's address space. In Rust address space it should be `2^30 * 4` but since it overflows the usize which is 32-bit on wasm32 we use `u32::MAX`. "-1" is to avoid `xor` op in the compiled Wasm.