### PR TITLE
Fix invalid trait object slice example

### DIFF
--- a/docs/external/src/appendix/known-limitations.md
+++ b/docs/external/src/appendix/known-limitations.md
@@ -104,7 +104,7 @@ impl Foo for u32 {
     fn is_foo(&self) -> bool { true }
 }
 
-fn has_foo(items: &[dyn Foo]) -> bool {
+fn has_foo(items: &[&dyn Foo]) -> bool {
     items.iter().any(|item| item.is_foo())
 }
 


### PR DESCRIPTION
The Rust example uses `&[dyn Foo]`, which does not compile because trait objects (`dyn Foo`) are unsized and cannot be used directly as slice elements.

Updated the function signature to use references to trait objects (`&[&dyn Foo]`), keeping the example behavior while making the snippet valid Rust.