### PR TITLE
Fix and publish the rest of the v0.4.1 crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,6 @@ jobs:
         run: |
           rustup update --no-self-update
           rustc --version
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/next' }}
       - name: Publish
         uses: release-plz/action@v0.5
         with:

--- a/codegen/masm/Cargo.toml
+++ b/codegen/masm/Cargo.toml
@@ -37,6 +37,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-midenc-expect-test.workspace = true
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
+midenc-expect-test = { path = "../../tools/expect-test" }
 proptest.workspace = true
 env_logger.workspace = true

--- a/dialects/hir/Cargo.toml
+++ b/dialects/hir/Cargo.toml
@@ -24,6 +24,7 @@ midenc-hir-analysis.workspace = true
 midenc-hir-transform.workspace = true
 
 [dev-dependencies]
-midenc-expect-test.workspace = true
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
+midenc-dialect-scf = { path = "../scf" }
+midenc-expect-test = { path = "../../tools/expect-test" }
 env_logger.workspace = true
-midenc-dialect-scf.workspace = true

--- a/dialects/scf/Cargo.toml
+++ b/dialects/scf/Cargo.toml
@@ -25,5 +25,6 @@ midenc-hir-transform.workspace = true
 bitvec.workspace = true
 
 [dev-dependencies]
-midenc-expect-test.workspace = true
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
+midenc-expect-test = { path = "../../tools/expect-test" }
 env_logger.workspace = true

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -34,5 +34,6 @@ thiserror.workspace = true
 wasmparser.workspace = true
 
 [dev-dependencies]
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
 wat.workspace = true
-midenc-expect-test.workspace = true
+midenc-expect-test = { path = "../../tools/expect-test" }

--- a/hir-analysis/Cargo.toml
+++ b/hir-analysis/Cargo.toml
@@ -23,5 +23,5 @@ midenc-dialect-hir = { path = "../dialects/hir" }
 midenc-dialect-arith = { path = "../dialects/arith" }
 midenc-dialect-cf = { path = "../dialects/cf" }
 midenc-dialect-scf = { path = "../dialects/scf" }
-midenc-expect-test.workspace = true
+midenc-expect-test = { path = "../tools/expect-test" }
 env_logger.workspace = true

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -39,5 +39,6 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
 pretty_assertions = "1.0"
 env_logger.workspace = true

--- a/sdk/base-macros/Cargo.toml
+++ b/sdk/base-macros/Cargo.toml
@@ -23,4 +23,5 @@ toml.workspace = true
 syn.workspace = true
 
 [dev-dependencies]
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
 miden-objects = { workspace = true, features = ["std"] }

--- a/tests/integration-node/Cargo.toml
+++ b/tests/integration-node/Cargo.toml
@@ -35,4 +35,5 @@ uuid = { version = "1.10", features = ["v4"] }
 miden-integration-tests = { path = "../integration" }
 
 [dev-dependencies]
-midenc-expect-test.workspace = true
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
+midenc-expect-test = { path = "../../tools/expect-test" }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -44,6 +44,7 @@ tokio.workspace = true
 walkdir = "2.5.0"
 
 [dev-dependencies]
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
 blake3 = "1.5"
 concat-idents = "1.1"
 

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -76,4 +76,5 @@ features = [
 ]
 
 [dev-dependencies]
+# Use local paths for dev-only dependency to avoid relying on crates.io during packaging
 miden-mast-package.workspace = true


### PR DESCRIPTION
This PR fixes:

1. Using our crates in `dev-dependencies` with only `path` specified. Fixes https://github.com/0xMiden/compiler/actions/runs/17444451785/job/49563651241 error.
Since `release-plz` does not consider dev-dependencies when computing the publish order the publishing will fail for a crate that has a not-yet-published crate version in the dev-dependencies.

2. Removes rust-cache for the `release-plz` CI job.
Apparently, `gix` fails if the registry index is present. See failed https://github.com/0xMiden/compiler/actions/runs/17444451785/job/49535289715

**After merging this PR, the CI job will publish all the unpublished crates.**
