### PR TITLE
fix: remove intrinsics exports from compiled MASM library

### DIFF
--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -292,6 +292,18 @@ impl MasmComponent {
 
         let converted_exports = recover_wasm_cm_interfaces(&lib);
 
+        // Workaround until https://github.com/0xMiden/compiler/issues/637 is fixed
+        let exports_wo_intrinsics = converted_exports
+            .into_iter()
+            .flat_map(|(name, node_id)| {
+                if name.to_string().starts_with("intrinsics") {
+                    None
+                } else {
+                    Some((name, node_id))
+                }
+            })
+            .collect();
+
         // Get a reference to the library MAST, then drop the library so we can obtain a mutable
         // reference so we can modify its advice map data
         let mut mast_forest = lib.mast_forest().clone();
@@ -302,7 +314,7 @@ impl MasmComponent {
         }
 
         // Reconstruct the library with the updated MAST
-        Ok(Library::new(mast_forest, converted_exports).map(Arc::new)?)
+        Ok(Library::new(mast_forest, exports_wo_intrinsics).map(Arc::new)?)
     }
 
     /// Generate an executable module which when run expects the raw data segment data to be

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -50,14 +50,12 @@ fn rust_sdk_cross_ctx_account_and_note() {
     test.expect_masm(expect_file![format!("../../expected/rust_sdk/cross_ctx_account.masm")]);
     let account_package = test.compiled_package();
     let lib = account_package.unwrap_library();
+    assert!(
+        !lib.exports().any(|export| { export.to_string().starts_with("intrinsics") }),
+        "expected no intrinsics in the exports"
+    );
     let expected_module = "miden:cross-ctx-account/foo@1.0.0";
     let expected_function = "process-felt";
-    let exports = lib
-        .exports()
-        .filter(|e| !e.module.to_string().starts_with("intrinsics"))
-        .map(|e| format!("{}::{}", e.module, e.name.as_str()))
-        .collect::<Vec<_>>();
-    dbg!(&exports);
     assert!(
         lib.exports().any(|export| {
             export.module.to_string() == expected_module


### PR DESCRIPTION
Close #637 

Pass intrinsics modules to the assembler via `Assembler::add_module`.