### PR TITLE
feat: enable `==` operator for `AccountId` type

### DIFF
--- a/examples/p2id-note/src/lib.rs
+++ b/examples/p2id-note/src/lib.rs
@@ -27,9 +27,11 @@ fn run(_arg: Word) {
     let inputs = note::get_inputs();
     let target_account_id_prefix = inputs[0];
     let target_account_id_suffix = inputs[1];
-    let account_id = account::get_id();
-    assert_eq(account_id.prefix, target_account_id_prefix);
-    assert_eq(account_id.suffix, target_account_id_suffix);
+
+    let target_account = AccountId::from(target_account_id_prefix, target_account_id_suffix);
+    let current_account = account::get_id();
+    assert_eq!(current_account, target_account);
+
     let assets = note::get_assets();
     for asset in assets {
         receive_asset(asset);

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -1,13 +1,18 @@
 use miden_stdlib_sys::{Felt, Word};
 
 #[allow(unused)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AccountId {
     pub prefix: Felt,
     pub suffix: Felt,
 }
 
-impl AccountId {}
+impl AccountId {
+    /// Creates a new AccountId from prefix and suffix Felt values
+    pub fn from(prefix: Felt, suffix: Felt) -> Self {
+        Self { prefix, suffix }
+    }
+}
 
 #[derive(Clone)]
 #[repr(transparent)]

--- a/tests/integration/expected/examples/p2id.hir
+++ b/tests/integration/expected/examples/p2id.hir
@@ -35,33 +35,33 @@ builtin.component miden:base/note-script@1.0.0 {
             v22 = arith.constant 1048664 : i32;
             v23 = arith.add v21, v22 : i32 #[overflow = wrapping];
             v24 = hir.exec @miden:base/note-script@1.0.0/p2id/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v23, v17, v16) : i32
-            v859 = arith.constant 0 : i32;
+            v876 = arith.constant 0 : i32;
             v25 = arith.constant 0 : i32;
             v26 = arith.eq v24, v25 : i1;
             v27 = arith.zext v26 : u32;
             v28 = hir.bitcast v27 : i32;
-            v30 = arith.neq v28, v859 : i1;
+            v30 = arith.neq v28, v876 : i1;
             scf.if v30{
             ^block16:
                 scf.yield ;
             } else {
             ^block17:
-                v857 = arith.constant 0 : i32;
-                v858 = arith.constant 0 : i32;
-                v32 = arith.eq v16, v858 : i1;
+                v874 = arith.constant 0 : i32;
+                v875 = arith.constant 0 : i32;
+                v32 = arith.eq v16, v875 : i1;
                 v33 = arith.zext v32 : u32;
                 v34 = hir.bitcast v33 : i32;
-                v36 = arith.neq v34, v857 : i1;
+                v36 = arith.neq v34, v874 : i1;
                 scf.if v36{
-                ^block110:
+                ^block112:
                     scf.yield ;
                 } else {
                 ^block18:
-                    v851 = arith.constant 0 : u8;
+                    v868 = arith.constant 0 : u8;
                     v39 = hir.bitcast v16 : u32;
                     v40 = hir.bitcast v24 : u32;
                     v41 = hir.int_to_ptr v40 : ptr<byte, u8>;
-                    hir.mem_set v41, v39, v851;
+                    hir.mem_set v41, v39, v868;
                     scf.yield ;
                 };
                 scf.yield ;
@@ -97,38 +97,38 @@ builtin.component miden:base/note-script@1.0.0 {
             v64 = hir.int_to_ptr v61 : ptr<byte, i32>;
             v65 = hir.load v64 : i32;
             v66 = hir.cast v65 : u32;
-            v916 = scf.index_switch v66 : u32 
+            v934 = scf.index_switch v66 : u32 
             case 0 {
-            ^block113:
-                v956 = arith.constant 1 : u32;
-                scf.yield v956;
+            ^block117:
+                v978 = arith.constant 1 : u32;
+                scf.yield v978;
             }
             case 1 {
-            ^block114:
-                v955 = arith.constant 1 : u32;
-                scf.yield v955;
+            ^block118:
+                v977 = arith.constant 1 : u32;
+                scf.yield v977;
             }
             default {
-            ^block23:
+            ^block24:
                 v68 = arith.constant 20 : u32;
                 v67 = hir.bitcast v54 : u32;
                 v69 = arith.add v67, v68 : u32 #[overflow = checked];
-                v984 = arith.constant 4 : u32;
-                v71 = arith.mod v69, v984 : u32;
+                v1011 = arith.constant 4 : u32;
+                v71 = arith.mod v69, v1011 : u32;
                 hir.assertz v71 #[code = 250];
                 v72 = hir.int_to_ptr v69 : ptr<byte, i32>;
                 v73 = hir.load v72 : i32;
-                v983 = arith.constant 4 : u32;
+                v1010 = arith.constant 4 : u32;
                 v74 = hir.bitcast v73 : u32;
-                v76 = arith.add v74, v983 : u32 #[overflow = checked];
-                v982 = arith.constant 4 : u32;
-                v78 = arith.mod v76, v982 : u32;
+                v76 = arith.add v74, v1010 : u32 #[overflow = checked];
+                v1009 = arith.constant 4 : u32;
+                v78 = arith.mod v76, v1009 : u32;
                 hir.assertz v78 #[code = 250];
                 v79 = hir.int_to_ptr v76 : ptr<byte, felt>;
                 v80 = hir.load v79 : felt;
                 v81 = hir.bitcast v73 : u32;
-                v981 = arith.constant 4 : u32;
-                v83 = arith.mod v81, v981 : u32;
+                v1008 = arith.constant 4 : u32;
+                v83 = arith.mod v81, v1008 : u32;
                 hir.assertz v83 #[code = 250];
                 v84 = hir.int_to_ptr v81 : ptr<byte, felt>;
                 v85 = hir.load v84 : felt;
@@ -138,1075 +138,1105 @@ builtin.component miden:base/note-script@1.0.0 {
                 v89 = arith.constant 12 : u32;
                 v88 = hir.bitcast v54 : u32;
                 v90 = arith.add v88, v89 : u32 #[overflow = checked];
-                v980 = arith.constant 4 : u32;
-                v92 = arith.mod v90, v980 : u32;
+                v1007 = arith.constant 4 : u32;
+                v92 = arith.mod v90, v1007 : u32;
                 hir.assertz v92 #[code = 250];
                 v93 = hir.int_to_ptr v90 : ptr<byte, felt>;
                 v94 = hir.load v93 : felt;
                 v96 = arith.constant 8 : u32;
                 v95 = hir.bitcast v54 : u32;
                 v97 = arith.add v95, v96 : u32 #[overflow = checked];
-                v979 = arith.constant 4 : u32;
-                v99 = arith.mod v97, v979 : u32;
+                v1006 = arith.constant 4 : u32;
+                v99 = arith.mod v97, v1006 : u32;
                 hir.assertz v99 #[code = 250];
                 v100 = hir.int_to_ptr v97 : ptr<byte, felt>;
                 v101 = hir.load v100 : felt;
-                hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::felt::assert_eq(v101, v85)
-                hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::felt::assert_eq(v94, v80)
-                v102 = arith.constant 28 : i32;
-                v103 = arith.add v54, v102 : i32 #[overflow = wrapping];
-                hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::get_assets(v103)
-                v105 = arith.constant 36 : u32;
-                v104 = hir.bitcast v54 : u32;
-                v106 = arith.add v104, v105 : u32 #[overflow = checked];
-                v978 = arith.constant 4 : u32;
-                v108 = arith.mod v106, v978 : u32;
-                hir.assertz v108 #[code = 250];
-                v109 = hir.int_to_ptr v106 : ptr<byte, i32>;
-                v110 = hir.load v109 : i32;
-                v115 = arith.constant 28 : u32;
-                v114 = hir.bitcast v54 : u32;
-                v116 = arith.add v114, v115 : u32 #[overflow = checked];
-                v977 = arith.constant 4 : u32;
-                v118 = arith.mod v116, v977 : u32;
-                hir.assertz v118 #[code = 250];
-                v119 = hir.int_to_ptr v116 : ptr<byte, i32>;
-                v120 = hir.load v119 : i32;
-                v122 = arith.constant 32 : u32;
-                v121 = hir.bitcast v54 : u32;
-                v123 = arith.add v121, v122 : u32 #[overflow = checked];
-                v976 = arith.constant 4 : u32;
-                v125 = arith.mod v123, v976 : u32;
-                hir.assertz v125 #[code = 250];
-                v126 = hir.int_to_ptr v123 : ptr<byte, i32>;
-                v127 = hir.load v126 : i32;
-                v975 = arith.constant 4 : u32;
-                v113 = arith.shl v110, v975 : i32;
-                v933, v934, v935, v936, v937, v938, v939, v940 = scf.while v113, v127, v54, v127, v120 : i32, i32, i32, i32, i32, i32, i32, i32 {
-                ^block124(v941: i32, v942: i32, v943: i32, v944: i32, v945: i32):
-                    v974 = arith.constant 0 : i32;
-                    v47 = arith.constant 0 : i32;
-                    v130 = arith.eq v941, v47 : i1;
-                    v131 = arith.zext v130 : u32;
-                    v132 = hir.bitcast v131 : i32;
-                    v134 = arith.neq v132, v974 : i1;
-                    v926, v927 = scf.if v134 : i32, i32 {
-                    ^block123:
-                        v870 = ub.poison i32 : i32;
-                        scf.yield v870, v870;
+                v102 = hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::felt::eq(v101, v85) : i32
+                v47 = arith.constant 0 : i32;
+                v103 = arith.constant 1 : i32;
+                v104 = arith.neq v102, v103 : i1;
+                v105 = arith.zext v104 : u32;
+                v106 = hir.bitcast v105 : i32;
+                v108 = arith.neq v106, v47 : i1;
+                v936 = scf.if v108 : u32 {
+                ^block116:
+                    v886 = arith.constant 1 : u32;
+                    scf.yield v886;
+                } else {
+                ^block25:
+                    v109 = hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::felt::eq(v94, v80) : i32
+                    v1004 = arith.constant 0 : i32;
+                    v1005 = arith.constant 1 : i32;
+                    v111 = arith.neq v109, v1005 : i1;
+                    v112 = arith.zext v111 : u32;
+                    v113 = hir.bitcast v112 : i32;
+                    v115 = arith.neq v113, v1004 : i1;
+                    scf.if v115{
+                    ^block115:
+                        scf.yield ;
                     } else {
-                    ^block28:
-                        v136 = hir.bitcast v942 : u32;
-                        v973 = arith.constant 4 : u32;
-                        v138 = arith.mod v136, v973 : u32;
-                        hir.assertz v138 #[code = 250];
-                        v139 = hir.int_to_ptr v136 : ptr<byte, felt>;
-                        v140 = hir.load v139 : felt;
-                        v972 = arith.constant 4 : u32;
-                        v141 = hir.bitcast v942 : u32;
-                        v143 = arith.add v141, v972 : u32 #[overflow = checked];
-                        v971 = arith.constant 4 : u32;
-                        v145 = arith.mod v143, v971 : u32;
-                        hir.assertz v145 #[code = 250];
-                        v146 = hir.int_to_ptr v143 : ptr<byte, felt>;
-                        v147 = hir.load v146 : felt;
-                        v970 = arith.constant 8 : u32;
-                        v148 = hir.bitcast v942 : u32;
-                        v150 = arith.add v148, v970 : u32 #[overflow = checked];
-                        v969 = arith.constant 4 : u32;
-                        v152 = arith.mod v150, v969 : u32;
-                        hir.assertz v152 #[code = 250];
-                        v153 = hir.int_to_ptr v150 : ptr<byte, felt>;
-                        v154 = hir.load v153 : felt;
-                        v968 = arith.constant 12 : u32;
-                        v155 = hir.bitcast v942 : u32;
-                        v157 = arith.add v155, v968 : u32 #[overflow = checked];
-                        v967 = arith.constant 4 : u32;
-                        v159 = arith.mod v157, v967 : u32;
-                        hir.assertz v159 #[code = 250];
-                        v160 = hir.int_to_ptr v157 : ptr<byte, felt>;
-                        v161 = hir.load v160 : felt;
-                        hir.exec @miden:base/note-script@1.0.0/p2id/p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7(v140, v147, v154, v161)
-                        v966 = arith.constant 16 : i32;
-                        v165 = arith.add v942, v966 : i32 #[overflow = wrapping];
-                        v162 = arith.constant -16 : i32;
-                        v163 = arith.add v941, v162 : i32 #[overflow = wrapping];
-                        scf.yield v163, v165;
+                    ^block26:
+                        v116 = arith.constant 28 : i32;
+                        v117 = arith.add v54, v116 : i32 #[overflow = wrapping];
+                        hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::get_assets(v117)
+                        v119 = arith.constant 36 : u32;
+                        v118 = hir.bitcast v54 : u32;
+                        v120 = arith.add v118, v119 : u32 #[overflow = checked];
+                        v1003 = arith.constant 4 : u32;
+                        v122 = arith.mod v120, v1003 : u32;
+                        hir.assertz v122 #[code = 250];
+                        v123 = hir.int_to_ptr v120 : ptr<byte, i32>;
+                        v124 = hir.load v123 : i32;
+                        v129 = arith.constant 28 : u32;
+                        v128 = hir.bitcast v54 : u32;
+                        v130 = arith.add v128, v129 : u32 #[overflow = checked];
+                        v1002 = arith.constant 4 : u32;
+                        v132 = arith.mod v130, v1002 : u32;
+                        hir.assertz v132 #[code = 250];
+                        v133 = hir.int_to_ptr v130 : ptr<byte, i32>;
+                        v134 = hir.load v133 : i32;
+                        v136 = arith.constant 32 : u32;
+                        v135 = hir.bitcast v54 : u32;
+                        v137 = arith.add v135, v136 : u32 #[overflow = checked];
+                        v1001 = arith.constant 4 : u32;
+                        v139 = arith.mod v137, v1001 : u32;
+                        hir.assertz v139 #[code = 250];
+                        v140 = hir.int_to_ptr v137 : ptr<byte, i32>;
+                        v141 = hir.load v140 : i32;
+                        v1000 = arith.constant 4 : u32;
+                        v127 = arith.shl v124, v1000 : i32;
+                        v954, v955, v956, v957, v958, v959, v960, v961 = scf.while v127, v141, v54, v141, v134 : i32, i32, i32, i32, i32, i32, i32, i32 {
+                        ^block130(v962: i32, v963: i32, v964: i32, v965: i32, v966: i32):
+                            v998 = arith.constant 0 : i32;
+                            v999 = arith.constant 0 : i32;
+                            v144 = arith.eq v962, v999 : i1;
+                            v145 = arith.zext v144 : u32;
+                            v146 = hir.bitcast v145 : i32;
+                            v148 = arith.neq v146, v998 : i1;
+                            v947, v948 = scf.if v148 : i32, i32 {
+                            ^block129:
+                                v887 = ub.poison i32 : i32;
+                                scf.yield v887, v887;
+                            } else {
+                            ^block30:
+                                v150 = hir.bitcast v963 : u32;
+                                v997 = arith.constant 4 : u32;
+                                v152 = arith.mod v150, v997 : u32;
+                                hir.assertz v152 #[code = 250];
+                                v153 = hir.int_to_ptr v150 : ptr<byte, felt>;
+                                v154 = hir.load v153 : felt;
+                                v996 = arith.constant 4 : u32;
+                                v155 = hir.bitcast v963 : u32;
+                                v157 = arith.add v155, v996 : u32 #[overflow = checked];
+                                v995 = arith.constant 4 : u32;
+                                v159 = arith.mod v157, v995 : u32;
+                                hir.assertz v159 #[code = 250];
+                                v160 = hir.int_to_ptr v157 : ptr<byte, felt>;
+                                v161 = hir.load v160 : felt;
+                                v994 = arith.constant 8 : u32;
+                                v162 = hir.bitcast v963 : u32;
+                                v164 = arith.add v162, v994 : u32 #[overflow = checked];
+                                v993 = arith.constant 4 : u32;
+                                v166 = arith.mod v164, v993 : u32;
+                                hir.assertz v166 #[code = 250];
+                                v167 = hir.int_to_ptr v164 : ptr<byte, felt>;
+                                v168 = hir.load v167 : felt;
+                                v992 = arith.constant 12 : u32;
+                                v169 = hir.bitcast v963 : u32;
+                                v171 = arith.add v169, v992 : u32 #[overflow = checked];
+                                v991 = arith.constant 4 : u32;
+                                v173 = arith.mod v171, v991 : u32;
+                                hir.assertz v173 #[code = 250];
+                                v174 = hir.int_to_ptr v171 : ptr<byte, felt>;
+                                v175 = hir.load v174 : felt;
+                                hir.exec @miden:base/note-script@1.0.0/p2id/p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7(v154, v161, v168, v175)
+                                v990 = arith.constant 16 : i32;
+                                v179 = arith.add v963, v990 : i32 #[overflow = wrapping];
+                                v176 = arith.constant -16 : i32;
+                                v177 = arith.add v962, v176 : i32 #[overflow = wrapping];
+                                scf.yield v177, v179;
+                            };
+                            v986 = ub.poison i32 : i32;
+                            v951 = cf.select v148, v986, v966 : i32;
+                            v987 = ub.poison i32 : i32;
+                            v950 = cf.select v148, v987, v965 : i32;
+                            v988 = ub.poison i32 : i32;
+                            v949 = cf.select v148, v988, v964 : i32;
+                            v989 = arith.constant 1 : u32;
+                            v878 = arith.constant 0 : u32;
+                            v953 = cf.select v148, v878, v989 : u32;
+                            v931 = arith.trunc v953 : i1;
+                            scf.condition v931, v947, v948, v949, v950, v951, v964, v965, v966;
+                        } do {
+                        ^block131(v967: i32, v968: i32, v969: i32, v970: i32, v971: i32, v972: i32, v973: i32, v974: i32):
+                            scf.yield v967, v968, v969, v970, v971;
+                        };
+                        v183 = arith.constant 44 : u32;
+                        v182 = hir.bitcast v959 : u32;
+                        v184 = arith.add v182, v183 : u32 #[overflow = checked];
+                        v985 = arith.constant 4 : u32;
+                        v186 = arith.mod v184, v985 : u32;
+                        hir.assertz v186 #[code = 250];
+                        v187 = hir.int_to_ptr v184 : ptr<byte, i32>;
+                        hir.store v187, v960;
+                        v190 = arith.constant 40 : u32;
+                        v189 = hir.bitcast v959 : u32;
+                        v191 = arith.add v189, v190 : u32 #[overflow = checked];
+                        v984 = arith.constant 4 : u32;
+                        v193 = arith.mod v191, v984 : u32;
+                        hir.assertz v193 #[code = 250];
+                        v194 = hir.int_to_ptr v191 : ptr<byte, i32>;
+                        hir.store v194, v961;
+                        v983 = arith.constant 16 : i32;
+                        v195 = arith.constant 40 : i32;
+                        v196 = arith.add v959, v195 : i32 #[overflow = wrapping];
+                        hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v196, v983, v983)
+                        v125 = arith.constant 4 : i32;
+                        v982 = arith.constant 16 : i32;
+                        v200 = arith.add v959, v982 : i32 #[overflow = wrapping];
+                        hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v200, v125, v125)
+                        v981 = arith.constant 48 : i32;
+                        v204 = arith.add v959, v981 : i32 #[overflow = wrapping];
+                        v205 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+                        v206 = hir.bitcast v205 : ptr<byte, i32>;
+                        hir.store v206, v204;
+                        scf.yield ;
                     };
-                    v963 = ub.poison i32 : i32;
-                    v930 = cf.select v134, v963, v945 : i32;
-                    v964 = ub.poison i32 : i32;
-                    v929 = cf.select v134, v964, v944 : i32;
-                    v965 = ub.poison i32 : i32;
-                    v928 = cf.select v134, v965, v943 : i32;
-                    v869 = arith.constant 1 : u32;
-                    v861 = arith.constant 0 : u32;
-                    v932 = cf.select v134, v861, v869 : u32;
-                    v914 = arith.trunc v932 : i1;
-                    scf.condition v914, v926, v927, v928, v929, v930, v943, v944, v945;
-                } do {
-                ^block125(v946: i32, v947: i32, v948: i32, v949: i32, v950: i32, v951: i32, v952: i32, v953: i32):
-                    scf.yield v946, v947, v948, v949, v950;
+                    v979 = arith.constant 0 : u32;
+                    v980 = arith.constant 1 : u32;
+                    v975 = cf.select v115, v980, v979 : u32;
+                    scf.yield v975;
                 };
-                v169 = arith.constant 44 : u32;
-                v168 = hir.bitcast v938 : u32;
-                v170 = arith.add v168, v169 : u32 #[overflow = checked];
-                v962 = arith.constant 4 : u32;
-                v172 = arith.mod v170, v962 : u32;
-                hir.assertz v172 #[code = 250];
-                v173 = hir.int_to_ptr v170 : ptr<byte, i32>;
-                hir.store v173, v939;
-                v176 = arith.constant 40 : u32;
-                v175 = hir.bitcast v938 : u32;
-                v177 = arith.add v175, v176 : u32 #[overflow = checked];
-                v961 = arith.constant 4 : u32;
-                v179 = arith.mod v177, v961 : u32;
-                hir.assertz v179 #[code = 250];
-                v180 = hir.int_to_ptr v177 : ptr<byte, i32>;
-                hir.store v180, v940;
-                v960 = arith.constant 16 : i32;
-                v181 = arith.constant 40 : i32;
-                v182 = arith.add v938, v181 : i32 #[overflow = wrapping];
-                hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v182, v960, v960)
-                v111 = arith.constant 4 : i32;
-                v959 = arith.constant 16 : i32;
-                v186 = arith.add v938, v959 : i32 #[overflow = wrapping];
-                hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v186, v111, v111)
-                v958 = arith.constant 48 : i32;
-                v190 = arith.add v938, v958 : i32 #[overflow = wrapping];
-                v191 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-                v192 = hir.bitcast v191 : ptr<byte, i32>;
-                hir.store v192, v190;
-                v957 = arith.constant 0 : u32;
-                scf.yield v957;
+                scf.yield v936;
             };
-            v954 = arith.constant 0 : u32;
-            v925 = arith.eq v916, v954 : i1;
-            cf.cond_br v925 ^block116, ^block24;
-        ^block24:
+            v976 = arith.constant 0 : u32;
+            v946 = arith.eq v934, v976 : i1;
+            cf.cond_br v946 ^block120, ^block23;
+        ^block23:
             ub.unreachable ;
-        ^block116:
+        ^block120:
             builtin.ret ;
         };
 
         private builtin.function @__rustc::__rust_no_alloc_shim_is_unstable_v2() {
-        ^block29:
+        ^block31:
             builtin.ret ;
         };
 
         private builtin.function @wit_bindgen::rt::run_ctors_once() {
-        ^block31:
-            v194 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v195 = hir.bitcast v194 : ptr<byte, i32>;
-            v196 = hir.load v195 : i32;
-            v197 = arith.constant 1048668 : i32;
-            v198 = arith.add v196, v197 : i32 #[overflow = wrapping];
-            v199 = hir.bitcast v198 : u32;
-            v200 = hir.int_to_ptr v199 : ptr<byte, u8>;
-            v201 = hir.load v200 : u8;
-            v193 = arith.constant 0 : i32;
-            v202 = arith.zext v201 : u32;
-            v203 = hir.bitcast v202 : i32;
-            v205 = arith.neq v203, v193 : i1;
-            scf.if v205{
-            ^block33:
+        ^block33:
+            v208 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v209 = hir.bitcast v208 : ptr<byte, i32>;
+            v210 = hir.load v209 : i32;
+            v211 = arith.constant 1048668 : i32;
+            v212 = arith.add v210, v211 : i32 #[overflow = wrapping];
+            v213 = hir.bitcast v212 : u32;
+            v214 = hir.int_to_ptr v213 : ptr<byte, u8>;
+            v215 = hir.load v214 : u8;
+            v207 = arith.constant 0 : i32;
+            v216 = arith.zext v215 : u32;
+            v217 = hir.bitcast v216 : i32;
+            v219 = arith.neq v217, v207 : i1;
+            scf.if v219{
+            ^block35:
                 scf.yield ;
             } else {
-            ^block34:
-                v206 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-                v207 = hir.bitcast v206 : ptr<byte, i32>;
-                v208 = hir.load v207 : i32;
+            ^block36:
+                v220 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+                v221 = hir.bitcast v220 : ptr<byte, i32>;
+                v222 = hir.load v221 : i32;
                 hir.exec @miden:base/note-script@1.0.0/p2id/__wasm_call_ctors()
-                v986 = arith.constant 1 : u8;
-                v988 = arith.constant 1048668 : i32;
-                v210 = arith.add v208, v988 : i32 #[overflow = wrapping];
-                v214 = hir.bitcast v210 : u32;
-                v215 = hir.int_to_ptr v214 : ptr<byte, u8>;
-                hir.store v215, v986;
+                v1013 = arith.constant 1 : u8;
+                v1015 = arith.constant 1048668 : i32;
+                v224 = arith.add v222, v1015 : i32 #[overflow = wrapping];
+                v228 = hir.bitcast v224 : u32;
+                v229 = hir.int_to_ptr v228 : ptr<byte, u8>;
+                hir.store v229, v1013;
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v216: i32, v217: i32, v218: i32) -> i32 {
-        ^block35(v216: i32, v217: i32, v218: i32):
-            v221 = arith.constant 16 : i32;
-            v220 = arith.constant 0 : i32;
-            v990 = arith.constant 16 : u32;
-            v223 = hir.bitcast v217 : u32;
-            v225 = arith.gt v223, v990 : i1;
-            v226 = arith.zext v225 : u32;
-            v227 = hir.bitcast v226 : i32;
-            v229 = arith.neq v227, v220 : i1;
-            v230 = cf.select v229, v217, v221 : i32;
-            v1030 = arith.constant 0 : i32;
-            v231 = arith.constant -1 : i32;
-            v232 = arith.add v230, v231 : i32 #[overflow = wrapping];
-            v233 = arith.band v230, v232 : i32;
-            v235 = arith.neq v233, v1030 : i1;
-            v999, v1000 = scf.if v235 : i32, u32 {
-            ^block129:
-                v991 = arith.constant 0 : u32;
-                v995 = ub.poison i32 : i32;
-                scf.yield v995, v991;
+        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v230: i32, v231: i32, v232: i32) -> i32 {
+        ^block37(v230: i32, v231: i32, v232: i32):
+            v235 = arith.constant 16 : i32;
+            v234 = arith.constant 0 : i32;
+            v1017 = arith.constant 16 : u32;
+            v237 = hir.bitcast v231 : u32;
+            v239 = arith.gt v237, v1017 : i1;
+            v240 = arith.zext v239 : u32;
+            v241 = hir.bitcast v240 : i32;
+            v243 = arith.neq v241, v234 : i1;
+            v244 = cf.select v243, v231, v235 : i32;
+            v1057 = arith.constant 0 : i32;
+            v245 = arith.constant -1 : i32;
+            v246 = arith.add v244, v245 : i32 #[overflow = wrapping];
+            v247 = arith.band v244, v246 : i32;
+            v249 = arith.neq v247, v1057 : i1;
+            v1026, v1027 = scf.if v249 : i32, u32 {
+            ^block135:
+                v1018 = arith.constant 0 : u32;
+                v1022 = ub.poison i32 : i32;
+                scf.yield v1022, v1018;
             } else {
-            ^block38:
-                v237 = hir.exec @miden:base/note-script@1.0.0/p2id/core::ptr::alignment::Alignment::max(v217, v230) : i32
-                v1029 = arith.constant 0 : i32;
-                v236 = arith.constant -2147483648 : i32;
-                v238 = arith.sub v236, v237 : i32 #[overflow = wrapping];
-                v240 = hir.bitcast v238 : u32;
-                v239 = hir.bitcast v218 : u32;
-                v241 = arith.gt v239, v240 : i1;
-                v242 = arith.zext v241 : u32;
-                v243 = hir.bitcast v242 : i32;
-                v245 = arith.neq v243, v1029 : i1;
-                v1014 = scf.if v245 : i32 {
-                ^block128:
-                    v1028 = ub.poison i32 : i32;
-                    scf.yield v1028;
+            ^block40:
+                v251 = hir.exec @miden:base/note-script@1.0.0/p2id/core::ptr::alignment::Alignment::max(v231, v244) : i32
+                v1056 = arith.constant 0 : i32;
+                v250 = arith.constant -2147483648 : i32;
+                v252 = arith.sub v250, v251 : i32 #[overflow = wrapping];
+                v254 = hir.bitcast v252 : u32;
+                v253 = hir.bitcast v232 : u32;
+                v255 = arith.gt v253, v254 : i1;
+                v256 = arith.zext v255 : u32;
+                v257 = hir.bitcast v256 : i32;
+                v259 = arith.neq v257, v1056 : i1;
+                v1041 = scf.if v259 : i32 {
+                ^block134:
+                    v1055 = ub.poison i32 : i32;
+                    scf.yield v1055;
                 } else {
-                ^block39:
-                    v1026 = arith.constant 0 : i32;
-                    v251 = arith.sub v1026, v237 : i32 #[overflow = wrapping];
-                    v1027 = arith.constant -1 : i32;
-                    v247 = arith.add v218, v237 : i32 #[overflow = wrapping];
-                    v249 = arith.add v247, v1027 : i32 #[overflow = wrapping];
-                    v252 = arith.band v249, v251 : i32;
-                    v253 = hir.bitcast v216 : u32;
-                    v254 = arith.constant 4 : u32;
-                    v255 = arith.mod v253, v254 : u32;
-                    hir.assertz v255 #[code = 250];
-                    v256 = hir.int_to_ptr v253 : ptr<byte, i32>;
-                    v257 = hir.load v256 : i32;
-                    v1025 = arith.constant 0 : i32;
-                    v259 = arith.neq v257, v1025 : i1;
-                    scf.if v259{
-                    ^block127:
+                ^block41:
+                    v1053 = arith.constant 0 : i32;
+                    v265 = arith.sub v1053, v251 : i32 #[overflow = wrapping];
+                    v1054 = arith.constant -1 : i32;
+                    v261 = arith.add v232, v251 : i32 #[overflow = wrapping];
+                    v263 = arith.add v261, v1054 : i32 #[overflow = wrapping];
+                    v266 = arith.band v263, v265 : i32;
+                    v267 = hir.bitcast v230 : u32;
+                    v268 = arith.constant 4 : u32;
+                    v269 = arith.mod v267, v268 : u32;
+                    hir.assertz v269 #[code = 250];
+                    v270 = hir.int_to_ptr v267 : ptr<byte, i32>;
+                    v271 = hir.load v270 : i32;
+                    v1052 = arith.constant 0 : i32;
+                    v273 = arith.neq v271, v1052 : i1;
+                    scf.if v273{
+                    ^block133:
                         scf.yield ;
-                    } else {
-                    ^block41:
-                        v260 = hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::mem::heap_base() : i32
-                        v261 = hir.mem_size  : u32;
-                        v267 = hir.bitcast v216 : u32;
-                        v1024 = arith.constant 4 : u32;
-                        v269 = arith.mod v267, v1024 : u32;
-                        hir.assertz v269 #[code = 250];
-                        v1023 = arith.constant 16 : u32;
-                        v262 = hir.bitcast v261 : i32;
-                        v265 = arith.shl v262, v1023 : i32;
-                        v266 = arith.add v260, v265 : i32 #[overflow = wrapping];
-                        v270 = hir.int_to_ptr v267 : ptr<byte, i32>;
-                        hir.store v270, v266;
-                        scf.yield ;
-                    };
-                    v273 = hir.bitcast v216 : u32;
-                    v1022 = arith.constant 4 : u32;
-                    v275 = arith.mod v273, v1022 : u32;
-                    hir.assertz v275 #[code = 250];
-                    v276 = hir.int_to_ptr v273 : ptr<byte, i32>;
-                    v277 = hir.load v276 : i32;
-                    v1020 = arith.constant 0 : i32;
-                    v1021 = arith.constant -1 : i32;
-                    v279 = arith.bxor v277, v1021 : i32;
-                    v281 = hir.bitcast v279 : u32;
-                    v280 = hir.bitcast v252 : u32;
-                    v282 = arith.gt v280, v281 : i1;
-                    v283 = arith.zext v282 : u32;
-                    v284 = hir.bitcast v283 : i32;
-                    v286 = arith.neq v284, v1020 : i1;
-                    v1013 = scf.if v286 : i32 {
-                    ^block42:
-                        v1019 = arith.constant 0 : i32;
-                        scf.yield v1019;
                     } else {
                     ^block43:
-                        v288 = hir.bitcast v216 : u32;
-                        v1018 = arith.constant 4 : u32;
-                        v290 = arith.mod v288, v1018 : u32;
-                        hir.assertz v290 #[code = 250];
-                        v287 = arith.add v277, v252 : i32 #[overflow = wrapping];
-                        v291 = hir.int_to_ptr v288 : ptr<byte, i32>;
-                        hir.store v291, v287;
-                        v293 = arith.add v277, v237 : i32 #[overflow = wrapping];
-                        scf.yield v293;
+                        v274 = hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::mem::heap_base() : i32
+                        v275 = hir.mem_size  : u32;
+                        v281 = hir.bitcast v230 : u32;
+                        v1051 = arith.constant 4 : u32;
+                        v283 = arith.mod v281, v1051 : u32;
+                        hir.assertz v283 #[code = 250];
+                        v1050 = arith.constant 16 : u32;
+                        v276 = hir.bitcast v275 : i32;
+                        v279 = arith.shl v276, v1050 : i32;
+                        v280 = arith.add v274, v279 : i32 #[overflow = wrapping];
+                        v284 = hir.int_to_ptr v281 : ptr<byte, i32>;
+                        hir.store v284, v280;
+                        scf.yield ;
                     };
-                    scf.yield v1013;
+                    v287 = hir.bitcast v230 : u32;
+                    v1049 = arith.constant 4 : u32;
+                    v289 = arith.mod v287, v1049 : u32;
+                    hir.assertz v289 #[code = 250];
+                    v290 = hir.int_to_ptr v287 : ptr<byte, i32>;
+                    v291 = hir.load v290 : i32;
+                    v1047 = arith.constant 0 : i32;
+                    v1048 = arith.constant -1 : i32;
+                    v293 = arith.bxor v291, v1048 : i32;
+                    v295 = hir.bitcast v293 : u32;
+                    v294 = hir.bitcast v266 : u32;
+                    v296 = arith.gt v294, v295 : i1;
+                    v297 = arith.zext v296 : u32;
+                    v298 = hir.bitcast v297 : i32;
+                    v300 = arith.neq v298, v1047 : i1;
+                    v1040 = scf.if v300 : i32 {
+                    ^block44:
+                        v1046 = arith.constant 0 : i32;
+                        scf.yield v1046;
+                    } else {
+                    ^block45:
+                        v302 = hir.bitcast v230 : u32;
+                        v1045 = arith.constant 4 : u32;
+                        v304 = arith.mod v302, v1045 : u32;
+                        hir.assertz v304 #[code = 250];
+                        v301 = arith.add v291, v266 : i32 #[overflow = wrapping];
+                        v305 = hir.int_to_ptr v302 : ptr<byte, i32>;
+                        hir.store v305, v301;
+                        v307 = arith.add v291, v251 : i32 #[overflow = wrapping];
+                        scf.yield v307;
+                    };
+                    scf.yield v1040;
                 };
-                v996 = arith.constant 1 : u32;
-                v1017 = arith.constant 0 : u32;
-                v1015 = cf.select v245, v1017, v996 : u32;
-                scf.yield v1014, v1015;
+                v1023 = arith.constant 1 : u32;
+                v1044 = arith.constant 0 : u32;
+                v1042 = cf.select v259, v1044, v1023 : u32;
+                scf.yield v1041, v1042;
             };
-            v1016 = arith.constant 0 : u32;
-            v1012 = arith.eq v1000, v1016 : i1;
-            cf.cond_br v1012 ^block37, ^block131(v999);
-        ^block37:
+            v1043 = arith.constant 0 : u32;
+            v1039 = arith.eq v1027, v1043 : i1;
+            cf.cond_br v1039 ^block39, ^block137(v1026);
+        ^block39:
             ub.unreachable ;
-        ^block131(v992: i32):
-            builtin.ret v992;
+        ^block137(v1019: i32):
+            builtin.ret v1019;
         };
 
         private builtin.function @intrinsics::mem::heap_base() -> i32 {
-        ^block44:
-            v296 = hir.exec @intrinsics/mem/heap_base() : i32
-            builtin.ret v296;
+        ^block46:
+            v310 = hir.exec @intrinsics/mem/heap_base() : i32
+            builtin.ret v310;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v298: i32, v299: i32, v300: i32, v301: i32) {
-        ^block48(v298: i32, v299: i32, v300: i32, v301: i32):
-            v303 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v304 = hir.bitcast v303 : ptr<byte, i32>;
-            v305 = hir.load v304 : i32;
-            v306 = arith.constant 16 : i32;
-            v307 = arith.sub v305, v306 : i32 #[overflow = wrapping];
-            v308 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v309 = hir.bitcast v308 : ptr<byte, i32>;
-            hir.store v309, v307;
-            v302 = arith.constant 0 : i32;
-            v312 = arith.constant 256 : i32;
-            v310 = arith.constant 4 : i32;
-            v311 = arith.add v307, v310 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v311, v312, v302, v299, v300)
-            v315 = arith.constant 8 : u32;
-            v314 = hir.bitcast v307 : u32;
-            v316 = arith.add v314, v315 : u32 #[overflow = checked];
-            v317 = arith.constant 4 : u32;
-            v318 = arith.mod v316, v317 : u32;
-            hir.assertz v318 #[code = 250];
-            v319 = hir.int_to_ptr v316 : ptr<byte, i32>;
-            v320 = hir.load v319 : i32;
-            v1041 = arith.constant 4 : u32;
-            v321 = hir.bitcast v307 : u32;
-            v323 = arith.add v321, v1041 : u32 #[overflow = checked];
-            v1040 = arith.constant 4 : u32;
-            v325 = arith.mod v323, v1040 : u32;
-            hir.assertz v325 #[code = 250];
-            v326 = hir.int_to_ptr v323 : ptr<byte, i32>;
-            v327 = hir.load v326 : i32;
-            v1039 = arith.constant 0 : i32;
-            v328 = arith.constant 1 : i32;
-            v329 = arith.neq v327, v328 : i1;
-            v330 = arith.zext v329 : u32;
-            v331 = hir.bitcast v330 : i32;
-            v333 = arith.neq v331, v1039 : i1;
-            cf.cond_br v333 ^block50, ^block51;
-        ^block50:
-            v342 = arith.constant 12 : u32;
-            v341 = hir.bitcast v307 : u32;
-            v343 = arith.add v341, v342 : u32 #[overflow = checked];
-            v1038 = arith.constant 4 : u32;
-            v345 = arith.mod v343, v1038 : u32;
-            hir.assertz v345 #[code = 250];
-            v346 = hir.int_to_ptr v343 : ptr<byte, i32>;
-            v347 = hir.load v346 : i32;
-            v1037 = arith.constant 4 : u32;
-            v348 = hir.bitcast v298 : u32;
-            v350 = arith.add v348, v1037 : u32 #[overflow = checked];
-            v1036 = arith.constant 4 : u32;
-            v352 = arith.mod v350, v1036 : u32;
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v312: i32, v313: i32, v314: i32, v315: i32) {
+        ^block50(v312: i32, v313: i32, v314: i32, v315: i32):
+            v317 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v318 = hir.bitcast v317 : ptr<byte, i32>;
+            v319 = hir.load v318 : i32;
+            v320 = arith.constant 16 : i32;
+            v321 = arith.sub v319, v320 : i32 #[overflow = wrapping];
+            v322 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v323 = hir.bitcast v322 : ptr<byte, i32>;
+            hir.store v323, v321;
+            v316 = arith.constant 0 : i32;
+            v326 = arith.constant 256 : i32;
+            v324 = arith.constant 4 : i32;
+            v325 = arith.add v321, v324 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v325, v326, v316, v313, v314)
+            v329 = arith.constant 8 : u32;
+            v328 = hir.bitcast v321 : u32;
+            v330 = arith.add v328, v329 : u32 #[overflow = checked];
+            v331 = arith.constant 4 : u32;
+            v332 = arith.mod v330, v331 : u32;
+            hir.assertz v332 #[code = 250];
+            v333 = hir.int_to_ptr v330 : ptr<byte, i32>;
+            v334 = hir.load v333 : i32;
+            v1068 = arith.constant 4 : u32;
+            v335 = hir.bitcast v321 : u32;
+            v337 = arith.add v335, v1068 : u32 #[overflow = checked];
+            v1067 = arith.constant 4 : u32;
+            v339 = arith.mod v337, v1067 : u32;
+            hir.assertz v339 #[code = 250];
+            v340 = hir.int_to_ptr v337 : ptr<byte, i32>;
+            v341 = hir.load v340 : i32;
+            v1066 = arith.constant 0 : i32;
+            v342 = arith.constant 1 : i32;
+            v343 = arith.neq v341, v342 : i1;
+            v344 = arith.zext v343 : u32;
+            v345 = hir.bitcast v344 : i32;
+            v347 = arith.neq v345, v1066 : i1;
+            cf.cond_br v347 ^block52, ^block53;
+        ^block52:
+            v356 = arith.constant 12 : u32;
+            v355 = hir.bitcast v321 : u32;
+            v357 = arith.add v355, v356 : u32 #[overflow = checked];
+            v1065 = arith.constant 4 : u32;
+            v359 = arith.mod v357, v1065 : u32;
+            hir.assertz v359 #[code = 250];
+            v360 = hir.int_to_ptr v357 : ptr<byte, i32>;
+            v361 = hir.load v360 : i32;
+            v1064 = arith.constant 4 : u32;
+            v362 = hir.bitcast v312 : u32;
+            v364 = arith.add v362, v1064 : u32 #[overflow = checked];
+            v1063 = arith.constant 4 : u32;
+            v366 = arith.mod v364, v1063 : u32;
+            hir.assertz v366 #[code = 250];
+            v367 = hir.int_to_ptr v364 : ptr<byte, i32>;
+            hir.store v367, v361;
+            v368 = hir.bitcast v312 : u32;
+            v1062 = arith.constant 4 : u32;
+            v370 = arith.mod v368, v1062 : u32;
+            hir.assertz v370 #[code = 250];
+            v371 = hir.int_to_ptr v368 : ptr<byte, i32>;
+            hir.store v371, v334;
+            v1061 = arith.constant 16 : i32;
+            v373 = arith.add v321, v1061 : i32 #[overflow = wrapping];
+            v374 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v375 = hir.bitcast v374 : ptr<byte, i32>;
+            hir.store v375, v373;
+            builtin.ret ;
+        ^block53:
+            v1060 = arith.constant 12 : u32;
+            v348 = hir.bitcast v321 : u32;
+            v350 = arith.add v348, v1060 : u32 #[overflow = checked];
+            v1059 = arith.constant 4 : u32;
+            v352 = arith.mod v350, v1059 : u32;
             hir.assertz v352 #[code = 250];
             v353 = hir.int_to_ptr v350 : ptr<byte, i32>;
-            hir.store v353, v347;
-            v354 = hir.bitcast v298 : u32;
-            v1035 = arith.constant 4 : u32;
-            v356 = arith.mod v354, v1035 : u32;
-            hir.assertz v356 #[code = 250];
-            v357 = hir.int_to_ptr v354 : ptr<byte, i32>;
-            hir.store v357, v320;
-            v1034 = arith.constant 16 : i32;
-            v359 = arith.add v307, v1034 : i32 #[overflow = wrapping];
-            v360 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v361 = hir.bitcast v360 : ptr<byte, i32>;
-            hir.store v361, v359;
-            builtin.ret ;
-        ^block51:
-            v1033 = arith.constant 12 : u32;
-            v334 = hir.bitcast v307 : u32;
-            v336 = arith.add v334, v1033 : u32 #[overflow = checked];
-            v1032 = arith.constant 4 : u32;
-            v338 = arith.mod v336, v1032 : u32;
-            hir.assertz v338 #[code = 250];
-            v339 = hir.int_to_ptr v336 : ptr<byte, i32>;
-            v340 = hir.load v339 : i32;
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::handle_error(v320, v340, v301)
+            v354 = hir.load v353 : i32;
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::handle_error(v334, v354, v315)
             ub.unreachable ;
         };
 
-        private builtin.function @miden_base_sys::bindings::account::get_id(v362: i32) {
-        ^block52(v362: i32):
-            v364 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v365 = hir.bitcast v364 : ptr<byte, i32>;
-            v366 = hir.load v365 : i32;
-            v367 = arith.constant 16 : i32;
-            v368 = arith.sub v366, v367 : i32 #[overflow = wrapping];
-            v369 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v370 = hir.bitcast v369 : ptr<byte, i32>;
-            hir.store v370, v368;
-            v371 = arith.constant 8 : i32;
-            v372 = arith.add v368, v371 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/miden::account::get_id(v372)
-            v374 = arith.constant 8 : u32;
-            v373 = hir.bitcast v368 : u32;
-            v375 = arith.add v373, v374 : u32 #[overflow = checked];
-            v376 = arith.constant 4 : u32;
-            v377 = arith.mod v375, v376 : u32;
-            hir.assertz v377 #[code = 250];
-            v378 = hir.int_to_ptr v375 : ptr<byte, i64>;
-            v379 = hir.load v378 : i64;
-            v380 = hir.bitcast v362 : u32;
-            v1043 = arith.constant 8 : u32;
-            v382 = arith.mod v380, v1043 : u32;
-            hir.assertz v382 #[code = 250];
-            v383 = hir.int_to_ptr v380 : ptr<byte, i64>;
-            hir.store v383, v379;
-            v1042 = arith.constant 16 : i32;
-            v385 = arith.add v368, v1042 : i32 #[overflow = wrapping];
-            v386 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v387 = hir.bitcast v386 : ptr<byte, i32>;
-            hir.store v387, v385;
+        private builtin.function @miden_base_sys::bindings::account::get_id(v376: i32) {
+        ^block54(v376: i32):
+            v378 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v379 = hir.bitcast v378 : ptr<byte, i32>;
+            v380 = hir.load v379 : i32;
+            v381 = arith.constant 16 : i32;
+            v382 = arith.sub v380, v381 : i32 #[overflow = wrapping];
+            v383 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v384 = hir.bitcast v383 : ptr<byte, i32>;
+            hir.store v384, v382;
+            v385 = arith.constant 8 : i32;
+            v386 = arith.add v382, v385 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/miden::account::get_id(v386)
+            v388 = arith.constant 8 : u32;
+            v387 = hir.bitcast v382 : u32;
+            v389 = arith.add v387, v388 : u32 #[overflow = checked];
+            v390 = arith.constant 4 : u32;
+            v391 = arith.mod v389, v390 : u32;
+            hir.assertz v391 #[code = 250];
+            v392 = hir.int_to_ptr v389 : ptr<byte, i64>;
+            v393 = hir.load v392 : i64;
+            v394 = hir.bitcast v376 : u32;
+            v1070 = arith.constant 8 : u32;
+            v396 = arith.mod v394, v1070 : u32;
+            hir.assertz v396 #[code = 250];
+            v397 = hir.int_to_ptr v394 : ptr<byte, i64>;
+            hir.store v397, v393;
+            v1069 = arith.constant 16 : i32;
+            v399 = arith.add v382, v1069 : i32 #[overflow = wrapping];
+            v400 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v401 = hir.bitcast v400 : ptr<byte, i32>;
+            hir.store v401, v399;
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::note::get_inputs(v388: i32) {
-        ^block54(v388: i32):
-            v390 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v391 = hir.bitcast v390 : ptr<byte, i32>;
-            v392 = hir.load v391 : i32;
-            v393 = arith.constant 16 : i32;
-            v394 = arith.sub v392, v393 : i32 #[overflow = wrapping];
-            v395 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v396 = hir.bitcast v395 : ptr<byte, i32>;
-            hir.store v396, v394;
-            v401 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v402 = hir.bitcast v401 : ptr<byte, i32>;
-            v403 = hir.load v402 : i32;
-            v404 = arith.constant 1048632 : i32;
-            v405 = arith.add v403, v404 : i32 #[overflow = wrapping];
-            v399 = arith.constant 4 : i32;
-            v397 = arith.constant 8 : i32;
-            v398 = arith.add v394, v397 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v398, v399, v399, v405)
-            v407 = arith.constant 8 : u32;
-            v406 = hir.bitcast v394 : u32;
-            v408 = arith.add v406, v407 : u32 #[overflow = checked];
-            v409 = arith.constant 4 : u32;
-            v410 = arith.mod v408, v409 : u32;
-            hir.assertz v410 #[code = 250];
-            v411 = hir.int_to_ptr v408 : ptr<byte, i32>;
-            v412 = hir.load v411 : i32;
-            v414 = arith.constant 12 : u32;
-            v413 = hir.bitcast v394 : u32;
-            v415 = arith.add v413, v414 : u32 #[overflow = checked];
-            v1051 = arith.constant 4 : u32;
-            v417 = arith.mod v415, v1051 : u32;
-            hir.assertz v417 #[code = 250];
-            v418 = hir.int_to_ptr v415 : ptr<byte, i32>;
-            v419 = hir.load v418 : i32;
-            v1044 = arith.constant 2 : u32;
-            v421 = hir.bitcast v419 : u32;
-            v423 = arith.shr v421, v1044 : u32;
-            v424 = hir.bitcast v423 : i32;
-            v425 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::note::get_inputs(v424) : i32
-            v1050 = arith.constant 8 : u32;
-            v426 = hir.bitcast v388 : u32;
-            v428 = arith.add v426, v1050 : u32 #[overflow = checked];
-            v1049 = arith.constant 4 : u32;
-            v430 = arith.mod v428, v1049 : u32;
-            hir.assertz v430 #[code = 250];
-            v431 = hir.int_to_ptr v428 : ptr<byte, i32>;
-            hir.store v431, v425;
-            v1048 = arith.constant 4 : u32;
-            v432 = hir.bitcast v388 : u32;
-            v434 = arith.add v432, v1048 : u32 #[overflow = checked];
-            v1047 = arith.constant 4 : u32;
-            v436 = arith.mod v434, v1047 : u32;
-            hir.assertz v436 #[code = 250];
-            v437 = hir.int_to_ptr v434 : ptr<byte, i32>;
-            hir.store v437, v419;
-            v438 = hir.bitcast v388 : u32;
-            v1046 = arith.constant 4 : u32;
-            v440 = arith.mod v438, v1046 : u32;
-            hir.assertz v440 #[code = 250];
-            v441 = hir.int_to_ptr v438 : ptr<byte, i32>;
-            hir.store v441, v412;
-            v1045 = arith.constant 16 : i32;
-            v443 = arith.add v394, v1045 : i32 #[overflow = wrapping];
-            v444 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v445 = hir.bitcast v444 : ptr<byte, i32>;
-            hir.store v445, v443;
+        private builtin.function @miden_base_sys::bindings::note::get_inputs(v402: i32) {
+        ^block56(v402: i32):
+            v404 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v405 = hir.bitcast v404 : ptr<byte, i32>;
+            v406 = hir.load v405 : i32;
+            v407 = arith.constant 16 : i32;
+            v408 = arith.sub v406, v407 : i32 #[overflow = wrapping];
+            v409 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v410 = hir.bitcast v409 : ptr<byte, i32>;
+            hir.store v410, v408;
+            v415 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v416 = hir.bitcast v415 : ptr<byte, i32>;
+            v417 = hir.load v416 : i32;
+            v418 = arith.constant 1048632 : i32;
+            v419 = arith.add v417, v418 : i32 #[overflow = wrapping];
+            v413 = arith.constant 4 : i32;
+            v411 = arith.constant 8 : i32;
+            v412 = arith.add v408, v411 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v412, v413, v413, v419)
+            v421 = arith.constant 8 : u32;
+            v420 = hir.bitcast v408 : u32;
+            v422 = arith.add v420, v421 : u32 #[overflow = checked];
+            v423 = arith.constant 4 : u32;
+            v424 = arith.mod v422, v423 : u32;
+            hir.assertz v424 #[code = 250];
+            v425 = hir.int_to_ptr v422 : ptr<byte, i32>;
+            v426 = hir.load v425 : i32;
+            v428 = arith.constant 12 : u32;
+            v427 = hir.bitcast v408 : u32;
+            v429 = arith.add v427, v428 : u32 #[overflow = checked];
+            v1078 = arith.constant 4 : u32;
+            v431 = arith.mod v429, v1078 : u32;
+            hir.assertz v431 #[code = 250];
+            v432 = hir.int_to_ptr v429 : ptr<byte, i32>;
+            v433 = hir.load v432 : i32;
+            v1071 = arith.constant 2 : u32;
+            v435 = hir.bitcast v433 : u32;
+            v437 = arith.shr v435, v1071 : u32;
+            v438 = hir.bitcast v437 : i32;
+            v439 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::note::get_inputs(v438) : i32
+            v1077 = arith.constant 8 : u32;
+            v440 = hir.bitcast v402 : u32;
+            v442 = arith.add v440, v1077 : u32 #[overflow = checked];
+            v1076 = arith.constant 4 : u32;
+            v444 = arith.mod v442, v1076 : u32;
+            hir.assertz v444 #[code = 250];
+            v445 = hir.int_to_ptr v442 : ptr<byte, i32>;
+            hir.store v445, v439;
+            v1075 = arith.constant 4 : u32;
+            v446 = hir.bitcast v402 : u32;
+            v448 = arith.add v446, v1075 : u32 #[overflow = checked];
+            v1074 = arith.constant 4 : u32;
+            v450 = arith.mod v448, v1074 : u32;
+            hir.assertz v450 #[code = 250];
+            v451 = hir.int_to_ptr v448 : ptr<byte, i32>;
+            hir.store v451, v433;
+            v452 = hir.bitcast v402 : u32;
+            v1073 = arith.constant 4 : u32;
+            v454 = arith.mod v452, v1073 : u32;
+            hir.assertz v454 #[code = 250];
+            v455 = hir.int_to_ptr v452 : ptr<byte, i32>;
+            hir.store v455, v426;
+            v1072 = arith.constant 16 : i32;
+            v457 = arith.add v408, v1072 : i32 #[overflow = wrapping];
+            v458 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v459 = hir.bitcast v458 : ptr<byte, i32>;
+            hir.store v459, v457;
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::note::get_assets(v446: i32) {
-        ^block56(v446: i32):
-            v448 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v449 = hir.bitcast v448 : ptr<byte, i32>;
-            v450 = hir.load v449 : i32;
-            v451 = arith.constant 16 : i32;
-            v452 = arith.sub v450, v451 : i32 #[overflow = wrapping];
-            v453 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v454 = hir.bitcast v453 : ptr<byte, i32>;
-            hir.store v454, v452;
-            v459 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v460 = hir.bitcast v459 : ptr<byte, i32>;
-            v461 = hir.load v460 : i32;
-            v462 = arith.constant 1048648 : i32;
-            v463 = arith.add v461, v462 : i32 #[overflow = wrapping];
-            v1060 = arith.constant 16 : i32;
-            v455 = arith.constant 8 : i32;
-            v456 = arith.add v452, v455 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v456, v1060, v1060, v463)
-            v465 = arith.constant 8 : u32;
-            v464 = hir.bitcast v452 : u32;
-            v466 = arith.add v464, v465 : u32 #[overflow = checked];
-            v467 = arith.constant 4 : u32;
-            v468 = arith.mod v466, v467 : u32;
-            hir.assertz v468 #[code = 250];
-            v469 = hir.int_to_ptr v466 : ptr<byte, i32>;
-            v470 = hir.load v469 : i32;
-            v472 = arith.constant 12 : u32;
-            v471 = hir.bitcast v452 : u32;
-            v473 = arith.add v471, v472 : u32 #[overflow = checked];
-            v1059 = arith.constant 4 : u32;
-            v475 = arith.mod v473, v1059 : u32;
-            hir.assertz v475 #[code = 250];
-            v476 = hir.int_to_ptr v473 : ptr<byte, i32>;
-            v477 = hir.load v476 : i32;
-            v1052 = arith.constant 2 : u32;
-            v479 = hir.bitcast v477 : u32;
-            v481 = arith.shr v479, v1052 : u32;
-            v482 = hir.bitcast v481 : i32;
-            v483 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::note::get_assets(v482) : i32
-            v1058 = arith.constant 8 : u32;
-            v484 = hir.bitcast v446 : u32;
-            v486 = arith.add v484, v1058 : u32 #[overflow = checked];
-            v1057 = arith.constant 4 : u32;
-            v488 = arith.mod v486, v1057 : u32;
-            hir.assertz v488 #[code = 250];
-            v489 = hir.int_to_ptr v486 : ptr<byte, i32>;
-            hir.store v489, v483;
-            v1056 = arith.constant 4 : u32;
-            v490 = hir.bitcast v446 : u32;
-            v492 = arith.add v490, v1056 : u32 #[overflow = checked];
-            v1055 = arith.constant 4 : u32;
-            v494 = arith.mod v492, v1055 : u32;
-            hir.assertz v494 #[code = 250];
-            v495 = hir.int_to_ptr v492 : ptr<byte, i32>;
-            hir.store v495, v477;
-            v496 = hir.bitcast v446 : u32;
-            v1054 = arith.constant 4 : u32;
-            v498 = arith.mod v496, v1054 : u32;
-            hir.assertz v498 #[code = 250];
-            v499 = hir.int_to_ptr v496 : ptr<byte, i32>;
-            hir.store v499, v470;
-            v1053 = arith.constant 16 : i32;
-            v501 = arith.add v452, v1053 : i32 #[overflow = wrapping];
-            v502 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v503 = hir.bitcast v502 : ptr<byte, i32>;
-            hir.store v503, v501;
+        private builtin.function @miden_base_sys::bindings::note::get_assets(v460: i32) {
+        ^block58(v460: i32):
+            v462 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v463 = hir.bitcast v462 : ptr<byte, i32>;
+            v464 = hir.load v463 : i32;
+            v465 = arith.constant 16 : i32;
+            v466 = arith.sub v464, v465 : i32 #[overflow = wrapping];
+            v467 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v468 = hir.bitcast v467 : ptr<byte, i32>;
+            hir.store v468, v466;
+            v473 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v474 = hir.bitcast v473 : ptr<byte, i32>;
+            v475 = hir.load v474 : i32;
+            v476 = arith.constant 1048648 : i32;
+            v477 = arith.add v475, v476 : i32 #[overflow = wrapping];
+            v1087 = arith.constant 16 : i32;
+            v469 = arith.constant 8 : i32;
+            v470 = arith.add v466, v469 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v470, v1087, v1087, v477)
+            v479 = arith.constant 8 : u32;
+            v478 = hir.bitcast v466 : u32;
+            v480 = arith.add v478, v479 : u32 #[overflow = checked];
+            v481 = arith.constant 4 : u32;
+            v482 = arith.mod v480, v481 : u32;
+            hir.assertz v482 #[code = 250];
+            v483 = hir.int_to_ptr v480 : ptr<byte, i32>;
+            v484 = hir.load v483 : i32;
+            v486 = arith.constant 12 : u32;
+            v485 = hir.bitcast v466 : u32;
+            v487 = arith.add v485, v486 : u32 #[overflow = checked];
+            v1086 = arith.constant 4 : u32;
+            v489 = arith.mod v487, v1086 : u32;
+            hir.assertz v489 #[code = 250];
+            v490 = hir.int_to_ptr v487 : ptr<byte, i32>;
+            v491 = hir.load v490 : i32;
+            v1079 = arith.constant 2 : u32;
+            v493 = hir.bitcast v491 : u32;
+            v495 = arith.shr v493, v1079 : u32;
+            v496 = hir.bitcast v495 : i32;
+            v497 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::note::get_assets(v496) : i32
+            v1085 = arith.constant 8 : u32;
+            v498 = hir.bitcast v460 : u32;
+            v500 = arith.add v498, v1085 : u32 #[overflow = checked];
+            v1084 = arith.constant 4 : u32;
+            v502 = arith.mod v500, v1084 : u32;
+            hir.assertz v502 #[code = 250];
+            v503 = hir.int_to_ptr v500 : ptr<byte, i32>;
+            hir.store v503, v497;
+            v1083 = arith.constant 4 : u32;
+            v504 = hir.bitcast v460 : u32;
+            v506 = arith.add v504, v1083 : u32 #[overflow = checked];
+            v1082 = arith.constant 4 : u32;
+            v508 = arith.mod v506, v1082 : u32;
+            hir.assertz v508 #[code = 250];
+            v509 = hir.int_to_ptr v506 : ptr<byte, i32>;
+            hir.store v509, v491;
+            v510 = hir.bitcast v460 : u32;
+            v1081 = arith.constant 4 : u32;
+            v512 = arith.mod v510, v1081 : u32;
+            hir.assertz v512 #[code = 250];
+            v513 = hir.int_to_ptr v510 : ptr<byte, i32>;
+            hir.store v513, v484;
+            v1080 = arith.constant 16 : i32;
+            v515 = arith.add v466, v1080 : i32 #[overflow = wrapping];
+            v516 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v517 = hir.bitcast v516 : ptr<byte, i32>;
+            hir.store v517, v515;
             builtin.ret ;
         };
 
-        private builtin.function @intrinsics::felt::assert_eq(v504: felt, v505: felt) {
-        ^block58(v504: felt, v505: felt):
-            hir.assert_eq v504, v505;
-            builtin.ret ;
+        private builtin.function @intrinsics::felt::eq(v518: felt, v519: felt) -> i32 {
+        ^block60(v518: felt, v519: felt):
+            v520 = arith.eq v518, v519 : i1;
+            v521 = hir.cast v520 : i32;
+            builtin.ret v521;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v506: i32, v507: i32, v508: i32) {
-        ^block60(v506: i32, v507: i32, v508: i32):
-            v510 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v511 = hir.bitcast v510 : ptr<byte, i32>;
-            v512 = hir.load v511 : i32;
-            v513 = arith.constant 16 : i32;
-            v514 = arith.sub v512, v513 : i32 #[overflow = wrapping];
-            v515 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v516 = hir.bitcast v515 : ptr<byte, i32>;
-            hir.store v516, v514;
-            v517 = arith.constant 4 : i32;
-            v518 = arith.add v514, v517 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::current_memory(v518, v506, v507, v508)
-            v520 = arith.constant 8 : u32;
-            v519 = hir.bitcast v514 : u32;
-            v521 = arith.add v519, v520 : u32 #[overflow = checked];
-            v522 = arith.constant 4 : u32;
-            v523 = arith.mod v521, v522 : u32;
-            hir.assertz v523 #[code = 250];
-            v524 = hir.int_to_ptr v521 : ptr<byte, i32>;
-            v525 = hir.load v524 : i32;
-            v1067 = arith.constant 0 : i32;
-            v509 = arith.constant 0 : i32;
-            v527 = arith.eq v525, v509 : i1;
-            v528 = arith.zext v527 : u32;
-            v529 = hir.bitcast v528 : i32;
-            v531 = arith.neq v529, v1067 : i1;
-            scf.if v531{
-            ^block137:
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v523: i32, v524: i32, v525: i32) {
+        ^block62(v523: i32, v524: i32, v525: i32):
+            v527 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v528 = hir.bitcast v527 : ptr<byte, i32>;
+            v529 = hir.load v528 : i32;
+            v530 = arith.constant 16 : i32;
+            v531 = arith.sub v529, v530 : i32 #[overflow = wrapping];
+            v532 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v533 = hir.bitcast v532 : ptr<byte, i32>;
+            hir.store v533, v531;
+            v534 = arith.constant 4 : i32;
+            v535 = arith.add v531, v534 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::current_memory(v535, v523, v524, v525)
+            v537 = arith.constant 8 : u32;
+            v536 = hir.bitcast v531 : u32;
+            v538 = arith.add v536, v537 : u32 #[overflow = checked];
+            v539 = arith.constant 4 : u32;
+            v540 = arith.mod v538, v539 : u32;
+            hir.assertz v540 #[code = 250];
+            v541 = hir.int_to_ptr v538 : ptr<byte, i32>;
+            v542 = hir.load v541 : i32;
+            v1094 = arith.constant 0 : i32;
+            v526 = arith.constant 0 : i32;
+            v544 = arith.eq v542, v526 : i1;
+            v545 = arith.zext v544 : u32;
+            v546 = hir.bitcast v545 : i32;
+            v548 = arith.neq v546, v1094 : i1;
+            scf.if v548{
+            ^block143:
                 scf.yield ;
             } else {
-            ^block63:
-                v1066 = arith.constant 4 : u32;
-                v532 = hir.bitcast v514 : u32;
-                v534 = arith.add v532, v1066 : u32 #[overflow = checked];
-                v1065 = arith.constant 4 : u32;
-                v536 = arith.mod v534, v1065 : u32;
-                hir.assertz v536 #[code = 250];
-                v537 = hir.int_to_ptr v534 : ptr<byte, i32>;
-                v538 = hir.load v537 : i32;
-                v540 = arith.constant 12 : u32;
-                v539 = hir.bitcast v514 : u32;
-                v541 = arith.add v539, v540 : u32 #[overflow = checked];
-                v1064 = arith.constant 4 : u32;
-                v543 = arith.mod v541, v1064 : u32;
-                hir.assertz v543 #[code = 250];
-                v544 = hir.int_to_ptr v541 : ptr<byte, i32>;
-                v545 = hir.load v544 : i32;
-                hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v538, v525, v545)
+            ^block65:
+                v1093 = arith.constant 4 : u32;
+                v549 = hir.bitcast v531 : u32;
+                v551 = arith.add v549, v1093 : u32 #[overflow = checked];
+                v1092 = arith.constant 4 : u32;
+                v553 = arith.mod v551, v1092 : u32;
+                hir.assertz v553 #[code = 250];
+                v554 = hir.int_to_ptr v551 : ptr<byte, i32>;
+                v555 = hir.load v554 : i32;
+                v557 = arith.constant 12 : u32;
+                v556 = hir.bitcast v531 : u32;
+                v558 = arith.add v556, v557 : u32 #[overflow = checked];
+                v1091 = arith.constant 4 : u32;
+                v560 = arith.mod v558, v1091 : u32;
+                hir.assertz v560 #[code = 250];
+                v561 = hir.int_to_ptr v558 : ptr<byte, i32>;
+                v562 = hir.load v561 : i32;
+                hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v555, v542, v562)
                 scf.yield ;
             };
-            v1063 = arith.constant 16 : i32;
-            v548 = arith.add v514, v1063 : i32 #[overflow = wrapping];
-            v549 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v550 = hir.bitcast v549 : ptr<byte, i32>;
-            hir.store v550, v548;
+            v1090 = arith.constant 16 : i32;
+            v565 = arith.add v531, v1090 : i32 #[overflow = wrapping];
+            v566 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v567 = hir.bitcast v566 : ptr<byte, i32>;
+            hir.store v567, v565;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v551: i32, v552: i32, v553: i32, v554: i32, v555: i32) {
-        ^block64(v551: i32, v552: i32, v553: i32, v554: i32, v555: i32):
-            v558 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v559 = hir.bitcast v558 : ptr<byte, i32>;
-            v560 = hir.load v559 : i32;
-            v561 = arith.constant 16 : i32;
-            v562 = arith.sub v560, v561 : i32 #[overflow = wrapping];
-            v563 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v564 = hir.bitcast v563 : ptr<byte, i32>;
-            hir.store v564, v562;
-            v574 = hir.bitcast v552 : u32;
-            v575 = arith.zext v574 : u64;
-            v576 = hir.bitcast v575 : i64;
-            v556 = arith.constant 0 : i32;
-            v569 = arith.sub v556, v554 : i32 #[overflow = wrapping];
-            v566 = arith.constant -1 : i32;
-            v565 = arith.add v554, v555 : i32 #[overflow = wrapping];
-            v567 = arith.add v565, v566 : i32 #[overflow = wrapping];
-            v570 = arith.band v567, v569 : i32;
-            v571 = hir.bitcast v570 : u32;
-            v572 = arith.zext v571 : u64;
-            v573 = hir.bitcast v572 : i64;
-            v577 = arith.mul v573, v576 : i64 #[overflow = wrapping];
-            v1171 = arith.constant 0 : i32;
-            v578 = arith.constant 32 : i64;
-            v580 = hir.cast v578 : u32;
-            v579 = hir.bitcast v577 : u64;
-            v581 = arith.shr v579, v580 : u64;
-            v582 = hir.bitcast v581 : i64;
-            v583 = arith.trunc v582 : i32;
-            v585 = arith.neq v583, v1171 : i1;
-            v1083, v1084, v1085, v1086, v1087, v1088 = scf.if v585 : i32, i32, i32, i32, i32, u32 {
-            ^block139:
-                v1068 = arith.constant 0 : u32;
-                v1075 = ub.poison i32 : i32;
-                scf.yield v551, v562, v1075, v1075, v1075, v1068;
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v568: i32, v569: i32, v570: i32, v571: i32, v572: i32) {
+        ^block66(v568: i32, v569: i32, v570: i32, v571: i32, v572: i32):
+            v575 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v576 = hir.bitcast v575 : ptr<byte, i32>;
+            v577 = hir.load v576 : i32;
+            v578 = arith.constant 16 : i32;
+            v579 = arith.sub v577, v578 : i32 #[overflow = wrapping];
+            v580 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v581 = hir.bitcast v580 : ptr<byte, i32>;
+            hir.store v581, v579;
+            v591 = hir.bitcast v569 : u32;
+            v592 = arith.zext v591 : u64;
+            v593 = hir.bitcast v592 : i64;
+            v573 = arith.constant 0 : i32;
+            v586 = arith.sub v573, v571 : i32 #[overflow = wrapping];
+            v583 = arith.constant -1 : i32;
+            v582 = arith.add v571, v572 : i32 #[overflow = wrapping];
+            v584 = arith.add v582, v583 : i32 #[overflow = wrapping];
+            v587 = arith.band v584, v586 : i32;
+            v588 = hir.bitcast v587 : u32;
+            v589 = arith.zext v588 : u64;
+            v590 = hir.bitcast v589 : i64;
+            v594 = arith.mul v590, v593 : i64 #[overflow = wrapping];
+            v1198 = arith.constant 0 : i32;
+            v595 = arith.constant 32 : i64;
+            v597 = hir.cast v595 : u32;
+            v596 = hir.bitcast v594 : u64;
+            v598 = arith.shr v596, v597 : u64;
+            v599 = hir.bitcast v598 : i64;
+            v600 = arith.trunc v599 : i32;
+            v602 = arith.neq v600, v1198 : i1;
+            v1110, v1111, v1112, v1113, v1114, v1115 = scf.if v602 : i32, i32, i32, i32, i32, u32 {
+            ^block145:
+                v1095 = arith.constant 0 : u32;
+                v1102 = ub.poison i32 : i32;
+                scf.yield v568, v579, v1102, v1102, v1102, v1095;
             } else {
-            ^block69:
-                v586 = arith.trunc v577 : i32;
-                v1170 = arith.constant 0 : i32;
-                v587 = arith.constant -2147483648 : i32;
-                v588 = arith.sub v587, v554 : i32 #[overflow = wrapping];
-                v590 = hir.bitcast v588 : u32;
-                v589 = hir.bitcast v586 : u32;
-                v591 = arith.lte v589, v590 : i1;
-                v592 = arith.zext v591 : u32;
-                v593 = hir.bitcast v592 : i32;
-                v595 = arith.neq v593, v1170 : i1;
-                v1131 = scf.if v595 : i32 {
-                ^block67:
-                    v1169 = arith.constant 0 : i32;
-                    v606 = arith.neq v586, v1169 : i1;
-                    v1130 = scf.if v606 : i32 {
-                    ^block71:
-                        v1168 = arith.constant 0 : i32;
-                        v622 = arith.neq v553, v1168 : i1;
-                        v1129 = scf.if v622 : i32 {
-                        ^block74:
-                            v604 = arith.constant 1 : i32;
-                            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v562, v554, v586, v604)
-                            v633 = hir.bitcast v562 : u32;
-                            v678 = arith.constant 4 : u32;
-                            v635 = arith.mod v633, v678 : u32;
-                            hir.assertz v635 #[code = 250];
-                            v636 = hir.int_to_ptr v633 : ptr<byte, i32>;
-                            v637 = hir.load v636 : i32;
-                            scf.yield v637;
-                        } else {
-                        ^block75:
-                            v623 = arith.constant 8 : i32;
-                            v624 = arith.add v562, v623 : i32 #[overflow = wrapping];
-                            hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v624, v554, v586)
-                            v608 = arith.constant 8 : u32;
-                            v625 = hir.bitcast v562 : u32;
-                            v627 = arith.add v625, v608 : u32 #[overflow = checked];
-                            v1167 = arith.constant 4 : u32;
-                            v629 = arith.mod v627, v1167 : u32;
-                            hir.assertz v629 #[code = 250];
-                            v630 = hir.int_to_ptr v627 : ptr<byte, i32>;
-                            v631 = hir.load v630 : i32;
-                            scf.yield v631;
-                        };
-                        v1165 = arith.constant 0 : i32;
-                        v1166 = arith.constant 0 : i32;
-                        v640 = arith.eq v1129, v1166 : i1;
-                        v641 = arith.zext v640 : u32;
-                        v642 = hir.bitcast v641 : i32;
-                        v644 = arith.neq v642, v1165 : i1;
-                        scf.if v644{
+            ^block71:
+                v603 = arith.trunc v594 : i32;
+                v1197 = arith.constant 0 : i32;
+                v604 = arith.constant -2147483648 : i32;
+                v605 = arith.sub v604, v571 : i32 #[overflow = wrapping];
+                v607 = hir.bitcast v605 : u32;
+                v606 = hir.bitcast v603 : u32;
+                v608 = arith.lte v606, v607 : i1;
+                v609 = arith.zext v608 : u32;
+                v610 = hir.bitcast v609 : i32;
+                v612 = arith.neq v610, v1197 : i1;
+                v1158 = scf.if v612 : i32 {
+                ^block69:
+                    v1196 = arith.constant 0 : i32;
+                    v623 = arith.neq v603, v1196 : i1;
+                    v1157 = scf.if v623 : i32 {
+                    ^block73:
+                        v1195 = arith.constant 0 : i32;
+                        v639 = arith.neq v570, v1195 : i1;
+                        v1156 = scf.if v639 : i32 {
                         ^block76:
-                            v1164 = arith.constant 8 : u32;
-                            v661 = hir.bitcast v551 : u32;
-                            v663 = arith.add v661, v1164 : u32 #[overflow = checked];
-                            v1163 = arith.constant 4 : u32;
-                            v665 = arith.mod v663, v1163 : u32;
-                            hir.assertz v665 #[code = 250];
-                            v666 = hir.int_to_ptr v663 : ptr<byte, i32>;
-                            hir.store v666, v586;
-                            v1162 = arith.constant 4 : u32;
-                            v668 = hir.bitcast v551 : u32;
-                            v670 = arith.add v668, v1162 : u32 #[overflow = checked];
-                            v1161 = arith.constant 4 : u32;
-                            v672 = arith.mod v670, v1161 : u32;
-                            hir.assertz v672 #[code = 250];
-                            v673 = hir.int_to_ptr v670 : ptr<byte, i32>;
-                            hir.store v673, v554;
-                            scf.yield ;
+                            v621 = arith.constant 1 : i32;
+                            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v579, v571, v603, v621)
+                            v650 = hir.bitcast v579 : u32;
+                            v695 = arith.constant 4 : u32;
+                            v652 = arith.mod v650, v695 : u32;
+                            hir.assertz v652 #[code = 250];
+                            v653 = hir.int_to_ptr v650 : ptr<byte, i32>;
+                            v654 = hir.load v653 : i32;
+                            scf.yield v654;
                         } else {
                         ^block77:
-                            v1160 = arith.constant 8 : u32;
-                            v646 = hir.bitcast v551 : u32;
-                            v648 = arith.add v646, v1160 : u32 #[overflow = checked];
-                            v1159 = arith.constant 4 : u32;
-                            v650 = arith.mod v648, v1159 : u32;
-                            hir.assertz v650 #[code = 250];
-                            v651 = hir.int_to_ptr v648 : ptr<byte, i32>;
-                            hir.store v651, v1129;
-                            v1158 = arith.constant 4 : u32;
-                            v653 = hir.bitcast v551 : u32;
-                            v655 = arith.add v653, v1158 : u32 #[overflow = checked];
-                            v1157 = arith.constant 4 : u32;
-                            v657 = arith.mod v655, v1157 : u32;
-                            hir.assertz v657 #[code = 250];
-                            v658 = hir.int_to_ptr v655 : ptr<byte, i32>;
-                            hir.store v658, v552;
+                            v640 = arith.constant 8 : i32;
+                            v641 = arith.add v579, v640 : i32 #[overflow = wrapping];
+                            hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v641, v571, v603)
+                            v625 = arith.constant 8 : u32;
+                            v642 = hir.bitcast v579 : u32;
+                            v644 = arith.add v642, v625 : u32 #[overflow = checked];
+                            v1194 = arith.constant 4 : u32;
+                            v646 = arith.mod v644, v1194 : u32;
+                            hir.assertz v646 #[code = 250];
+                            v647 = hir.int_to_ptr v644 : ptr<byte, i32>;
+                            v648 = hir.load v647 : i32;
+                            scf.yield v648;
+                        };
+                        v1192 = arith.constant 0 : i32;
+                        v1193 = arith.constant 0 : i32;
+                        v657 = arith.eq v1156, v1193 : i1;
+                        v658 = arith.zext v657 : u32;
+                        v659 = hir.bitcast v658 : i32;
+                        v661 = arith.neq v659, v1192 : i1;
+                        scf.if v661{
+                        ^block78:
+                            v1191 = arith.constant 8 : u32;
+                            v678 = hir.bitcast v568 : u32;
+                            v680 = arith.add v678, v1191 : u32 #[overflow = checked];
+                            v1190 = arith.constant 4 : u32;
+                            v682 = arith.mod v680, v1190 : u32;
+                            hir.assertz v682 #[code = 250];
+                            v683 = hir.int_to_ptr v680 : ptr<byte, i32>;
+                            hir.store v683, v603;
+                            v1189 = arith.constant 4 : u32;
+                            v685 = hir.bitcast v568 : u32;
+                            v687 = arith.add v685, v1189 : u32 #[overflow = checked];
+                            v1188 = arith.constant 4 : u32;
+                            v689 = arith.mod v687, v1188 : u32;
+                            hir.assertz v689 #[code = 250];
+                            v690 = hir.int_to_ptr v687 : ptr<byte, i32>;
+                            hir.store v690, v571;
+                            scf.yield ;
+                        } else {
+                        ^block79:
+                            v1187 = arith.constant 8 : u32;
+                            v663 = hir.bitcast v568 : u32;
+                            v665 = arith.add v663, v1187 : u32 #[overflow = checked];
+                            v1186 = arith.constant 4 : u32;
+                            v667 = arith.mod v665, v1186 : u32;
+                            hir.assertz v667 #[code = 250];
+                            v668 = hir.int_to_ptr v665 : ptr<byte, i32>;
+                            hir.store v668, v1156;
+                            v1185 = arith.constant 4 : u32;
+                            v670 = hir.bitcast v568 : u32;
+                            v672 = arith.add v670, v1185 : u32 #[overflow = checked];
+                            v1184 = arith.constant 4 : u32;
+                            v674 = arith.mod v672, v1184 : u32;
+                            hir.assertz v674 #[code = 250];
+                            v675 = hir.int_to_ptr v672 : ptr<byte, i32>;
+                            hir.store v675, v569;
                             scf.yield ;
                         };
-                        v1155 = arith.constant 0 : i32;
-                        v1156 = arith.constant 1 : i32;
-                        v1128 = cf.select v644, v1156, v1155 : i32;
-                        scf.yield v1128;
+                        v1182 = arith.constant 0 : i32;
+                        v1183 = arith.constant 1 : i32;
+                        v1155 = cf.select v661, v1183, v1182 : i32;
+                        scf.yield v1155;
                     } else {
-                    ^block72:
-                        v1154 = arith.constant 8 : u32;
-                        v607 = hir.bitcast v551 : u32;
-                        v609 = arith.add v607, v1154 : u32 #[overflow = checked];
-                        v1153 = arith.constant 4 : u32;
-                        v611 = arith.mod v609, v1153 : u32;
-                        hir.assertz v611 #[code = 250];
-                        v612 = hir.int_to_ptr v609 : ptr<byte, i32>;
-                        hir.store v612, v554;
-                        v1152 = arith.constant 4 : u32;
-                        v615 = hir.bitcast v551 : u32;
-                        v617 = arith.add v615, v1152 : u32 #[overflow = checked];
-                        v1151 = arith.constant 4 : u32;
-                        v619 = arith.mod v617, v1151 : u32;
-                        hir.assertz v619 #[code = 250];
-                        v1150 = arith.constant 0 : i32;
-                        v620 = hir.int_to_ptr v617 : ptr<byte, i32>;
-                        hir.store v620, v1150;
-                        v1149 = arith.constant 0 : i32;
-                        scf.yield v1149;
+                    ^block74:
+                        v1181 = arith.constant 8 : u32;
+                        v624 = hir.bitcast v568 : u32;
+                        v626 = arith.add v624, v1181 : u32 #[overflow = checked];
+                        v1180 = arith.constant 4 : u32;
+                        v628 = arith.mod v626, v1180 : u32;
+                        hir.assertz v628 #[code = 250];
+                        v629 = hir.int_to_ptr v626 : ptr<byte, i32>;
+                        hir.store v629, v571;
+                        v1179 = arith.constant 4 : u32;
+                        v632 = hir.bitcast v568 : u32;
+                        v634 = arith.add v632, v1179 : u32 #[overflow = checked];
+                        v1178 = arith.constant 4 : u32;
+                        v636 = arith.mod v634, v1178 : u32;
+                        hir.assertz v636 #[code = 250];
+                        v1177 = arith.constant 0 : i32;
+                        v637 = hir.int_to_ptr v634 : ptr<byte, i32>;
+                        hir.store v637, v1177;
+                        v1176 = arith.constant 0 : i32;
+                        scf.yield v1176;
                     };
-                    scf.yield v1130;
+                    scf.yield v1157;
                 } else {
-                ^block70:
-                    v1148 = ub.poison i32 : i32;
-                    scf.yield v1148;
+                ^block72:
+                    v1175 = ub.poison i32 : i32;
+                    scf.yield v1175;
                 };
-                v1143 = arith.constant 0 : u32;
-                v1076 = arith.constant 1 : u32;
-                v1136 = cf.select v595, v1076, v1143 : u32;
-                v1144 = ub.poison i32 : i32;
-                v1135 = cf.select v595, v562, v1144 : i32;
-                v1145 = ub.poison i32 : i32;
-                v1134 = cf.select v595, v551, v1145 : i32;
-                v1146 = ub.poison i32 : i32;
-                v1133 = cf.select v595, v1146, v562 : i32;
-                v1147 = ub.poison i32 : i32;
-                v1132 = cf.select v595, v1147, v551 : i32;
-                scf.yield v1132, v1133, v1134, v1131, v1135, v1136;
+                v1170 = arith.constant 0 : u32;
+                v1103 = arith.constant 1 : u32;
+                v1163 = cf.select v612, v1103, v1170 : u32;
+                v1171 = ub.poison i32 : i32;
+                v1162 = cf.select v612, v579, v1171 : i32;
+                v1172 = ub.poison i32 : i32;
+                v1161 = cf.select v612, v568, v1172 : i32;
+                v1173 = ub.poison i32 : i32;
+                v1160 = cf.select v612, v1173, v579 : i32;
+                v1174 = ub.poison i32 : i32;
+                v1159 = cf.select v612, v1174, v568 : i32;
+                scf.yield v1159, v1160, v1161, v1158, v1162, v1163;
             };
-            v1089, v1090, v1091 = scf.index_switch v1088 : i32, i32, i32 
+            v1116, v1117, v1118 = scf.index_switch v1115 : i32, i32, i32 
             case 0 {
-            ^block68:
-                v1142 = arith.constant 4 : u32;
-                v598 = hir.bitcast v1083 : u32;
-                v600 = arith.add v598, v1142 : u32 #[overflow = checked];
-                v1141 = arith.constant 4 : u32;
-                v602 = arith.mod v600, v1141 : u32;
-                hir.assertz v602 #[code = 250];
-                v1140 = arith.constant 0 : i32;
-                v603 = hir.int_to_ptr v600 : ptr<byte, i32>;
-                hir.store v603, v1140;
-                v1139 = arith.constant 1 : i32;
-                scf.yield v1083, v1139, v1084;
+            ^block70:
+                v1169 = arith.constant 4 : u32;
+                v615 = hir.bitcast v1110 : u32;
+                v617 = arith.add v615, v1169 : u32 #[overflow = checked];
+                v1168 = arith.constant 4 : u32;
+                v619 = arith.mod v617, v1168 : u32;
+                hir.assertz v619 #[code = 250];
+                v1167 = arith.constant 0 : i32;
+                v620 = hir.int_to_ptr v617 : ptr<byte, i32>;
+                hir.store v620, v1167;
+                v1166 = arith.constant 1 : i32;
+                scf.yield v1110, v1166, v1111;
             }
             default {
-            ^block143:
-                scf.yield v1085, v1086, v1087;
+            ^block149:
+                scf.yield v1112, v1113, v1114;
             };
-            v677 = hir.bitcast v1089 : u32;
-            v1138 = arith.constant 4 : u32;
-            v679 = arith.mod v677, v1138 : u32;
-            hir.assertz v679 #[code = 250];
-            v680 = hir.int_to_ptr v677 : ptr<byte, i32>;
-            hir.store v680, v1090;
-            v1137 = arith.constant 16 : i32;
-            v685 = arith.add v1091, v1137 : i32 #[overflow = wrapping];
-            v686 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v687 = hir.bitcast v686 : ptr<byte, i32>;
-            hir.store v687, v685;
+            v694 = hir.bitcast v1116 : u32;
+            v1165 = arith.constant 4 : u32;
+            v696 = arith.mod v694, v1165 : u32;
+            hir.assertz v696 #[code = 250];
+            v697 = hir.int_to_ptr v694 : ptr<byte, i32>;
+            hir.store v697, v1117;
+            v1164 = arith.constant 16 : i32;
+            v702 = arith.add v1118, v1164 : i32 #[overflow = wrapping];
+            v703 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v704 = hir.bitcast v703 : ptr<byte, i32>;
+            hir.store v704, v702;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v688: i32, v689: i32, v690: i32) {
-        ^block78(v688: i32, v689: i32, v690: i32):
-            v692 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v693 = hir.bitcast v692 : ptr<byte, i32>;
-            v694 = hir.load v693 : i32;
-            v695 = arith.constant 16 : i32;
-            v696 = arith.sub v694, v695 : i32 #[overflow = wrapping];
-            v697 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v698 = hir.bitcast v697 : ptr<byte, i32>;
-            hir.store v698, v696;
-            v691 = arith.constant 0 : i32;
-            v699 = arith.constant 8 : i32;
-            v700 = arith.add v696, v699 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v700, v689, v690, v691)
-            v703 = arith.constant 12 : u32;
-            v702 = hir.bitcast v696 : u32;
-            v704 = arith.add v702, v703 : u32 #[overflow = checked];
-            v705 = arith.constant 4 : u32;
-            v706 = arith.mod v704, v705 : u32;
-            hir.assertz v706 #[code = 250];
-            v707 = hir.int_to_ptr v704 : ptr<byte, i32>;
-            v708 = hir.load v707 : i32;
-            v710 = arith.constant 8 : u32;
-            v709 = hir.bitcast v696 : u32;
-            v711 = arith.add v709, v710 : u32 #[overflow = checked];
-            v1176 = arith.constant 4 : u32;
-            v713 = arith.mod v711, v1176 : u32;
-            hir.assertz v713 #[code = 250];
-            v714 = hir.int_to_ptr v711 : ptr<byte, i32>;
-            v715 = hir.load v714 : i32;
-            v716 = hir.bitcast v688 : u32;
-            v1175 = arith.constant 4 : u32;
-            v718 = arith.mod v716, v1175 : u32;
-            hir.assertz v718 #[code = 250];
-            v719 = hir.int_to_ptr v716 : ptr<byte, i32>;
-            hir.store v719, v715;
-            v1174 = arith.constant 4 : u32;
-            v720 = hir.bitcast v688 : u32;
-            v722 = arith.add v720, v1174 : u32 #[overflow = checked];
-            v1173 = arith.constant 4 : u32;
-            v724 = arith.mod v722, v1173 : u32;
-            hir.assertz v724 #[code = 250];
-            v725 = hir.int_to_ptr v722 : ptr<byte, i32>;
-            hir.store v725, v708;
-            v1172 = arith.constant 16 : i32;
-            v727 = arith.add v696, v1172 : i32 #[overflow = wrapping];
-            v728 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v729 = hir.bitcast v728 : ptr<byte, i32>;
-            hir.store v729, v727;
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v705: i32, v706: i32, v707: i32) {
+        ^block80(v705: i32, v706: i32, v707: i32):
+            v709 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v710 = hir.bitcast v709 : ptr<byte, i32>;
+            v711 = hir.load v710 : i32;
+            v712 = arith.constant 16 : i32;
+            v713 = arith.sub v711, v712 : i32 #[overflow = wrapping];
+            v714 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v715 = hir.bitcast v714 : ptr<byte, i32>;
+            hir.store v715, v713;
+            v708 = arith.constant 0 : i32;
+            v716 = arith.constant 8 : i32;
+            v717 = arith.add v713, v716 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v717, v706, v707, v708)
+            v720 = arith.constant 12 : u32;
+            v719 = hir.bitcast v713 : u32;
+            v721 = arith.add v719, v720 : u32 #[overflow = checked];
+            v722 = arith.constant 4 : u32;
+            v723 = arith.mod v721, v722 : u32;
+            hir.assertz v723 #[code = 250];
+            v724 = hir.int_to_ptr v721 : ptr<byte, i32>;
+            v725 = hir.load v724 : i32;
+            v727 = arith.constant 8 : u32;
+            v726 = hir.bitcast v713 : u32;
+            v728 = arith.add v726, v727 : u32 #[overflow = checked];
+            v1203 = arith.constant 4 : u32;
+            v730 = arith.mod v728, v1203 : u32;
+            hir.assertz v730 #[code = 250];
+            v731 = hir.int_to_ptr v728 : ptr<byte, i32>;
+            v732 = hir.load v731 : i32;
+            v733 = hir.bitcast v705 : u32;
+            v1202 = arith.constant 4 : u32;
+            v735 = arith.mod v733, v1202 : u32;
+            hir.assertz v735 #[code = 250];
+            v736 = hir.int_to_ptr v733 : ptr<byte, i32>;
+            hir.store v736, v732;
+            v1201 = arith.constant 4 : u32;
+            v737 = hir.bitcast v705 : u32;
+            v739 = arith.add v737, v1201 : u32 #[overflow = checked];
+            v1200 = arith.constant 4 : u32;
+            v741 = arith.mod v739, v1200 : u32;
+            hir.assertz v741 #[code = 250];
+            v742 = hir.int_to_ptr v739 : ptr<byte, i32>;
+            hir.store v742, v725;
+            v1199 = arith.constant 16 : i32;
+            v744 = arith.add v713, v1199 : i32 #[overflow = wrapping];
+            v745 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v746 = hir.bitcast v745 : ptr<byte, i32>;
+            hir.store v746, v744;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::alloc::Global::alloc_impl(v730: i32, v731: i32, v732: i32, v733: i32) {
-        ^block80(v730: i32, v731: i32, v732: i32, v733: i32):
-            v1192 = arith.constant 0 : i32;
-            v734 = arith.constant 0 : i32;
-            v735 = arith.eq v732, v734 : i1;
-            v736 = arith.zext v735 : u32;
-            v737 = hir.bitcast v736 : i32;
-            v739 = arith.neq v737, v1192 : i1;
-            v1188 = scf.if v739 : i32 {
-            ^block146:
-                scf.yield v731;
+        private builtin.function @alloc::alloc::Global::alloc_impl(v747: i32, v748: i32, v749: i32, v750: i32) {
+        ^block82(v747: i32, v748: i32, v749: i32, v750: i32):
+            v1219 = arith.constant 0 : i32;
+            v751 = arith.constant 0 : i32;
+            v752 = arith.eq v749, v751 : i1;
+            v753 = arith.zext v752 : u32;
+            v754 = hir.bitcast v753 : i32;
+            v756 = arith.neq v754, v1219 : i1;
+            v1215 = scf.if v756 : i32 {
+            ^block152:
+                scf.yield v748;
             } else {
-            ^block83:
+            ^block85:
                 hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v1191 = arith.constant 0 : i32;
-                v741 = arith.neq v733, v1191 : i1;
-                v1187 = scf.if v741 : i32 {
-                ^block84:
-                    v743 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v732, v731) : i32
-                    scf.yield v743;
+                v1218 = arith.constant 0 : i32;
+                v758 = arith.neq v750, v1218 : i1;
+                v1214 = scf.if v758 : i32 {
+                ^block86:
+                    v760 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v749, v748) : i32
+                    scf.yield v760;
                 } else {
-                ^block85:
-                    v742 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v732, v731) : i32
-                    scf.yield v742;
+                ^block87:
+                    v759 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v749, v748) : i32
+                    scf.yield v759;
                 };
-                scf.yield v1187;
+                scf.yield v1214;
             };
-            v747 = arith.constant 4 : u32;
-            v746 = hir.bitcast v730 : u32;
-            v748 = arith.add v746, v747 : u32 #[overflow = checked];
-            v1190 = arith.constant 4 : u32;
-            v750 = arith.mod v748, v1190 : u32;
-            hir.assertz v750 #[code = 250];
-            v751 = hir.int_to_ptr v748 : ptr<byte, i32>;
-            hir.store v751, v732;
-            v753 = hir.bitcast v730 : u32;
-            v1189 = arith.constant 4 : u32;
-            v755 = arith.mod v753, v1189 : u32;
-            hir.assertz v755 #[code = 250];
-            v756 = hir.int_to_ptr v753 : ptr<byte, i32>;
-            hir.store v756, v1188;
+            v764 = arith.constant 4 : u32;
+            v763 = hir.bitcast v747 : u32;
+            v765 = arith.add v763, v764 : u32 #[overflow = checked];
+            v1217 = arith.constant 4 : u32;
+            v767 = arith.mod v765, v1217 : u32;
+            hir.assertz v767 #[code = 250];
+            v768 = hir.int_to_ptr v765 : ptr<byte, i32>;
+            hir.store v768, v749;
+            v770 = hir.bitcast v747 : u32;
+            v1216 = arith.constant 4 : u32;
+            v772 = arith.mod v770, v1216 : u32;
+            hir.assertz v772 #[code = 250];
+            v773 = hir.int_to_ptr v770 : ptr<byte, i32>;
+            hir.store v773, v1215;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v757: i32, v758: i32, v759: i32, v760: i32) {
-        ^block86(v757: i32, v758: i32, v759: i32, v760: i32):
-            v1218 = arith.constant 0 : i32;
-            v761 = arith.constant 0 : i32;
-            v765 = arith.eq v760, v761 : i1;
-            v766 = arith.zext v765 : u32;
-            v767 = hir.bitcast v766 : i32;
-            v769 = arith.neq v767, v1218 : i1;
-            v1205, v1206 = scf.if v769 : i32, i32 {
-            ^block150:
-                v1217 = arith.constant 0 : i32;
-                v763 = arith.constant 4 : i32;
-                scf.yield v763, v1217;
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v774: i32, v775: i32, v776: i32, v777: i32) {
+        ^block88(v774: i32, v775: i32, v776: i32, v777: i32):
+            v1245 = arith.constant 0 : i32;
+            v778 = arith.constant 0 : i32;
+            v782 = arith.eq v777, v778 : i1;
+            v783 = arith.zext v782 : u32;
+            v784 = hir.bitcast v783 : i32;
+            v786 = arith.neq v784, v1245 : i1;
+            v1232, v1233 = scf.if v786 : i32, i32 {
+            ^block156:
+                v1244 = arith.constant 0 : i32;
+                v780 = arith.constant 4 : i32;
+                scf.yield v780, v1244;
             } else {
-            ^block89:
-                v770 = hir.bitcast v758 : u32;
-                v805 = arith.constant 4 : u32;
-                v772 = arith.mod v770, v805 : u32;
-                hir.assertz v772 #[code = 250];
-                v773 = hir.int_to_ptr v770 : ptr<byte, i32>;
-                v774 = hir.load v773 : i32;
-                v1215 = arith.constant 0 : i32;
-                v1216 = arith.constant 0 : i32;
-                v776 = arith.eq v774, v1216 : i1;
-                v777 = arith.zext v776 : u32;
-                v778 = hir.bitcast v777 : i32;
-                v780 = arith.neq v778, v1215 : i1;
-                v1203 = scf.if v780 : i32 {
-                ^block149:
-                    v1214 = arith.constant 0 : i32;
-                    scf.yield v1214;
+            ^block91:
+                v787 = hir.bitcast v775 : u32;
+                v822 = arith.constant 4 : u32;
+                v789 = arith.mod v787, v822 : u32;
+                hir.assertz v789 #[code = 250];
+                v790 = hir.int_to_ptr v787 : ptr<byte, i32>;
+                v791 = hir.load v790 : i32;
+                v1242 = arith.constant 0 : i32;
+                v1243 = arith.constant 0 : i32;
+                v793 = arith.eq v791, v1243 : i1;
+                v794 = arith.zext v793 : u32;
+                v795 = hir.bitcast v794 : i32;
+                v797 = arith.neq v795, v1242 : i1;
+                v1230 = scf.if v797 : i32 {
+                ^block155:
+                    v1241 = arith.constant 0 : i32;
+                    scf.yield v1241;
                 } else {
-                ^block90:
-                    v1213 = arith.constant 4 : u32;
-                    v781 = hir.bitcast v757 : u32;
-                    v783 = arith.add v781, v1213 : u32 #[overflow = checked];
-                    v1212 = arith.constant 4 : u32;
-                    v785 = arith.mod v783, v1212 : u32;
-                    hir.assertz v785 #[code = 250];
-                    v786 = hir.int_to_ptr v783 : ptr<byte, i32>;
-                    hir.store v786, v759;
-                    v1211 = arith.constant 4 : u32;
-                    v787 = hir.bitcast v758 : u32;
-                    v789 = arith.add v787, v1211 : u32 #[overflow = checked];
-                    v1210 = arith.constant 4 : u32;
-                    v791 = arith.mod v789, v1210 : u32;
-                    hir.assertz v791 #[code = 250];
-                    v792 = hir.int_to_ptr v789 : ptr<byte, i32>;
-                    v793 = hir.load v792 : i32;
-                    v794 = hir.bitcast v757 : u32;
-                    v1209 = arith.constant 4 : u32;
-                    v796 = arith.mod v794, v1209 : u32;
-                    hir.assertz v796 #[code = 250];
-                    v797 = hir.int_to_ptr v794 : ptr<byte, i32>;
-                    hir.store v797, v793;
-                    v798 = arith.mul v774, v760 : i32 #[overflow = wrapping];
-                    scf.yield v798;
+                ^block92:
+                    v1240 = arith.constant 4 : u32;
+                    v798 = hir.bitcast v774 : u32;
+                    v800 = arith.add v798, v1240 : u32 #[overflow = checked];
+                    v1239 = arith.constant 4 : u32;
+                    v802 = arith.mod v800, v1239 : u32;
+                    hir.assertz v802 #[code = 250];
+                    v803 = hir.int_to_ptr v800 : ptr<byte, i32>;
+                    hir.store v803, v776;
+                    v1238 = arith.constant 4 : u32;
+                    v804 = hir.bitcast v775 : u32;
+                    v806 = arith.add v804, v1238 : u32 #[overflow = checked];
+                    v1237 = arith.constant 4 : u32;
+                    v808 = arith.mod v806, v1237 : u32;
+                    hir.assertz v808 #[code = 250];
+                    v809 = hir.int_to_ptr v806 : ptr<byte, i32>;
+                    v810 = hir.load v809 : i32;
+                    v811 = hir.bitcast v774 : u32;
+                    v1236 = arith.constant 4 : u32;
+                    v813 = arith.mod v811, v1236 : u32;
+                    hir.assertz v813 #[code = 250];
+                    v814 = hir.int_to_ptr v811 : ptr<byte, i32>;
+                    hir.store v814, v810;
+                    v815 = arith.mul v791, v777 : i32 #[overflow = wrapping];
+                    scf.yield v815;
                 };
-                v799 = arith.constant 8 : i32;
-                v1208 = arith.constant 4 : i32;
-                v1204 = cf.select v780, v1208, v799 : i32;
-                scf.yield v1204, v1203;
+                v816 = arith.constant 8 : i32;
+                v1235 = arith.constant 4 : i32;
+                v1231 = cf.select v797, v1235, v816 : i32;
+                scf.yield v1231, v1230;
             };
-            v802 = arith.add v757, v1205 : i32 #[overflow = wrapping];
-            v804 = hir.bitcast v802 : u32;
-            v1207 = arith.constant 4 : u32;
-            v806 = arith.mod v804, v1207 : u32;
-            hir.assertz v806 #[code = 250];
-            v807 = hir.int_to_ptr v804 : ptr<byte, i32>;
-            hir.store v807, v1206;
+            v819 = arith.add v774, v1232 : i32 #[overflow = wrapping];
+            v821 = hir.bitcast v819 : u32;
+            v1234 = arith.constant 4 : u32;
+            v823 = arith.mod v821, v1234 : u32;
+            hir.assertz v823 #[code = 250];
+            v824 = hir.int_to_ptr v821 : ptr<byte, i32>;
+            hir.store v824, v1233;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v808: i32, v809: i32, v810: i32) {
-        ^block91(v808: i32, v809: i32, v810: i32):
-            v1220 = arith.constant 0 : i32;
-            v811 = arith.constant 0 : i32;
-            v812 = arith.eq v810, v811 : i1;
-            v813 = arith.zext v812 : u32;
-            v814 = hir.bitcast v813 : i32;
-            v816 = arith.neq v814, v1220 : i1;
-            scf.if v816{
-            ^block93:
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v825: i32, v826: i32, v827: i32) {
+        ^block93(v825: i32, v826: i32, v827: i32):
+            v1247 = arith.constant 0 : i32;
+            v828 = arith.constant 0 : i32;
+            v829 = arith.eq v827, v828 : i1;
+            v830 = arith.zext v829 : u32;
+            v831 = hir.bitcast v830 : i32;
+            v833 = arith.neq v831, v1247 : i1;
+            scf.if v833{
+            ^block95:
                 scf.yield ;
             } else {
-            ^block94:
-                hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_dealloc(v808, v810, v809)
+            ^block96:
+                hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_dealloc(v825, v827, v826)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::handle_error(v817: i32, v818: i32, v819: i32) {
-        ^block95(v817: i32, v818: i32, v819: i32):
+        private builtin.function @alloc::raw_vec::handle_error(v834: i32, v835: i32, v836: i32) {
+        ^block97(v834: i32, v835: i32, v836: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v820: i32, v821: i32) -> i32 {
-        ^block97(v820: i32, v821: i32):
-            v828 = arith.constant 0 : i32;
-            v824 = hir.bitcast v821 : u32;
-            v823 = hir.bitcast v820 : u32;
-            v825 = arith.gt v823, v824 : i1;
-            v826 = arith.zext v825 : u32;
-            v827 = hir.bitcast v826 : i32;
-            v829 = arith.neq v827, v828 : i1;
-            v830 = cf.select v829, v820, v821 : i32;
-            builtin.ret v830;
+        private builtin.function @core::ptr::alignment::Alignment::max(v837: i32, v838: i32) -> i32 {
+        ^block99(v837: i32, v838: i32):
+            v845 = arith.constant 0 : i32;
+            v841 = hir.bitcast v838 : u32;
+            v840 = hir.bitcast v837 : u32;
+            v842 = arith.gt v840, v841 : i1;
+            v843 = arith.zext v842 : u32;
+            v844 = hir.bitcast v843 : i32;
+            v846 = arith.neq v844, v845 : i1;
+            v847 = cf.select v846, v837, v838 : i32;
+            builtin.ret v847;
         };
 
-        private builtin.function @miden::account::get_id(v831: i32) {
-        ^block99(v831: i32):
-            v832, v833 = hir.exec @miden/account/get_id() : felt, felt
-            v834 = hir.bitcast v831 : u32;
-            v835 = hir.int_to_ptr v834 : ptr<byte, felt>;
-            hir.store v835, v832;
-            v836 = arith.constant 4 : u32;
-            v837 = arith.add v834, v836 : u32 #[overflow = checked];
-            v838 = hir.int_to_ptr v837 : ptr<byte, felt>;
-            hir.store v838, v833;
+        private builtin.function @miden::account::get_id(v848: i32) {
+        ^block101(v848: i32):
+            v849, v850 = hir.exec @miden/account/get_id() : felt, felt
+            v851 = hir.bitcast v848 : u32;
+            v852 = hir.int_to_ptr v851 : ptr<byte, felt>;
+            hir.store v852, v849;
+            v853 = arith.constant 4 : u32;
+            v854 = arith.add v851, v853 : u32 #[overflow = checked];
+            v855 = hir.int_to_ptr v854 : ptr<byte, felt>;
+            hir.store v855, v850;
             builtin.ret ;
         };
 
-        private builtin.function @miden::note::get_inputs(v839: i32) -> i32 {
-        ^block103(v839: i32):
-            v840, v841 = hir.exec @miden/note/get_inputs(v839) : i32, i32
-            builtin.ret v840;
+        private builtin.function @miden::note::get_inputs(v856: i32) -> i32 {
+        ^block105(v856: i32):
+            v857, v858 = hir.exec @miden/note/get_inputs(v856) : i32, i32
+            builtin.ret v857;
         };
 
-        private builtin.function @miden::note::get_assets(v843: i32) -> i32 {
-        ^block106(v843: i32):
-            v844, v845 = hir.exec @miden/note/get_assets(v843) : i32, i32
-            builtin.ret v844;
+        private builtin.function @miden::note::get_assets(v860: i32) -> i32 {
+        ^block108(v860: i32):
+            v861, v862 = hir.exec @miden/note/get_assets(v860) : i32, i32
+            builtin.ret v861;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {
@@ -1222,9 +1252,9 @@ builtin.component miden:base/note-script@1.0.0 {
         builtin.segment @1048620 = 0x0000002200000030000000290010000000000021000000120000002900100000000000010000000100000001;
     };
 
-    public builtin.function @run(v847: felt, v848: felt, v849: felt, v850: felt) {
-    ^block108(v847: felt, v848: felt, v849: felt, v850: felt):
-        hir.exec @miden:base/note-script@1.0.0/p2id/miden:base/note-script@1.0.0#run(v847, v848, v849, v850)
+    public builtin.function @run(v864: felt, v865: felt, v866: felt, v867: felt) {
+    ^block110(v864: felt, v865: felt, v866: felt, v867: felt):
+        hir.exec @miden:base/note-script@1.0.0/p2id/miden:base/note-script@1.0.0#run(v864, v865, v866, v867)
         builtin.ret ;
     };
 };

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -326,98 +326,47 @@ proc.miden:base/note-script@1.0.0#run
         swap.1
         trace.240
         nop
-        exec.::miden:base/note-script@1.0.0::p2id::intrinsics::felt::assert_eq
+        exec.::miden:base/note-script@1.0.0::p2id::intrinsics::felt::eq
         trace.252
         nop
-        trace.240
-        nop
-        exec.::miden:base/note-script@1.0.0::p2id::intrinsics::felt::assert_eq
-        trace.252
-        nop
-        push.28
-        dup.1
-        u32wrapping_add
-        trace.240
-        nop
-        exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::note::get_assets
-        trace.252
-        nop
-        push.36
-        dup.1
-        add
-        u32assert
-        push.4
-        dup.1
-        swap.1
-        u32mod
-        u32assert
-        assertz
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::load_sw
-        trace.252
-        nop
-        push.28
-        dup.2
-        add
-        u32assert
-        push.4
-        dup.1
-        swap.1
-        u32mod
-        u32assert
-        assertz
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::load_sw
-        trace.252
-        nop
-        push.32
-        dup.3
-        add
-        u32assert
-        push.4
-        dup.1
-        swap.1
-        u32mod
-        u32assert
-        assertz
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::load_sw
-        trace.252
-        nop
-        push.4
-        movup.3
-        swap.1
-        u32shl
-        dup.1
-        swap.3
-        swap.4
-        swap.2
-        swap.1
+        push.0
         push.1
-        while.true
+        movup.2
+        neq
+        neq
+        if.true
+            drop
+            drop
+            drop
+            push.1
+        else
+            trace.240
+            nop
+            exec.::miden:base/note-script@1.0.0::p2id::intrinsics::felt::eq
+            trace.252
+            nop
             push.0
-            push.0
-            dup.2
-            eq
+            push.1
+            movup.2
+            neq
             neq
             dup.0
             if.true
-                movdn.2
+                swap.1
                 drop
-                drop
-                push.3735929054
-                dup.0
             else
+                push.28
                 dup.2
+                u32wrapping_add
+                trace.240
+                nop
+                exec.::miden:base/note-script@1.0.0::p2id::miden_base_sys::bindings::note::get_assets
+                trace.252
+                nop
+                push.36
+                dup.2
+                add
+                u32assert
                 push.4
                 dup.1
                 swap.1
@@ -428,10 +377,27 @@ proc.miden:base/note-script@1.0.0#run
                 swap.1
                 trace.240
                 nop
-                exec.::intrinsics::mem::load_felt
+                exec.::intrinsics::mem::load_sw
                 trace.252
                 nop
+                push.28
+                dup.3
+                add
+                u32assert
                 push.4
+                dup.1
+                swap.1
+                u32mod
+                u32assert
+                assertz
+                u32divmod.4
+                swap.1
+                trace.240
+                nop
+                exec.::intrinsics::mem::load_sw
+                trace.252
+                nop
+                push.32
                 dup.4
                 add
                 u32assert
@@ -445,177 +411,238 @@ proc.miden:base/note-script@1.0.0#run
                 swap.1
                 trace.240
                 nop
-                exec.::intrinsics::mem::load_felt
+                exec.::intrinsics::mem::load_sw
                 trace.252
                 nop
-                push.8
-                dup.5
-                add
-                u32assert
                 push.4
+                movup.3
+                swap.1
+                u32shl
                 dup.1
-                swap.1
-                u32mod
-                u32assert
-                assertz
-                u32divmod.4
-                swap.1
-                trace.240
-                nop
-                exec.::intrinsics::mem::load_felt
-                trace.252
-                nop
-                push.12
-                dup.6
-                add
-                u32assert
-                push.4
-                dup.1
-                swap.1
-                u32mod
-                u32assert
-                assertz
-                u32divmod.4
-                swap.1
-                trace.240
-                nop
-                exec.::intrinsics::mem::load_felt
-                trace.252
-                nop
-                movdn.3
+                swap.3
+                swap.4
+                swap.5
                 swap.2
+                swap.1
+                push.1
+                while.true
+                    push.0
+                    push.0
+                    dup.2
+                    eq
+                    neq
+                    dup.0
+                    if.true
+                        movdn.2
+                        drop
+                        drop
+                        push.3735929054
+                        dup.0
+                    else
+                        dup.2
+                        push.4
+                        dup.1
+                        swap.1
+                        u32mod
+                        u32assert
+                        assertz
+                        u32divmod.4
+                        swap.1
+                        trace.240
+                        nop
+                        exec.::intrinsics::mem::load_felt
+                        trace.252
+                        nop
+                        push.4
+                        dup.4
+                        add
+                        u32assert
+                        push.4
+                        dup.1
+                        swap.1
+                        u32mod
+                        u32assert
+                        assertz
+                        u32divmod.4
+                        swap.1
+                        trace.240
+                        nop
+                        exec.::intrinsics::mem::load_felt
+                        trace.252
+                        nop
+                        push.8
+                        dup.5
+                        add
+                        u32assert
+                        push.4
+                        dup.1
+                        swap.1
+                        u32mod
+                        u32assert
+                        assertz
+                        u32divmod.4
+                        swap.1
+                        trace.240
+                        nop
+                        exec.::intrinsics::mem::load_felt
+                        trace.252
+                        nop
+                        push.12
+                        dup.6
+                        add
+                        u32assert
+                        push.4
+                        dup.1
+                        swap.1
+                        u32mod
+                        u32assert
+                        assertz
+                        u32divmod.4
+                        swap.1
+                        trace.240
+                        nop
+                        exec.::intrinsics::mem::load_felt
+                        trace.252
+                        nop
+                        movdn.3
+                        swap.2
+                        trace.240
+                        nop
+                        exec.::miden:base/note-script@1.0.0::p2id::p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7
+                        trace.252
+                        nop
+                        push.16
+                        movup.3
+                        u32wrapping_add
+                        push.4294967280
+                        movup.3
+                        u32wrapping_add
+                    end
+                    push.3735929054
+                    dup.3
+                    dup.7
+                    swap.2
+                    swap.1
+                    cdrop
+                    push.3735929054
+                    dup.4
+                    dup.7
+                    swap.2
+                    swap.1
+                    cdrop
+                    push.3735929054
+                    dup.5
+                    dup.7
+                    swap.2
+                    swap.1
+                    cdrop
+                    push.1
+                    push.0
+                    movup.7
+                    cdrop
+                    push.1
+                    u32and
+                    swap.1
+                    swap.3
+                    swap.5
+                    swap.2
+                    swap.4
+                    swap.1
+                    if.true
+                        movup.5
+                        drop
+                        movup.5
+                        drop
+                        movup.5
+                        drop
+                        push.1
+                    else
+                        push.0
+                    end
+                end
+                drop
+                drop
+                drop
+                drop
+                drop
+                push.44
+                dup.1
+                add
+                u32assert
+                push.4
+                dup.1
+                swap.1
+                u32mod
+                u32assert
+                assertz
+                movup.2
+                swap.1
+                u32divmod.4
+                swap.1
                 trace.240
                 nop
-                exec.::miden:base/note-script@1.0.0::p2id::p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7
+                exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
+                push.40
+                dup.1
+                add
+                u32assert
+                push.4
+                dup.1
+                swap.1
+                u32mod
+                u32assert
+                assertz
+                movup.2
+                swap.1
+                u32divmod.4
+                swap.1
+                trace.240
+                nop
+                exec.::intrinsics::mem::store_sw
                 trace.252
                 nop
                 push.16
-                movup.3
+                push.40
+                dup.2
                 u32wrapping_add
-                push.4294967280
-                movup.3
+                dup.1
+                swap.2
+                swap.1
+                trace.240
+                nop
+                exec.::miden:base/note-script@1.0.0::p2id::alloc::raw_vec::RawVecInner<A>::deallocate
+                trace.252
+                nop
+                push.4
+                push.16
+                dup.2
                 u32wrapping_add
+                dup.1
+                swap.2
+                swap.1
+                trace.240
+                nop
+                exec.::miden:base/note-script@1.0.0::p2id::alloc::raw_vec::RawVecInner<A>::deallocate
+                trace.252
+                nop
+                push.48
+                u32wrapping_add
+                push.1114208
+                u32divmod.4
+                swap.1
+                trace.240
+                nop
+                exec.::intrinsics::mem::store_sw
+                trace.252
+                nop
             end
-            push.3735929054
-            dup.3
-            dup.7
-            swap.2
-            swap.1
-            cdrop
-            push.3735929054
-            dup.4
-            dup.7
-            swap.2
-            swap.1
-            cdrop
-            push.3735929054
-            dup.5
-            dup.7
-            swap.2
-            swap.1
-            cdrop
-            push.1
             push.0
-            movup.7
-            cdrop
             push.1
-            u32and
-            swap.1
-            swap.3
-            swap.5
-            swap.2
-            swap.4
-            swap.1
-            if.true
-                movup.5
-                drop
-                movup.5
-                drop
-                movup.5
-                drop
-                push.1
-            else
-                push.0
-            end
+            movup.2
+            cdrop
         end
-        drop
-        drop
-        drop
-        drop
-        drop
-        push.44
-        dup.1
-        add
-        u32assert
-        push.4
-        dup.1
-        swap.1
-        u32mod
-        u32assert
-        assertz
-        movup.2
-        swap.1
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::store_sw
-        trace.252
-        nop
-        push.40
-        dup.1
-        add
-        u32assert
-        push.4
-        dup.1
-        swap.1
-        u32mod
-        u32assert
-        assertz
-        movup.2
-        swap.1
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::store_sw
-        trace.252
-        nop
-        push.16
-        push.40
-        dup.2
-        u32wrapping_add
-        dup.1
-        swap.2
-        swap.1
-        trace.240
-        nop
-        exec.::miden:base/note-script@1.0.0::p2id::alloc::raw_vec::RawVecInner<A>::deallocate
-        trace.252
-        nop
-        push.4
-        push.16
-        dup.2
-        u32wrapping_add
-        dup.1
-        swap.2
-        swap.1
-        trace.240
-        nop
-        exec.::miden:base/note-script@1.0.0::p2id::alloc::raw_vec::RawVecInner<A>::deallocate
-        trace.252
-        nop
-        push.48
-        u32wrapping_add
-        push.1114208
-        u32divmod.4
-        swap.1
-        trace.240
-        nop
-        exec.::intrinsics::mem::store_sw
-        trace.252
-        nop
-        push.0
     end
     push.0
     eq
@@ -1417,8 +1444,8 @@ proc.miden_base_sys::bindings::note::get_assets
     nop
 end
 
-proc.intrinsics::felt::assert_eq
-    assert_eq
+proc.intrinsics::felt::eq
+    eq
 end
 
 proc.alloc::raw_vec::RawVecInner<A>::deallocate

--- a/tests/integration/expected/examples/p2id.wat
+++ b/tests/integration/expected/examples/p2id.wat
@@ -30,7 +30,7 @@
     (type (;5;) (func (result i32)))
     (type (;6;) (func (param i32 i32 i32 i32)))
     (type (;7;) (func (param i32)))
-    (type (;8;) (func (param f32 f32)))
+    (type (;8;) (func (param f32 f32) (result i32)))
     (type (;9;) (func (param i32 i32 i32 i32 i32)))
     (type (;10;) (func (param i32) (result i32)))
     (import "miden:basic-wallet/basic-wallet@1.0.0" "receive-asset" (func $p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7 (;0;) (type 0)))
@@ -89,95 +89,102 @@
         block ;; label = @2
           local.get 4
           i32.load offset=24
-          br_table 0 (;@2;) 0 (;@2;) 1 (;@1;)
+          br_table 1 (;@1;) 1 (;@1;) 0 (;@2;)
         end
-        unreachable
-      end
-      local.get 4
-      i32.load offset=20
-      local.tee 5
-      f32.load offset=4
-      local.set 6
-      local.get 5
-      f32.load
-      local.set 7
-      local.get 4
-      i32.const 8
-      i32.add
-      call $miden_base_sys::bindings::account::get_id
-      local.get 4
-      f32.load offset=12
-      local.set 8
-      local.get 4
-      f32.load offset=8
-      local.get 7
-      call $intrinsics::felt::assert_eq
-      local.get 8
-      local.get 6
-      call $intrinsics::felt::assert_eq
-      local.get 4
-      i32.const 28
-      i32.add
-      call $miden_base_sys::bindings::note::get_assets
-      local.get 4
-      i32.load offset=36
-      i32.const 4
-      i32.shl
-      local.set 9
-      local.get 4
-      i32.load offset=28
-      local.set 10
-      local.get 4
-      i32.load offset=32
-      local.tee 11
-      local.set 5
-      block ;; label = @1
-        loop ;; label = @2
-          local.get 9
-          i32.eqz
-          br_if 1 (;@1;)
-          local.get 5
-          f32.load
-          local.get 5
-          f32.load offset=4
-          local.get 5
-          f32.load offset=8
-          local.get 5
-          f32.load offset=12
-          call $p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7
-          local.get 9
-          i32.const -16
-          i32.add
-          local.set 9
-          local.get 5
-          i32.const 16
-          i32.add
-          local.set 5
-          br 0 (;@2;)
+        local.get 4
+        i32.load offset=20
+        local.tee 5
+        f32.load offset=4
+        local.set 6
+        local.get 5
+        f32.load
+        local.set 7
+        local.get 4
+        i32.const 8
+        i32.add
+        call $miden_base_sys::bindings::account::get_id
+        local.get 4
+        f32.load offset=12
+        local.set 8
+        local.get 4
+        f32.load offset=8
+        local.get 7
+        call $intrinsics::felt::eq
+        i32.const 1
+        i32.ne
+        br_if 0 (;@1;)
+        local.get 8
+        local.get 6
+        call $intrinsics::felt::eq
+        i32.const 1
+        i32.ne
+        br_if 0 (;@1;)
+        local.get 4
+        i32.const 28
+        i32.add
+        call $miden_base_sys::bindings::note::get_assets
+        local.get 4
+        i32.load offset=36
+        i32.const 4
+        i32.shl
+        local.set 9
+        local.get 4
+        i32.load offset=28
+        local.set 10
+        local.get 4
+        i32.load offset=32
+        local.tee 11
+        local.set 5
+        block ;; label = @2
+          loop ;; label = @3
+            local.get 9
+            i32.eqz
+            br_if 1 (;@2;)
+            local.get 5
+            f32.load
+            local.get 5
+            f32.load offset=4
+            local.get 5
+            f32.load offset=8
+            local.get 5
+            f32.load offset=12
+            call $p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7
+            local.get 9
+            i32.const -16
+            i32.add
+            local.set 9
+            local.get 5
+            i32.const 16
+            i32.add
+            local.set 5
+            br 0 (;@3;)
+          end
         end
+        local.get 4
+        local.get 11
+        i32.store offset=44
+        local.get 4
+        local.get 10
+        i32.store offset=40
+        local.get 4
+        i32.const 40
+        i32.add
+        i32.const 16
+        i32.const 16
+        call $alloc::raw_vec::RawVecInner<A>::deallocate
+        local.get 4
+        i32.const 16
+        i32.add
+        i32.const 4
+        i32.const 4
+        call $alloc::raw_vec::RawVecInner<A>::deallocate
+        local.get 4
+        i32.const 48
+        i32.add
+        global.set $__stack_pointer
+        return
       end
-      local.get 4
-      local.get 11
-      i32.store offset=44
-      local.get 4
-      local.get 10
-      i32.store offset=40
-      local.get 4
-      i32.const 40
-      i32.add
-      i32.const 16
-      i32.const 16
-      call $alloc::raw_vec::RawVecInner<A>::deallocate
-      local.get 4
-      i32.const 16
-      i32.add
-      i32.const 4
-      i32.const 4
-      call $alloc::raw_vec::RawVecInner<A>::deallocate
-      local.get 4
-      i32.const 48
-      i32.add
-      global.set $__stack_pointer
+      unreachable
     )
     (func $__rustc::__rust_no_alloc_shim_is_unstable_v2 (;7;) (type 1)
       return
@@ -414,7 +421,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $intrinsics::felt::assert_eq (;15;) (type 8) (param f32 f32)
+    (func $intrinsics::felt::eq (;15;) (type 8) (param f32 f32) (result i32)
       unreachable
     )
     (func $alloc::raw_vec::RawVecInner<A>::deallocate (;16;) (type 3) (param i32 i32 i32)


### PR DESCRIPTION
Resolves #702 

This PR adds on two new features to the `AccountId` type:

1) Enables the `==` operator to be used with the `AccountId` type.
2) Adds a `AccountId::from` method to convert two `Felt` types into an `AccountId`.

The P2ID script is updated to use these two new features. 