### PR TITLE
fix(midenc): print compiled artifact path

### DIFF
--- a/midenc-compile/src/lib.rs
+++ b/midenc-compile/src/lib.rs
@@ -19,7 +19,7 @@ use alloc::rc::Rc;
 pub use midenc_hir::Context;
 use midenc_hir::Op;
 use midenc_session::{
-    OutputMode,
+    Emit, OutputMode, OutputType,
     diagnostics::{Diagnostic, Report, WrapErr, miette},
 };
 
@@ -54,10 +54,15 @@ pub fn compile(context: Rc<Context>) -> CompilerResult<()> {
                 .emit(OutputMode::Text, package)
                 .map_err(Report::msg)
                 .wrap_err("failed to pretty print 'mast' artifact")?;
+            let output_path = session.emit_to(OutputType::Masp, package.name());
             session
                 .emit(OutputMode::Binary, package)
                 .map_err(Report::msg)
-                .wrap_err("failed to serialize 'mast' artifact")
+                .wrap_err("failed to serialize 'mast' artifact")?;
+            if let Some(output_path) = output_path {
+                session.diagnostics.info(format!("Compiled {}", output_path.display()));
+            }
+            Ok(())
         }
         CompiledArtifact::Lowered(_) => {
             log::debug!("no outputs requested by user: pipeline stopped before assembly");


### PR DESCRIPTION
Fixes #1274.

`midenc_compile::compile` now asks the session for the `.masp` output path before writing the binary artifact, then reports `Compiled <path>` through the normal diagnostics path after serialization succeeds. That keeps stdout untouched when the artifact itself is written there.

Validation:
- `git diff --check -- midenc-compile/src/lib.rs`
- Tried `cargo check -p midenc-compile`, but this machine only has Homebrew rustc 1.90.0 and no rustup. The current workspace/dependencies require rustc 1.97 / nightly-2026-04-30, so I could not complete a local build here.