### PR TITLE
feat: add `I32RemS` op to `wasm` dialect

### DIFF
--- a/codegen/masm/src/emit/binary.rs
+++ b/codegen/masm/src/emit/binary.rs
@@ -691,6 +691,21 @@ impl OpEmitter<'_> {
         self.push(ty);
     }
 
+    pub fn wrapping_mod(&mut self, span: SourceSpan) {
+        let rhs = self.pop().expect("operand stack is empty");
+        let lhs = self.pop().expect("operand stack is empty");
+        let ty = lhs.ty();
+        assert_eq!(ty, rhs.ty(), "expected wrapping_mod operands to be the same type");
+        match &ty {
+            Type::I32 => self.wrapping_mod_i32(span),
+            ty if !ty.is_integer() => {
+                panic!("invalid binary operand: wrapping_mod expects integer operands, got {ty}")
+            }
+            ty => unimplemented!("wrapping_mod for {ty} is not supported"),
+        }
+        self.push(ty);
+    }
+
     #[allow(unused)]
     pub fn unchecked_mod(&mut self, span: SourceSpan) {
         let rhs = self.pop().expect("operand stack is empty");

--- a/codegen/masm/src/emit/int32.rs
+++ b/codegen/masm/src/emit/int32.rs
@@ -785,6 +785,7 @@ impl OpEmitter<'_> {
     /// Pops two i32 values off the stack, `b` and `a`, and performs `a % b`.
     ///
     /// This operation is checked, so if the operands or result are not valid i32, execution traps.
+    /// It also traps for `i32::MIN % -1` since the underlying division overflows.
     pub fn checked_mod_i32(&mut self, span: SourceSpan) {
         self.raw_exec("::intrinsics::i32::checked_mod", span);
     }
@@ -794,10 +795,19 @@ impl OpEmitter<'_> {
     /// This function will panic if the divisor is zero.
     ///
     /// This operation is checked, so if the operand or result are not valid i32, execution traps.
+    /// It also traps for `i32::MIN % -1` since the underlying division overflows.
     pub fn checked_mod_imm_i32(&mut self, imm: i32, span: SourceSpan) {
         assert_ne!(imm, 0, "division by zero is not allowed");
         self.emit_push(imm as u32, span);
         self.raw_exec("::intrinsics::i32::checked_mod", span);
+    }
+
+    /// Pops two i32 values off the stack, `b` and `a`, and performs `a % b`.
+    ///
+    /// This operation wraps around on overflow, so for `i32::MIN % -1` it returns `0` instead of
+    /// trapping. It will still trap on division by zero (i.e. when `b` == 0).
+    pub fn wrapping_mod_i32(&mut self, span: SourceSpan) {
+        self.raw_exec("::intrinsics::i32::wrapping_mod", span);
     }
 
     /// Pops two u32 values off the stack, `b` and `a`, and performs `a / b`.

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -212,6 +212,7 @@ fn lower_wasm_ops(info: &mut midenc_hir::DialectInfo) {
     info.register_operation_trait::<wasm::I64Load8S, dyn HirLowering>();
     info.register_operation_trait::<wasm::I64Load16S, dyn HirLowering>();
     info.register_operation_trait::<wasm::I64Load32S, dyn HirLowering>();
+    info.register_operation_trait::<wasm::I32RemS, dyn HirLowering>();
 }
 
 fn lower_debuginfo_ops(info: &mut midenc_hir::DialectInfo) {

--- a/codegen/masm/src/lower/lowering.rs
+++ b/codegen/masm/src/lower/lowering.rs
@@ -1840,3 +1840,10 @@ impl_hir_lowering_load_sext!(wasm::I32Load16S);
 impl_hir_lowering_load_sext!(wasm::I64Load8S);
 impl_hir_lowering_load_sext!(wasm::I64Load16S);
 impl_hir_lowering_load_sext!(wasm::I64Load32S);
+
+impl HirLowering for wasm::I32RemS {
+    fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
+        emitter.inst_emitter(self.as_operation()).wrapping_mod(self.span());
+        Ok(())
+    }
+}

--- a/dialects/wasm/src/builders.rs
+++ b/dialects/wasm/src/builders.rs
@@ -78,6 +78,17 @@ pub trait WasmOpBuilder<'f, B: ?Sized + Builder>: WasmMemOpBuilder<'f, B> {
         Ok(op.borrow().result().as_value_ref())
     }
 
+    fn i32_rem_s(
+        &mut self,
+        lhs: ValueRef,
+        rhs: ValueRef,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        let op_builder = WasmOpBuilder::builder_mut(self).create::<crate::ops::I32RemS, _>(span);
+        let op = op_builder(lhs, rhs)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
     fn builder(&self) -> &B;
     fn builder_mut(&mut self) -> &mut B;
 }

--- a/dialects/wasm/src/ops.rs
+++ b/dialects/wasm/src/ops.rs
@@ -285,3 +285,29 @@ impl InferTypeOpInterface for I64Load32S {
         Ok(())
     }
 }
+
+/// Signed integer remainder, traps on division by zero.
+///
+/// This corresponds to Wasm's `i32.rem_s` instruction. The result has the same sign as the
+/// dividend (lhs). For `i32::MIN % -1` the result wraps to `0`, matching Wasm semantics.
+#[derive(EffectOpInterface, OpPrinter, OpParser)]
+#[operation(
+    dialect = WasmDialect,
+    traits(BinaryOp, SameTypeOperands, SameOperandsAndResultType),
+    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+)]
+pub struct I32RemS {
+    #[operand]
+    lhs: Int32,
+    #[operand]
+    rhs: Int32,
+    #[result]
+    result: Int32,
+}
+
+impl InferTypeOpInterface for I32RemS {
+    fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
+        self.result_mut().set_type(Type::I32);
+        Ok(())
+    }
+}

--- a/eval/src/eval.rs
+++ b/eval/src/eval.rs
@@ -931,6 +931,47 @@ macro_rules! binop_overflowing {
     }};
 }
 
+macro_rules! binop_wrapping_nonzero_rhs {
+    ($op:ident, $evaluator:ident, $operator:ident) => {{
+        let lhs = $op.lhs();
+        let lhs_value = $evaluator.use_value(&lhs.as_value_ref())?;
+        let rhs = $op.rhs();
+        let rhs_value = $evaluator.use_value(&rhs.as_value_ref())?;
+
+        let lhs_ty = lhs.ty();
+        let rhs_ty = lhs.ty();
+        if lhs_ty != rhs_ty {
+            return Err($evaluator.report(
+                "evaluation failed",
+                $op.span(),
+                format!("operand types do not match: {lhs_ty} vs {rhs_ty}"),
+            ));
+        }
+
+        if rhs_value == 0 {
+            return Err($evaluator.report(
+                "evaluation failed",
+                $op.span(),
+                format!("rhs must not be zero"),
+            ));
+        }
+
+        match (lhs_value, rhs_value) {
+            (Immediate::I8(x), Immediate::I8(y)) => Immediate::I8(x.$operator(y)),
+            (Immediate::U8(x), Immediate::U8(y)) => Immediate::U8(x.$operator(y)),
+            (Immediate::I16(x), Immediate::I16(y)) => Immediate::I16(x.$operator(y)),
+            (Immediate::U16(x), Immediate::U16(y)) => Immediate::U16(x.$operator(y)),
+            (Immediate::I32(x), Immediate::I32(y)) => Immediate::I32(x.$operator(y)),
+            (Immediate::U32(x), Immediate::U32(y)) => Immediate::U32(x.$operator(y)),
+            (Immediate::I64(x), Immediate::I64(y)) => Immediate::I64(x.$operator(y)),
+            (Immediate::U64(x), Immediate::U64(y)) => Immediate::U64(x.$operator(y)),
+            (Immediate::I128(x), Immediate::I128(y)) => Immediate::I128(x.$operator(y)),
+            (Immediate::U128(x), Immediate::U128(y)) => Immediate::U128(x.$operator(y)),
+            _ => unreachable!(),
+        }
+    }};
+}
+
 macro_rules! logical_binop {
     ($op:ident, $evaluator:ident, $operator:ident) => {{
         let lhs = $op.lhs();
@@ -2172,3 +2213,11 @@ impl_eval_load_sext!(wasm::I32Load16S, I16, I32, i32);
 impl_eval_load_sext!(wasm::I64Load8S, I8, I64, i64);
 impl_eval_load_sext!(wasm::I64Load16S, I16, I64, i64);
 impl_eval_load_sext!(wasm::I64Load32S, I32, I64, i64);
+
+impl Eval for wasm::I32RemS {
+    fn eval(&self, evaluator: &mut HirEvaluator) -> Result<ControlFlowEffect, Report> {
+        let result = binop_wrapping_nonzero_rhs!(self, evaluator, wrapping_rem);
+        evaluator.set_value(self.result().as_value_ref(), result);
+        Ok(ControlFlowEffect::None)
+    }
+}

--- a/eval/src/eval.rs
+++ b/eval/src/eval.rs
@@ -872,7 +872,7 @@ macro_rules! binop_overflowing {
         let rhs_value = $evaluator.use_value(&rhs.as_value_ref())?;
 
         let lhs_ty = lhs.ty();
-        let rhs_ty = lhs.ty();
+        let rhs_ty = rhs.ty();
         if lhs_ty != rhs_ty {
             return Err($evaluator.report(
                 "evaluation failed",

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -160,6 +160,7 @@ fn eval_wasm_dialect(info: &mut ::midenc_hir::DialectInfo) {
     info.register_operation_trait::<wasm::I64Load8S, dyn Eval>();
     info.register_operation_trait::<wasm::I64Load16S, dyn Eval>();
     info.register_operation_trait::<wasm::I64Load32S, dyn Eval>();
+    info.register_operation_trait::<wasm::I32RemS, dyn Eval>();
 }
 
 fn eval_debuginfo_dialect(info: &mut ::midenc_hir::DialectInfo) {

--- a/frontend/wasm/src/code_translator/expected/i32_rem_s.hir
+++ b/frontend/wasm/src/code_translator/expected/i32_rem_s.hir
@@ -1,7 +1,7 @@
 builtin.function public extern("C") @test_wrapper() {
     %0 = arith.constant 2 : i32;
     %1 = arith.constant 1 : i32;
-    %2 = arith.mod %0, %1;
+    %2 = wasm.i32_rem_s %0, %1;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -598,7 +598,11 @@ pub fn translate_operator<B: ?Sized + Builder>(
             let val = builder.r#mod(arg1, arg2, span)?;
             state.push1(builder.bitcast(val, I64, span)?);
         }
-        Operator::I32RemS | Operator::I64RemS => {
+        Operator::I32RemS => {
+            let (arg1, arg2) = state.pop2();
+            state.push1(builder.i32_rem_s(arg1, arg2, span)?);
+        }
+        Operator::I64RemS => {
             let (arg1, arg2) = state.pop2();
             state.push1(builder.r#mod(arg1, arg2, span)?);
         }

--- a/tests/integration/src/end_to_end/wasm_translation/i32.rs
+++ b/tests/integration/src/end_to_end/wasm_translation/i32.rs
@@ -114,7 +114,6 @@ fn i32_div_s() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1206"]
 fn i32_rem_s() {
     test_i32_wasm_op_binary("i32.rem_s", NumericStrategy::<i32>::rem_signed_checked());
 }


### PR DESCRIPTION
- Adds op `I32RemS` to the `wasm` dialect
- Translates Wasm's `i32.rem_s` to `I32RemS`, which is lowered to intrinsic `i32::wrapping_mod` instead of `i32::checked_mod`

Fixes the `i32.rem_s` miscompilation (see #1206) and makes the `i32_rem_s` test pass.