### PR TITLE
test: un-ignore spill_edge differential regression test

### DIFF
--- a/tests/integration/src/end_to_end/differential/tests/spills.rs
+++ b/tests/integration/src/end_to_end/differential/tests/spills.rs
@@ -47,8 +47,6 @@ fn spill_twin() {
 /// then yields it, so the spilled value crosses the control-flow edge as the
 /// arm's result. A second shape (nested wide diamonds) hits the same panic.
 #[test]
-#[ignore = "compile-time compiler panic: TransformSpills convert_reload_to_load unwraps None \
-            (dialects/hir/src/transforms/spill.rs:157); gates the edge-split spill cluster"]
 fn spill_edge() {
     run_case("spill_edge", include_str!("../cases/case_spill_edge.rs"));
 }


### PR DESCRIPTION
Re-enables `spill_edge` per @bitwalker's comment on #1289.

The compile-time panic this test was `#[ignore]`d for (`TransformSpills convert_reload_to_load` unwrapping `None` at `dialects/hir/src/transforms/spill.rs:157`) no longer reproduces against current `next` - that function already returns a graceful `Result::Err` instead of unwrapping, likely as a side effect of other recent spill-related changes.

Confirmed with:
```
PROPTEST_CASES=200 cargo test -p midenc-integration-tests --lib -- \
  --exact end_to_end::differential::tests::spills::spill_edge --ignored --nocapture
```
`test result: ok. 1 passed; 0 failed`

Closes #1289.