### PR TITLE
fix: draft cargo-miden support (disabled for now) for building the crate which is included in the workspace

### DIFF
--- a/tools/cargo-miden/src/target.rs
+++ b/tools/cargo-miden/src/target.rs
@@ -5,13 +5,11 @@ use std::{
 };
 
 use anyhow::{bail, Result};
+use cargo_metadata::Package;
 use midenc_session::{ProjectType, RollupTarget, TargetEnv};
 
 /// Detects the target environment based on Cargo metadata.
-pub fn detect_target_environment(metadata: &cargo_metadata::Metadata) -> Result<TargetEnv> {
-    let Some(root_pkg) = metadata.root_package() else {
-        return Ok(TargetEnv::Base);
-    };
+pub fn detect_target_environment(root_pkg: &Package) -> Result<TargetEnv> {
     let Some(meta_obj) = root_pkg.metadata.as_object() else {
         return Ok(TargetEnv::Base);
     };
@@ -70,8 +68,8 @@ pub fn target_environment_to_project_type(target_env: TargetEnv) -> ProjectType 
 }
 
 /// Detect the project type
-pub fn detect_project_type(metadata: &cargo_metadata::Metadata) -> Result<ProjectType> {
-    let target_env = detect_target_environment(metadata)?;
+pub fn detect_project_type(root_pkg: &Package) -> Result<ProjectType> {
+    let target_env = detect_target_environment(root_pkg)?;
     Ok(target_environment_to_project_type(target_env))
 }
 

--- a/tools/cargo-miden/tests/mod.rs
+++ b/tools/cargo-miden/tests/mod.rs
@@ -1,3 +1,4 @@
 mod build;
 mod project_type;
 mod utils;
+mod workspace;

--- a/tools/cargo-miden/tests/project_type.rs
+++ b/tools/cargo-miden/tests/project_type.rs
@@ -60,8 +60,9 @@ fn test_project_type_detection() {
                 )
             });
 
-        // Test target environment detection
-        let detected_env = cargo_miden::detect_target_environment(&metadata).unwrap_or_else(|e| {
+        // Determine root package and test target environment detection
+        let root_pkg = metadata.root_package().expect("example metadata missing root package");
+        let detected_env = cargo_miden::detect_target_environment(root_pkg).unwrap_or_else(|e| {
             panic!(
                 "Failed to detect target environment for {}: {}",
                 example_manifest_path.display(),
@@ -80,7 +81,7 @@ fn test_project_type_detection() {
         );
 
         // Test project type detection
-        let detected_type = cargo_miden::detect_project_type(&metadata).unwrap_or_else(|e| {
+        let detected_type = cargo_miden::detect_project_type(root_pkg).unwrap_or_else(|e| {
             panic!("Failed to detect project type for {}: {}", example_manifest_path.display(), e)
         });
         assert_eq!(

--- a/tools/cargo-miden/tests/workspace.rs
+++ b/tools/cargo-miden/tests/workspace.rs
@@ -1,0 +1,135 @@
+use std::{env, fs, path::Path};
+
+use cargo_miden::{run, OutputType};
+
+/// Creates a minimal Cargo workspace at `root` with a single member named `member_name`.
+fn write_workspace_root(root: &Path, member_name: &str) {
+    let ws_toml = format!(
+        r#"[workspace]
+resolver = "2"
+members = ["{member_name}"]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+authors = ["Miden Contributors"]
+license = "MIT"
+repository = "https://example.com/test"
+"#
+    );
+    fs::write(root.join("Cargo.toml"), ws_toml).expect("write workspace Cargo.toml");
+}
+
+fn new_project_args(project_name: &str, template: &str) -> Vec<String> {
+    let template = if let Ok(templates_path) = std::env::var("TEST_LOCAL_TEMPLATES_PATH") {
+        &format!("--template-path={templates_path}/{}", template.trim_start_matches("--"))
+    } else {
+        template
+    };
+    ["cargo", "miden", "new", project_name, template]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn build_workspace_member_account_project() {
+    let _ = env_logger::Builder::from_env("MIDENC_TRACE")
+        .is_test(true)
+        .format_timestamp(None)
+        .try_init();
+    // signal integration tests to the cargo-miden code path
+    env::set_var("TEST", "1");
+
+    // create temp workspace root
+    let restore_dir = env::current_dir().unwrap();
+    let ws_root = env::temp_dir().join(format!(
+        "cargo_miden_ws_test_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    if ws_root.exists() {
+        fs::remove_dir_all(&ws_root).unwrap();
+    }
+    fs::create_dir_all(&ws_root).unwrap();
+    env::set_current_dir(&ws_root).unwrap();
+
+    // write workspace manifest
+    let member_name = "member_account";
+    write_workspace_root(&ws_root, member_name);
+
+    // create account project as a workspace member
+    let output = run(new_project_args(member_name, "--account").into_iter(), OutputType::Masm)
+        .expect("cargo miden new failed")
+        .expect("expected NewCommandOutput");
+    let project_path = match output {
+        cargo_miden::CommandOutput::NewCommandOutput { project_path } => project_path,
+        other => panic!("Expected NewCommandOutput, got {other:?}"),
+    };
+    assert!(project_path.ends_with(member_name));
+
+    // change into the member directory and try to build using cargo-miden
+    env::set_current_dir(&project_path).unwrap();
+    // see https://github.com/0xMiden/compiler/issues/648
+    let err = run(["cargo", "miden", "build"].into_iter().map(|s| s.to_string()), OutputType::Masm)
+        .expect_err("expected workspace member build to be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("part of a Cargo workspace"), "unexpected error: {msg}");
+
+    // cleanup
+    env::set_current_dir(restore_dir).unwrap();
+    fs::remove_dir_all(ws_root).unwrap();
+}
+
+#[test]
+fn build_from_workspace_root_is_rejected() {
+    let _ = env_logger::Builder::from_env("MIDENC_TRACE")
+        .is_test(true)
+        .format_timestamp(None)
+        .try_init();
+    env::set_var("TEST", "1");
+
+    // create temp workspace root
+    let restore_dir = env::current_dir().unwrap();
+    let ws_root = env::temp_dir().join(format!(
+        "cargo_miden_ws_root_test_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    if ws_root.exists() {
+        fs::remove_dir_all(&ws_root).unwrap();
+    }
+    fs::create_dir_all(&ws_root).unwrap();
+    env::set_current_dir(&ws_root).unwrap();
+
+    // write workspace manifest and scaffold a member
+    let member_name = "member_account";
+    write_workspace_root(&ws_root, member_name);
+    let _ = run(
+        ["cargo", "miden", "new", member_name, "--account"]
+            .into_iter()
+            .map(|s| s.to_string()),
+        OutputType::Masm,
+    )
+    .expect("cargo miden new failed")
+    .expect("expected NewCommandOutput");
+
+    // Run cargo miden build at the workspace root without selecting a package
+    env::set_current_dir(&ws_root).unwrap();
+    let err = run(["cargo", "miden", "build"].into_iter().map(|s| s.to_string()), OutputType::Masm)
+        .expect_err("expected workspace root build to be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("workspace root") && msg.contains("Build a single member"),
+        "unexpected error message: {msg}"
+    );
+
+    // cleanup
+    env::set_current_dir(restore_dir).unwrap();
+    fs::remove_dir_all(ws_root).unwrap();
+}


### PR DESCRIPTION
Ref #648 

This PR adds `cargo-miden` support to build the crate, which is a part of the workspace but it is disabled for now. 

Unfortunately,`cargo` ignores profiles defined in the Cargo.toml in the individual crate and expects them to be defined in the workspace Cargo.toml file. We end up with the default release/dev profile with all the panic machinery, etc. which cannot compile yet.
We should move our profile definitions to `.cargo/config.toml` and rewrite the `cargo-miden` and our test harness to not use the `--manifest-path` but change the current directory to the crate we're compiling and run `cargo` there.

For now we throw an error if the user tries to build a crate that is included in the workspace with the tips (move the crate out of the workspace or delete the workspace Cargo.toml).