### PR TITLE
feat: add eq & debug attributes to protocol types

### DIFF
--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -14,7 +14,7 @@ impl AccountId {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Asset {
     pub inner: Word,
@@ -61,6 +61,7 @@ impl AsRef<Word> for Asset {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Recipient {
     pub inner: Word,
@@ -74,6 +75,13 @@ impl From<[Felt; 4]> for Recipient {
     }
 }
 
+impl From<Word> for Recipient {
+    fn from(value: Word) -> Self {
+        Recipient { inner: value }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Tag {
     pub inner: Felt,
@@ -85,12 +93,13 @@ impl From<Felt> for Tag {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct NoteIdx {
     pub inner: Felt,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct NoteType {
     pub inner: Felt,
@@ -102,6 +111,7 @@ impl From<Felt> for NoteType {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct StorageCommitmentRoot(Word);
 


### PR DESCRIPTION
This PR makes it possible to use `==`, `assert_eq!`, and `assert!` with protocol types. This PR is related to #703 except extents this to all protocol types in the compiler.