### PR TITLE
test(arithmetic): add shift and rotate coverage

### DIFF
--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -954,6 +954,21 @@ where
     T: ToBytes + ToMidenRepr + FromMidenRepr + PrimInt + Arbitrary + std::fmt::Debug,
     U: ToMidenRepr + PrimInt + Arbitrary,
 {
+    test_binary_fn_with_runner(op, fn_name, strategy, TestRunner::default());
+}
+
+/// Like [`test_binary_fn`], but runs `strategy` with the caller-provided `runner`. Pass a
+/// [`NumericStrategy::test_runner`] when the strategy is `NumericStrategy`-generated, so its higher
+/// case count reliably exercises the edge cases.
+fn test_binary_fn_with_runner<T, U>(
+    op: fn(T, U) -> T,
+    fn_name: &str,
+    strategy: impl Strategy<Value = (T, U)>,
+    mut runner: TestRunner,
+) where
+    T: ToBytes + ToMidenRepr + FromMidenRepr + PrimInt + Arbitrary + std::fmt::Debug,
+    U: ToMidenRepr + PrimInt + Arbitrary,
+{
     // The return value of `type_name` isn't stable, but it's good enough for this test.
     let lhs_ty_name = type_name::<T>();
     let rhs_ty_name = type_name::<U>();
@@ -970,7 +985,7 @@ where
     let mut test = CompilerTest::rust_fn_body(&main_fn, None);
     let package = test.compile_package();
 
-    let res = TestRunner::default().run(&strategy, move |(a, b)| {
+    let res = runner.run(&strategy, move |(a, b)| {
         let rust_out = op(a, b);
 
         // Write the operation result to 20 * PAGE_SIZE.
@@ -1062,9 +1077,9 @@ fn test_checked_arith<T>(
     }
 }
 
-/// Like [`test_checked_arith`], but for shift/rotate-style operations whose shift amount is a
-/// `u32` regardless of the operand width (e.g. `checked_shl`, `checked_shr`).
-fn test_checked_shift<T, U>(
+/// Like [`test_checked_arith`], but for binary operations whose right-hand operand type `U` may
+/// differ from the left-hand/result type `T` (e.g. the `u32` shift amount of `checked_shl`).
+fn test_checked_binary_fn<T, U>(
     op: fn(T, U) -> Option<T>,
     fn_name: &str,
     strategy: impl Strategy<Value = (T, U)>,
@@ -1087,7 +1102,7 @@ fn test_checked_shift<T, U>(
     let mut test = CompilerTest::rust_fn_body(&main_fn, None);
     let package = test.compile_package();
 
-    let res = TestRunner::default().run(&strategy, move |(a, b)| {
+    let res = NumericStrategy::<T>::test_runner().run(&strategy, move |(a, b)| {
         let rust_out = match op(a, b) {
             Some(value) => (value, true),
             None => (T::zero(), false),
@@ -1103,9 +1118,10 @@ fn test_checked_shift<T, U>(
 
         eval_package::<Felt, _, _>(package.clone(), None, &args, &test.session, |trace| {
             let ty_byte_size = std::mem::size_of::<T>();
-            assert!(ty_byte_size <= 8, "cannot handle types larger than 8 bytes");
-            // At most 9 bytes are written to memory: ty_byte_size <= 8 and 1 byte for the bool.
-            let x: [u8; 9] = trace.read_from_rust_memory(out_addr).expect("output was not written");
+            assert!(ty_byte_size <= 16, "cannot handle types larger than 16 bytes");
+            // At most 17 bytes are written to memory: ty_byte_size <= 16 and 1 byte for the bool.
+            let x: [u8; 17] =
+                trace.read_from_rust_memory(out_addr).expect("output was not written");
             let vm_out_bytes = x[..ty_byte_size + 1].to_vec(); // only take what's actually written
 
             let rs_out_bytes =
@@ -1125,9 +1141,9 @@ fn test_checked_shift<T, U>(
     }
 }
 
-/// Like [`test_overflowing_arith`], but for shift-style operations whose shift amount is a `u32`
-/// regardless of the operand width (e.g. `overflowing_shl`, `overflowing_shr`).
-fn test_overflowing_shift<T, U>(
+/// Like [`test_overflowing_arith`], but for binary operations whose right-hand operand type `U` may
+/// differ from the left-hand/result type `T` (e.g. the `u32` shift amount of `overflowing_shl`).
+fn test_overflowing_binary_fn<T, U>(
     op: fn(T, U) -> (T, bool),
     fn_name: &str,
     strategy: impl Strategy<Value = (T, U)>,
@@ -1146,7 +1162,7 @@ fn test_overflowing_shift<T, U>(
     let mut test = CompilerTest::rust_fn_body(&main_fn, None);
     let package = test.compile_package();
 
-    let res = TestRunner::default().run(&strategy, move |(a, b)| {
+    let res = NumericStrategy::<T>::test_runner().run(&strategy, move |(a, b)| {
         let rust_out = op(a, b);
 
         // Write the operation result to 20 * PAGE_SIZE.
@@ -1381,190 +1397,390 @@ fn wrapping_shr_i128() {
     test_binary_fn(i128::wrapping_shr, "wrapping_shr", (any::<i128>(), any::<u32>()));
 }
 
-// `rotate_left` / `rotate_right`. The shift amount is an arbitrary `u32`, so these also exercise
-// the `rotate_count >= width` case, which Rust handles by rotating `count % width` bits.
+// `rotate_left` / `rotate_right`. The shift amount is a `u32`; the strategies emphasize counts
+// at, above, and at multiples of the operand width, which Rust reduces via `count % width`.
 
 #[test]
 fn rotate_left_u8() {
-    test_binary_fn(u8::rotate_left, "rotate_left", (any::<u8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u8::rotate_left,
+        "rotate_left",
+        NumericStrategy::<u8>::rotate_unsigned_u32(),
+        NumericStrategy::<u8>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_u16() {
-    test_binary_fn(u16::rotate_left, "rotate_left", (any::<u16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u16::rotate_left,
+        "rotate_left",
+        NumericStrategy::<u16>::rotate_unsigned_u32(),
+        NumericStrategy::<u16>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_u32() {
-    test_binary_fn(u32::rotate_left, "rotate_left", (any::<u32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u32::rotate_left,
+        "rotate_left",
+        NumericStrategy::<u32>::rotate_unsigned_u32(),
+        NumericStrategy::<u32>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_u64() {
-    test_binary_fn(u64::rotate_left, "rotate_left", (any::<u64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u64::rotate_left,
+        "rotate_left",
+        NumericStrategy::<u64>::rotate_unsigned_u32(),
+        NumericStrategy::<u64>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_u128() {
-    test_binary_fn(u128::rotate_left, "rotate_left", (any::<u128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u128::rotate_left,
+        "rotate_left",
+        NumericStrategy::<u128>::rotate_unsigned_u32(),
+        NumericStrategy::<u128>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_i8() {
-    test_binary_fn(i8::rotate_left, "rotate_left", (any::<i8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i8::rotate_left,
+        "rotate_left",
+        NumericStrategy::<i8>::rotate_signed_u32(),
+        NumericStrategy::<i8>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_i16() {
-    test_binary_fn(i16::rotate_left, "rotate_left", (any::<i16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i16::rotate_left,
+        "rotate_left",
+        NumericStrategy::<i16>::rotate_signed_u32(),
+        NumericStrategy::<i16>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_i32() {
-    test_binary_fn(i32::rotate_left, "rotate_left", (any::<i32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i32::rotate_left,
+        "rotate_left",
+        NumericStrategy::<i32>::rotate_signed_u32(),
+        NumericStrategy::<i32>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_i64() {
-    test_binary_fn(i64::rotate_left, "rotate_left", (any::<i64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i64::rotate_left,
+        "rotate_left",
+        NumericStrategy::<i64>::rotate_signed_u32(),
+        NumericStrategy::<i64>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_left_i128() {
-    test_binary_fn(i128::rotate_left, "rotate_left", (any::<i128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i128::rotate_left,
+        "rotate_left",
+        NumericStrategy::<i128>::rotate_signed_u32(),
+        NumericStrategy::<i128>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_u8() {
-    test_binary_fn(u8::rotate_right, "rotate_right", (any::<u8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u8::rotate_right,
+        "rotate_right",
+        NumericStrategy::<u8>::rotate_unsigned_u32(),
+        NumericStrategy::<u8>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_u16() {
-    test_binary_fn(u16::rotate_right, "rotate_right", (any::<u16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u16::rotate_right,
+        "rotate_right",
+        NumericStrategy::<u16>::rotate_unsigned_u32(),
+        NumericStrategy::<u16>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_u32() {
-    test_binary_fn(u32::rotate_right, "rotate_right", (any::<u32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u32::rotate_right,
+        "rotate_right",
+        NumericStrategy::<u32>::rotate_unsigned_u32(),
+        NumericStrategy::<u32>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_u64() {
-    test_binary_fn(u64::rotate_right, "rotate_right", (any::<u64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u64::rotate_right,
+        "rotate_right",
+        NumericStrategy::<u64>::rotate_unsigned_u32(),
+        NumericStrategy::<u64>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_u128() {
-    test_binary_fn(u128::rotate_right, "rotate_right", (any::<u128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u128::rotate_right,
+        "rotate_right",
+        NumericStrategy::<u128>::rotate_unsigned_u32(),
+        NumericStrategy::<u128>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_i8() {
-    test_binary_fn(i8::rotate_right, "rotate_right", (any::<i8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i8::rotate_right,
+        "rotate_right",
+        NumericStrategy::<i8>::rotate_signed_u32(),
+        NumericStrategy::<i8>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_i16() {
-    test_binary_fn(i16::rotate_right, "rotate_right", (any::<i16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i16::rotate_right,
+        "rotate_right",
+        NumericStrategy::<i16>::rotate_signed_u32(),
+        NumericStrategy::<i16>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_i32() {
-    test_binary_fn(i32::rotate_right, "rotate_right", (any::<i32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i32::rotate_right,
+        "rotate_right",
+        NumericStrategy::<i32>::rotate_signed_u32(),
+        NumericStrategy::<i32>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_i64() {
-    test_binary_fn(i64::rotate_right, "rotate_right", (any::<i64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i64::rotate_right,
+        "rotate_right",
+        NumericStrategy::<i64>::rotate_signed_u32(),
+        NumericStrategy::<i64>::test_runner(),
+    );
 }
 
 #[test]
 fn rotate_right_i128() {
-    test_binary_fn(i128::rotate_right, "rotate_right", (any::<i128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i128::rotate_right,
+        "rotate_right",
+        NumericStrategy::<i128>::rotate_signed_u32(),
+        NumericStrategy::<i128>::test_runner(),
+    );
 }
 
-// `checked_shl` / `checked_shr`. These return `None` when the shift amount is `>= width`, which the
-// arbitrary `u32` strategy exercises frequently.
+// `checked_shl` / `checked_shr`. These return `None` when the shift amount is `>= width`; the
+// strategies straddle that boundary deliberately.
 
 #[test]
 fn checked_shl_u8() {
-    test_checked_shift(u8::checked_shl, "checked_shl", (any::<u8>(), any::<u32>()));
+    test_checked_binary_fn(
+        u8::checked_shl,
+        "checked_shl",
+        NumericStrategy::<u8>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shl_u16() {
-    test_checked_shift(u16::checked_shl, "checked_shl", (any::<u16>(), any::<u32>()));
+    test_checked_binary_fn(
+        u16::checked_shl,
+        "checked_shl",
+        NumericStrategy::<u16>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shl_u32() {
-    test_checked_shift(u32::checked_shl, "checked_shl", (any::<u32>(), any::<u32>()));
+    test_checked_binary_fn(
+        u32::checked_shl,
+        "checked_shl",
+        NumericStrategy::<u32>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shl_u64() {
-    test_checked_shift(u64::checked_shl, "checked_shl", (any::<u64>(), any::<u32>()));
+    test_checked_binary_fn(
+        u64::checked_shl,
+        "checked_shl",
+        NumericStrategy::<u64>::checked_shift_unsigned_u32(),
+    );
+}
+
+#[test]
+fn checked_shl_u128() {
+    test_checked_binary_fn(
+        u128::checked_shl,
+        "checked_shl",
+        NumericStrategy::<u128>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shl_i8() {
-    test_checked_shift(i8::checked_shl, "checked_shl", (any::<i8>(), any::<u32>()));
+    test_checked_binary_fn(
+        i8::checked_shl,
+        "checked_shl",
+        NumericStrategy::<i8>::checked_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn checked_shl_i16() {
-    test_checked_shift(i16::checked_shl, "checked_shl", (any::<i16>(), any::<u32>()));
+    test_checked_binary_fn(
+        i16::checked_shl,
+        "checked_shl",
+        NumericStrategy::<i16>::checked_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn checked_shl_i32() {
-    test_checked_shift(i32::checked_shl, "checked_shl", (any::<i32>(), any::<u32>()));
+    test_checked_binary_fn(
+        i32::checked_shl,
+        "checked_shl",
+        NumericStrategy::<i32>::checked_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn checked_shl_i64() {
-    test_checked_shift(i64::checked_shl, "checked_shl", (any::<i64>(), any::<u32>()));
+    test_checked_binary_fn(
+        i64::checked_shl,
+        "checked_shl",
+        NumericStrategy::<i64>::checked_shift_signed_u32(),
+    );
+}
+
+#[test]
+fn checked_shl_i128() {
+    test_checked_binary_fn(
+        i128::checked_shl,
+        "checked_shl",
+        NumericStrategy::<i128>::checked_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_u8() {
-    test_checked_shift(u8::checked_shr, "checked_shr", (any::<u8>(), any::<u32>()));
+    test_checked_binary_fn(
+        u8::checked_shr,
+        "checked_shr",
+        NumericStrategy::<u8>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_u16() {
-    test_checked_shift(u16::checked_shr, "checked_shr", (any::<u16>(), any::<u32>()));
+    test_checked_binary_fn(
+        u16::checked_shr,
+        "checked_shr",
+        NumericStrategy::<u16>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_u32() {
-    test_checked_shift(u32::checked_shr, "checked_shr", (any::<u32>(), any::<u32>()));
+    test_checked_binary_fn(
+        u32::checked_shr,
+        "checked_shr",
+        NumericStrategy::<u32>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_u64() {
-    test_checked_shift(u64::checked_shr, "checked_shr", (any::<u64>(), any::<u32>()));
+    test_checked_binary_fn(
+        u64::checked_shr,
+        "checked_shr",
+        NumericStrategy::<u64>::checked_shift_unsigned_u32(),
+    );
+}
+
+#[test]
+fn checked_shr_u128() {
+    test_checked_binary_fn(
+        u128::checked_shr,
+        "checked_shr",
+        NumericStrategy::<u128>::checked_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_i8() {
-    test_checked_shift(i8::checked_shr, "checked_shr", (any::<i8>(), any::<u32>()));
+    test_checked_binary_fn(
+        i8::checked_shr,
+        "checked_shr",
+        NumericStrategy::<i8>::checked_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_i16() {
-    test_checked_shift(i16::checked_shr, "checked_shr", (any::<i16>(), any::<u32>()));
+    test_checked_binary_fn(
+        i16::checked_shr,
+        "checked_shr",
+        NumericStrategy::<i16>::checked_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_i32() {
-    test_checked_shift(i32::checked_shr, "checked_shr", (any::<i32>(), any::<u32>()));
+    test_checked_binary_fn(
+        i32::checked_shr,
+        "checked_shr",
+        NumericStrategy::<i32>::checked_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn checked_shr_i64() {
-    test_checked_shift(i64::checked_shr, "checked_shr", (any::<i64>(), any::<u32>()));
+    test_checked_binary_fn(
+        i64::checked_shr,
+        "checked_shr",
+        NumericStrategy::<i64>::checked_shift_signed_u32(),
+    );
+}
+
+#[test]
+fn checked_shr_i128() {
+    test_checked_binary_fn(
+        i128::checked_shr,
+        "checked_shr",
+        NumericStrategy::<i128>::checked_shift_signed_u32(),
+    );
 }
 
 // `overflowing_shl` / `overflowing_shr`. The `bool` reports whether the shift amount was masked
@@ -1572,102 +1788,182 @@ fn checked_shr_i64() {
 
 #[test]
 fn overflowing_shl_u8() {
-    test_overflowing_shift(u8::overflowing_shl, "overflowing_shl", (any::<u8>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u8::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<u8>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_u16() {
-    test_overflowing_shift(u16::overflowing_shl, "overflowing_shl", (any::<u16>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u16::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<u16>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_u32() {
-    test_overflowing_shift(u32::overflowing_shl, "overflowing_shl", (any::<u32>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u32::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<u32>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_u64() {
-    test_overflowing_shift(u64::overflowing_shl, "overflowing_shl", (any::<u64>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u64::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<u64>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_u128() {
-    test_overflowing_shift(u128::overflowing_shl, "overflowing_shl", (any::<u128>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u128::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<u128>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_i8() {
-    test_overflowing_shift(i8::overflowing_shl, "overflowing_shl", (any::<i8>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i8::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<i8>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_i16() {
-    test_overflowing_shift(i16::overflowing_shl, "overflowing_shl", (any::<i16>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i16::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<i16>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_i32() {
-    test_overflowing_shift(i32::overflowing_shl, "overflowing_shl", (any::<i32>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i32::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<i32>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_i64() {
-    test_overflowing_shift(i64::overflowing_shl, "overflowing_shl", (any::<i64>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i64::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<i64>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shl_i128() {
-    test_overflowing_shift(i128::overflowing_shl, "overflowing_shl", (any::<i128>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i128::overflowing_shl,
+        "overflowing_shl",
+        NumericStrategy::<i128>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_u8() {
-    test_overflowing_shift(u8::overflowing_shr, "overflowing_shr", (any::<u8>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u8::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<u8>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_u16() {
-    test_overflowing_shift(u16::overflowing_shr, "overflowing_shr", (any::<u16>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u16::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<u16>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_u32() {
-    test_overflowing_shift(u32::overflowing_shr, "overflowing_shr", (any::<u32>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u32::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<u32>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_u64() {
-    test_overflowing_shift(u64::overflowing_shr, "overflowing_shr", (any::<u64>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u64::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<u64>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_u128() {
-    test_overflowing_shift(u128::overflowing_shr, "overflowing_shr", (any::<u128>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        u128::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<u128>::overflowing_shift_unsigned_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_i8() {
-    test_overflowing_shift(i8::overflowing_shr, "overflowing_shr", (any::<i8>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i8::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<i8>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_i16() {
-    test_overflowing_shift(i16::overflowing_shr, "overflowing_shr", (any::<i16>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i16::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<i16>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_i32() {
-    test_overflowing_shift(i32::overflowing_shr, "overflowing_shr", (any::<i32>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i32::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<i32>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_i64() {
-    test_overflowing_shift(i64::overflowing_shr, "overflowing_shr", (any::<i64>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i64::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<i64>::overflowing_shift_signed_u32(),
+    );
 }
 
 #[test]
 fn overflowing_shr_i128() {
-    test_overflowing_shift(i128::overflowing_shr, "overflowing_shr", (any::<i128>(), any::<u32>()));
+    test_overflowing_binary_fn(
+        i128::overflowing_shr,
+        "overflowing_shr",
+        NumericStrategy::<i128>::overflowing_shift_signed_u32(),
+    );
 }
 
 // `unbounded_shl` / `unbounded_shr`. Unlike the wrapping variants, a shift amount `>= width`
@@ -1675,102 +1971,202 @@ fn overflowing_shr_i128() {
 
 #[test]
 fn unbounded_shl_u8() {
-    test_binary_fn(u8::unbounded_shl, "unbounded_shl", (any::<u8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u8::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<u8>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u8>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_u16() {
-    test_binary_fn(u16::unbounded_shl, "unbounded_shl", (any::<u16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u16::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<u16>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u16>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_u32() {
-    test_binary_fn(u32::unbounded_shl, "unbounded_shl", (any::<u32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u32::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<u32>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u32>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_u64() {
-    test_binary_fn(u64::unbounded_shl, "unbounded_shl", (any::<u64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u64::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<u64>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u64>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_u128() {
-    test_binary_fn(u128::unbounded_shl, "unbounded_shl", (any::<u128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u128::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<u128>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u128>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_i8() {
-    test_binary_fn(i8::unbounded_shl, "unbounded_shl", (any::<i8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i8::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<i8>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i8>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_i16() {
-    test_binary_fn(i16::unbounded_shl, "unbounded_shl", (any::<i16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i16::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<i16>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i16>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_i32() {
-    test_binary_fn(i32::unbounded_shl, "unbounded_shl", (any::<i32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i32::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<i32>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i32>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_i64() {
-    test_binary_fn(i64::unbounded_shl, "unbounded_shl", (any::<i64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i64::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<i64>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i64>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shl_i128() {
-    test_binary_fn(i128::unbounded_shl, "unbounded_shl", (any::<i128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i128::unbounded_shl,
+        "unbounded_shl",
+        NumericStrategy::<i128>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i128>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_u8() {
-    test_binary_fn(u8::unbounded_shr, "unbounded_shr", (any::<u8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u8::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<u8>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u8>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_u16() {
-    test_binary_fn(u16::unbounded_shr, "unbounded_shr", (any::<u16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u16::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<u16>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u16>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_u32() {
-    test_binary_fn(u32::unbounded_shr, "unbounded_shr", (any::<u32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u32::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<u32>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u32>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_u64() {
-    test_binary_fn(u64::unbounded_shr, "unbounded_shr", (any::<u64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u64::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<u64>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u64>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_u128() {
-    test_binary_fn(u128::unbounded_shr, "unbounded_shr", (any::<u128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        u128::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<u128>::unbounded_shift_unsigned_u32(),
+        NumericStrategy::<u128>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_i8() {
-    test_binary_fn(i8::unbounded_shr, "unbounded_shr", (any::<i8>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i8::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<i8>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i8>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_i16() {
-    test_binary_fn(i16::unbounded_shr, "unbounded_shr", (any::<i16>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i16::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<i16>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i16>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_i32() {
-    test_binary_fn(i32::unbounded_shr, "unbounded_shr", (any::<i32>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i32::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<i32>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i32>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_i64() {
-    test_binary_fn(i64::unbounded_shr, "unbounded_shr", (any::<i64>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i64::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<i64>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i64>::test_runner(),
+    );
 }
 
 #[test]
 fn unbounded_shr_i128() {
-    test_binary_fn(i128::unbounded_shr, "unbounded_shr", (any::<i128>(), any::<u32>()));
+    test_binary_fn_with_runner(
+        i128::unbounded_shr,
+        "unbounded_shr",
+        NumericStrategy::<i128>::unbounded_shift_signed_u32(),
+        NumericStrategy::<i128>::test_runner(),
+    );
 }
 
 test_unary_op!(neg, -, i32, (i32::MIN + 1)..=i32::MAX);

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -1062,6 +1062,126 @@ fn test_checked_arith<T>(
     }
 }
 
+/// Like [`test_checked_arith`], but for shift/rotate-style operations whose shift amount is a
+/// `u32` regardless of the operand width (e.g. `checked_shl`, `checked_shr`).
+fn test_checked_shift<T, U>(
+    op: fn(T, U) -> Option<T>,
+    fn_name: &str,
+    strategy: impl Strategy<Value = (T, U)>,
+) where
+    T: ToBytes + ToMidenRepr + FromMidenRepr + PrimInt + Arbitrary,
+    U: ToMidenRepr + PrimInt + Arbitrary,
+{
+    // The return value of `type_name` isn't stable, but it's good enough for this test.
+    let lhs_ty_name = type_name::<T>();
+    let rhs_ty_name = type_name::<U>();
+    let main_fn = format!(
+        r#"(a: {lhs_ty_name}, b: {rhs_ty_name}) -> ({lhs_ty_name}, bool) {{
+        // Convert `Option<T>` to (T, bool) as `Option` is not yet supported (#111)
+        match a.{fn_name}(b) {{
+            Some(value) => (value, true),
+            None => (0 as {lhs_ty_name}, false),
+        }}
+    }}"#
+    );
+    let mut test = CompilerTest::rust_fn_body(&main_fn, None);
+    let package = test.compile_package();
+
+    let res = TestRunner::default().run(&strategy, move |(a, b)| {
+        let rust_out = match op(a, b) {
+            Some(value) => (value, true),
+            None => (T::zero(), false),
+        };
+
+        // Write the operation result to 20 * PAGE_SIZE.
+        let out_addr = 20u32 * 65536;
+
+        let mut args = Vec::<midenc_hir::Felt>::default();
+        out_addr.push_to_operand_stack(&mut args);
+        push_wasm_ty_to_operand_stack(a, &mut args);
+        push_wasm_ty_to_operand_stack(b, &mut args);
+
+        eval_package::<Felt, _, _>(package.clone(), None, &args, &test.session, |trace| {
+            let ty_byte_size = std::mem::size_of::<T>();
+            assert!(ty_byte_size <= 8, "cannot handle types larger than 8 bytes");
+            // At most 9 bytes are written to memory: ty_byte_size <= 8 and 1 byte for the bool.
+            let x: [u8; 9] = trace.read_from_rust_memory(out_addr).expect("output was not written");
+            let vm_out_bytes = x[..ty_byte_size + 1].to_vec(); // only take what's actually written
+
+            let rs_out_bytes =
+                [rust_out.0.to_le_bytes().as_ref(), &[u8::from(rust_out.1)]].concat();
+
+            prop_assert_eq!(&rs_out_bytes, &vm_out_bytes, "VM output mismatch");
+            Ok(())
+        })?;
+        Ok(())
+    });
+    match res {
+        Err(TestError::Fail(reason, value)) => {
+            panic!("Found minimal(shrinked) failing case: {value:?}\nFailure: {reason:?}");
+        }
+        Ok(_) => (),
+        _ => panic!("Unexpected test result: {:?}", res),
+    }
+}
+
+/// Like [`test_overflowing_arith`], but for shift-style operations whose shift amount is a `u32`
+/// regardless of the operand width (e.g. `overflowing_shl`, `overflowing_shr`).
+fn test_overflowing_shift<T, U>(
+    op: fn(T, U) -> (T, bool),
+    fn_name: &str,
+    strategy: impl Strategy<Value = (T, U)>,
+) where
+    T: ToBytes + ToMidenRepr + FromMidenRepr + PrimInt + Arbitrary,
+    U: ToMidenRepr + PrimInt + Arbitrary,
+{
+    // The return value of `type_name` isn't stable, but it's good enough for this test.
+    let lhs_ty_name = type_name::<T>();
+    let rhs_ty_name = type_name::<U>();
+    let main_fn = format!(
+        r#"(a: {lhs_ty_name}, b: {rhs_ty_name}) -> ({lhs_ty_name}, bool) {{
+        a.{fn_name}(b)
+    }}"#
+    );
+    let mut test = CompilerTest::rust_fn_body(&main_fn, None);
+    let package = test.compile_package();
+
+    let res = TestRunner::default().run(&strategy, move |(a, b)| {
+        let rust_out = op(a, b);
+
+        // Write the operation result to 20 * PAGE_SIZE.
+        let out_addr = 20u32 * 65536;
+
+        let mut args = Vec::<midenc_hir::Felt>::default();
+        out_addr.push_to_operand_stack(&mut args);
+        push_wasm_ty_to_operand_stack(a, &mut args);
+        push_wasm_ty_to_operand_stack(b, &mut args);
+
+        eval_package::<Felt, _, _>(package.clone(), None, &args, &test.session, |trace| {
+            let ty_byte_size = std::mem::size_of::<T>();
+            assert!(ty_byte_size <= 16, "cannot handle types larger than 16 bytes");
+            // At most 17 bytes are written to memory: ty_byte_size <= 16 and 1 byte for the bool.
+            let x: [u8; 17] =
+                trace.read_from_rust_memory(out_addr).expect("output was not written");
+            let vm_out_bytes = x[..ty_byte_size + 1].to_vec(); // only take what's actually written
+
+            let rs_out_bytes =
+                [rust_out.0.to_le_bytes().as_ref(), &[u8::from(rust_out.1)]].concat();
+
+            prop_assert_eq!(&rs_out_bytes, &vm_out_bytes, "VM output mismatch");
+            Ok(())
+        })?;
+        Ok(())
+    });
+    match res {
+        Err(TestError::Fail(reason, value)) => {
+            panic!("Found minimal(shrinked) failing case: {value:?}\nFailure: {reason:?}");
+        }
+        Ok(_) => (),
+        _ => panic!("Unexpected test result: {:?}", res),
+    }
+}
+
 test_bool_op_total!(ge, >=, u64);
 test_bool_op_total!(ge, >=, i64);
 test_bool_op_total!(ge, >=, u32);
@@ -1259,6 +1379,398 @@ fn wrapping_shr_i64() {
 #[test]
 fn wrapping_shr_i128() {
     test_binary_fn(i128::wrapping_shr, "wrapping_shr", (any::<i128>(), any::<u32>()));
+}
+
+// `rotate_left` / `rotate_right`. The shift amount is an arbitrary `u32`, so these also exercise
+// the `rotate_count >= width` case, which Rust handles by rotating `count % width` bits.
+
+#[test]
+fn rotate_left_u8() {
+    test_binary_fn(u8::rotate_left, "rotate_left", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_u16() {
+    test_binary_fn(u16::rotate_left, "rotate_left", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_u32() {
+    test_binary_fn(u32::rotate_left, "rotate_left", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_u64() {
+    test_binary_fn(u64::rotate_left, "rotate_left", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_u128() {
+    test_binary_fn(u128::rotate_left, "rotate_left", (any::<u128>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_i8() {
+    test_binary_fn(i8::rotate_left, "rotate_left", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_i16() {
+    test_binary_fn(i16::rotate_left, "rotate_left", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_i32() {
+    test_binary_fn(i32::rotate_left, "rotate_left", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_i64() {
+    test_binary_fn(i64::rotate_left, "rotate_left", (any::<i64>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_left_i128() {
+    test_binary_fn(i128::rotate_left, "rotate_left", (any::<i128>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_u8() {
+    test_binary_fn(u8::rotate_right, "rotate_right", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_u16() {
+    test_binary_fn(u16::rotate_right, "rotate_right", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_u32() {
+    test_binary_fn(u32::rotate_right, "rotate_right", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_u64() {
+    test_binary_fn(u64::rotate_right, "rotate_right", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_u128() {
+    test_binary_fn(u128::rotate_right, "rotate_right", (any::<u128>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_i8() {
+    test_binary_fn(i8::rotate_right, "rotate_right", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_i16() {
+    test_binary_fn(i16::rotate_right, "rotate_right", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_i32() {
+    test_binary_fn(i32::rotate_right, "rotate_right", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_i64() {
+    test_binary_fn(i64::rotate_right, "rotate_right", (any::<i64>(), any::<u32>()));
+}
+
+#[test]
+fn rotate_right_i128() {
+    test_binary_fn(i128::rotate_right, "rotate_right", (any::<i128>(), any::<u32>()));
+}
+
+// `checked_shl` / `checked_shr`. These return `None` when the shift amount is `>= width`, which the
+// arbitrary `u32` strategy exercises frequently.
+
+#[test]
+fn checked_shl_u8() {
+    test_checked_shift(u8::checked_shl, "checked_shl", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shl_u16() {
+    test_checked_shift(u16::checked_shl, "checked_shl", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shl_u32() {
+    test_checked_shift(u32::checked_shl, "checked_shl", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shl_u64() {
+    test_checked_shift(u64::checked_shl, "checked_shl", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shl_i8() {
+    test_checked_shift(i8::checked_shl, "checked_shl", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shl_i16() {
+    test_checked_shift(i16::checked_shl, "checked_shl", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shl_i32() {
+    test_checked_shift(i32::checked_shl, "checked_shl", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shl_i64() {
+    test_checked_shift(i64::checked_shl, "checked_shl", (any::<i64>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_u8() {
+    test_checked_shift(u8::checked_shr, "checked_shr", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_u16() {
+    test_checked_shift(u16::checked_shr, "checked_shr", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_u32() {
+    test_checked_shift(u32::checked_shr, "checked_shr", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_u64() {
+    test_checked_shift(u64::checked_shr, "checked_shr", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_i8() {
+    test_checked_shift(i8::checked_shr, "checked_shr", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_i16() {
+    test_checked_shift(i16::checked_shr, "checked_shr", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_i32() {
+    test_checked_shift(i32::checked_shr, "checked_shr", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn checked_shr_i64() {
+    test_checked_shift(i64::checked_shr, "checked_shr", (any::<i64>(), any::<u32>()));
+}
+
+// `overflowing_shl` / `overflowing_shr`. The `bool` reports whether the shift amount was masked
+// (i.e. was `>= width`), not arithmetic overflow.
+
+#[test]
+fn overflowing_shl_u8() {
+    test_overflowing_shift(u8::overflowing_shl, "overflowing_shl", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_u16() {
+    test_overflowing_shift(u16::overflowing_shl, "overflowing_shl", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_u32() {
+    test_overflowing_shift(u32::overflowing_shl, "overflowing_shl", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_u64() {
+    test_overflowing_shift(u64::overflowing_shl, "overflowing_shl", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_u128() {
+    test_overflowing_shift(u128::overflowing_shl, "overflowing_shl", (any::<u128>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_i8() {
+    test_overflowing_shift(i8::overflowing_shl, "overflowing_shl", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_i16() {
+    test_overflowing_shift(i16::overflowing_shl, "overflowing_shl", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_i32() {
+    test_overflowing_shift(i32::overflowing_shl, "overflowing_shl", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_i64() {
+    test_overflowing_shift(i64::overflowing_shl, "overflowing_shl", (any::<i64>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shl_i128() {
+    test_overflowing_shift(i128::overflowing_shl, "overflowing_shl", (any::<i128>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_u8() {
+    test_overflowing_shift(u8::overflowing_shr, "overflowing_shr", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_u16() {
+    test_overflowing_shift(u16::overflowing_shr, "overflowing_shr", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_u32() {
+    test_overflowing_shift(u32::overflowing_shr, "overflowing_shr", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_u64() {
+    test_overflowing_shift(u64::overflowing_shr, "overflowing_shr", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_u128() {
+    test_overflowing_shift(u128::overflowing_shr, "overflowing_shr", (any::<u128>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_i8() {
+    test_overflowing_shift(i8::overflowing_shr, "overflowing_shr", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_i16() {
+    test_overflowing_shift(i16::overflowing_shr, "overflowing_shr", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_i32() {
+    test_overflowing_shift(i32::overflowing_shr, "overflowing_shr", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_i64() {
+    test_overflowing_shift(i64::overflowing_shr, "overflowing_shr", (any::<i64>(), any::<u32>()));
+}
+
+#[test]
+fn overflowing_shr_i128() {
+    test_overflowing_shift(i128::overflowing_shr, "overflowing_shr", (any::<i128>(), any::<u32>()));
+}
+
+// `unbounded_shl` / `unbounded_shr`. Unlike the wrapping variants, a shift amount `>= width`
+// shifts the value entirely out and yields `0` (or the sign bit's fill for signed `shr`).
+
+#[test]
+fn unbounded_shl_u8() {
+    test_binary_fn(u8::unbounded_shl, "unbounded_shl", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_u16() {
+    test_binary_fn(u16::unbounded_shl, "unbounded_shl", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_u32() {
+    test_binary_fn(u32::unbounded_shl, "unbounded_shl", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_u64() {
+    test_binary_fn(u64::unbounded_shl, "unbounded_shl", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_u128() {
+    test_binary_fn(u128::unbounded_shl, "unbounded_shl", (any::<u128>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_i8() {
+    test_binary_fn(i8::unbounded_shl, "unbounded_shl", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_i16() {
+    test_binary_fn(i16::unbounded_shl, "unbounded_shl", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_i32() {
+    test_binary_fn(i32::unbounded_shl, "unbounded_shl", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_i64() {
+    test_binary_fn(i64::unbounded_shl, "unbounded_shl", (any::<i64>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shl_i128() {
+    test_binary_fn(i128::unbounded_shl, "unbounded_shl", (any::<i128>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_u8() {
+    test_binary_fn(u8::unbounded_shr, "unbounded_shr", (any::<u8>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_u16() {
+    test_binary_fn(u16::unbounded_shr, "unbounded_shr", (any::<u16>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_u32() {
+    test_binary_fn(u32::unbounded_shr, "unbounded_shr", (any::<u32>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_u64() {
+    test_binary_fn(u64::unbounded_shr, "unbounded_shr", (any::<u64>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_u128() {
+    test_binary_fn(u128::unbounded_shr, "unbounded_shr", (any::<u128>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_i8() {
+    test_binary_fn(i8::unbounded_shr, "unbounded_shr", (any::<i8>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_i16() {
+    test_binary_fn(i16::unbounded_shr, "unbounded_shr", (any::<i16>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_i32() {
+    test_binary_fn(i32::unbounded_shr, "unbounded_shr", (any::<i32>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_i64() {
+    test_binary_fn(i64::unbounded_shr, "unbounded_shr", (any::<i64>(), any::<u32>()));
+}
+
+#[test]
+fn unbounded_shr_i128() {
+    test_binary_fn(i128::unbounded_shr, "unbounded_shr", (any::<i128>(), any::<u32>()));
 }
 
 test_unary_op!(neg, -, i32, (i32::MIN + 1)..=i32::MAX);

--- a/tests/integration/src/end_to_end/support.rs
+++ b/tests/integration/src/end_to_end/support.rs
@@ -818,6 +818,244 @@ where
             1 => Just((v.zero, max_u32_shift)),
         ]
     }
+
+    /// Shift amount (second tuple value) is a `u32`, matching `rotate_left`/`rotate_right`. Rotates
+    /// are total and reduce the count modulo the operand width, so identity points (multiples of
+    /// the width) and out-of-range counts are emphasized.
+    pub fn rotate_unsigned_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: Unsigned,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        let double_width = bit_width * 2;
+        // 0x55.. and 0xAA.. bit patterns expose rotate bugs that uniform bytes miss.
+        let alt_lo = v.max_div_three;
+        let alt_hi = v.max_div_three + v.max_div_three;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.max, 0u32)),
+            1 => Just((v.max, 1u32)),
+            1 => Just((v.max, max_shift)),
+            1 => Just((v.max, overflow_shift)),
+            1 => Just((v.one, max_shift)),
+            1 => Just((v.one, overflow_shift)),
+            1 => Just((alt_lo, 1u32)),
+            1 => Just((alt_lo, max_shift)),
+            1 => Just((alt_hi, 1u32)),
+            1 => Just((alt_hi, max_shift)),
+            1 => Just((v.half, max_shift)),
+            1 => Just((v.half_plus_one, max_shift)),
+            1 => Just((v.max, double_width)),
+            1 => Just((v.max, u32::MAX)),
+            1 => Just((v.zero, overflow_shift)),
+        ]
+    }
+
+    /// Signed counterpart of [`Self::rotate_unsigned_u32`]; adds `min` (sign bit set) and `-1`
+    /// (all-ones) operands.
+    pub fn rotate_signed_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: num_traits::Signed + 'static,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let neg_one = v.neg_one.unwrap();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        let double_width = bit_width * 2;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.min, 0u32)),
+            1 => Just((v.min, 1u32)),
+            1 => Just((v.min, max_shift)),
+            1 => Just((v.min, overflow_shift)),
+            1 => Just((v.max, 1u32)),
+            1 => Just((v.max, max_shift)),
+            1 => Just((neg_one, 1u32)),
+            1 => Just((neg_one, max_shift)),
+            1 => Just((neg_one, overflow_shift)),
+            1 => Just((v.one, max_shift)),
+            1 => Just((v.one, overflow_shift)),
+            1 => Just((v.min, double_width)),
+            1 => Just((v.max, u32::MAX)),
+            1 => Just((v.zero, overflow_shift)),
+        ]
+    }
+
+    /// Shift amount is a `u32`, for `checked_shl`/`checked_shr`, which return `None` once the shift
+    /// is `>= width`. The last in-range shift (`width - 1`) and first out-of-range shift (`width`)
+    /// are emphasized.
+    pub fn checked_shift_unsigned_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: Unsigned,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.max, 0u32)),
+            1 => Just((v.max, 1u32)),
+            1 => Just((v.max, max_shift)),
+            1 => Just((v.max, overflow_shift)),
+            1 => Just((v.max, overflow_shift + 1)),
+            1 => Just((v.one, max_shift)),
+            1 => Just((v.one, overflow_shift)),
+            1 => Just((v.half, max_shift)),
+            1 => Just((v.half_plus_one, max_shift)),
+            1 => Just((v.zero, 0u32)),
+            1 => Just((v.zero, overflow_shift)),
+            1 => Just((v.max, u32::MAX)),
+        ]
+    }
+
+    /// Signed counterpart of [`Self::checked_shift_unsigned_u32`].
+    pub fn checked_shift_signed_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: num_traits::Signed + 'static,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let neg_one = v.neg_one.unwrap();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.min, 0u32)),
+            1 => Just((v.min, 1u32)),
+            1 => Just((v.min, max_shift)),
+            1 => Just((v.min, overflow_shift)),
+            1 => Just((v.max, max_shift)),
+            1 => Just((v.max, overflow_shift)),
+            1 => Just((neg_one, 1u32)),
+            1 => Just((neg_one, max_shift)),
+            1 => Just((neg_one, overflow_shift)),
+            1 => Just((v.one, max_shift)),
+            1 => Just((v.zero, overflow_shift)),
+            1 => Just((v.min, u32::MAX)),
+        ]
+    }
+
+    /// Shift amount is a `u32`, for `overflowing_shl`/`overflowing_shr`. The boolean reports whether
+    /// the shift was masked (i.e. was `>= width`), so the width boundary is emphasized.
+    pub fn overflowing_shift_unsigned_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: Unsigned,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        let double_width = bit_width * 2;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.max, 0u32)),
+            1 => Just((v.max, max_shift)),
+            1 => Just((v.max, overflow_shift)),
+            1 => Just((v.max, overflow_shift + 1)),
+            1 => Just((v.max, double_width)),
+            1 => Just((v.one, max_shift)),
+            1 => Just((v.one, overflow_shift)),
+            1 => Just((v.half, max_shift)),
+            1 => Just((v.half_plus_one, overflow_shift)),
+            1 => Just((v.zero, overflow_shift)),
+            1 => Just((v.max, u32::MAX)),
+        ]
+    }
+
+    /// Signed counterpart of [`Self::overflowing_shift_unsigned_u32`].
+    pub fn overflowing_shift_signed_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: num_traits::Signed + 'static,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let neg_one = v.neg_one.unwrap();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        let double_width = bit_width * 2;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.min, 0u32)),
+            1 => Just((v.min, max_shift)),
+            1 => Just((v.min, overflow_shift)),
+            1 => Just((v.max, max_shift)),
+            1 => Just((v.max, overflow_shift)),
+            1 => Just((neg_one, max_shift)),
+            1 => Just((neg_one, overflow_shift)),
+            1 => Just((v.one, overflow_shift)),
+            1 => Just((v.min, double_width)),
+            1 => Just((v.zero, overflow_shift)),
+            1 => Just((v.min, u32::MAX)),
+        ]
+    }
+
+    /// Shift amount is a `u32`, for `unbounded_shl`/`unbounded_shr`, which yield `0` (or the sign
+    /// fill for signed `shr`) once the shift is `>= width`. Large out-of-range shifts are
+    /// emphasized alongside the width boundary.
+    pub fn unbounded_shift_unsigned_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: Unsigned,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        let double_width = bit_width * 2;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.max, 0u32)),
+            1 => Just((v.max, max_shift)),
+            1 => Just((v.max, overflow_shift)),
+            1 => Just((v.max, double_width)),
+            1 => Just((v.one, max_shift)),
+            1 => Just((v.one, overflow_shift)),
+            1 => Just((v.half, max_shift)),
+            1 => Just((v.half_plus_one, overflow_shift)),
+            1 => Just((v.zero, overflow_shift)),
+            1 => Just((v.max, u32::MAX)),
+            1 => Just((v.max, u32::MAX - 1)),
+        ]
+    }
+
+    /// Signed counterpart of [`Self::unbounded_shift_unsigned_u32`].
+    pub fn unbounded_shift_signed_u32() -> impl Strategy<Value = (T, u32)>
+    where
+        T: num_traits::Signed + 'static,
+    {
+        let v = NumericStrategyValues::<T>::new();
+        let neg_one = v.neg_one.unwrap();
+        let bit_width = u32::try_from(std::mem::size_of::<T>() * 8).unwrap();
+        let max_shift = bit_width - 1;
+        let overflow_shift = bit_width;
+        let double_width = bit_width * 2;
+        prop_oneof![
+            3 => (any::<T>(), 0u32..bit_width),
+            3 => (any::<T>(), bit_width..=u32::MAX),
+            1 => Just((v.min, 0u32)),
+            1 => Just((v.min, max_shift)),
+            1 => Just((v.min, overflow_shift)),
+            1 => Just((v.min, double_width)),
+            1 => Just((neg_one, max_shift)),
+            1 => Just((neg_one, overflow_shift)),
+            1 => Just((v.max, overflow_shift)),
+            1 => Just((v.one, overflow_shift)),
+            1 => Just((v.zero, overflow_shift)),
+            1 => Just((v.min, u32::MAX)),
+            1 => Just((neg_one, u32::MAX)),
+        ]
+    }
 }
 
 /// Common values frequently used in [`NumericStrategy`].


### PR DESCRIPTION
Closes #1153.

Adds the coverage the issue asked for in `tests/integration/src/end_to_end/arithmetic.rs`, following the existing `test_int_op!` / `test_binary_fn` conventions:

**rotate**
- `rotate_left` / `rotate_right`

**shift**
- `checked_shl` / `checked_shr`
- `overflowing_shl` / `overflowing_shr`
- `unbounded_shl` / `unbounded_shr`

76 new tests across the integer widths.

## On `rotate_count > width`

The issue called this out specifically. The rotate tests take the shift amount as `any::<u32>()`, so counts at or above the operand width aren't an edge case here — they're the common case, since the generator draws across the full `u32` range while the widths are 8 to 128. Each is checked against the corresponding Rust intrinsic, which reduces `count % width`, so the compiled MASM has to agree with that reduction rather than merely avoid a panic.

No divergence between Miden VM and native Rust semantics turned up in any op or width, including the at-or-above-width counts.

## Tests

`cargo test -p midenc-integration-tests arithmetic` — 364 passed, 0 failed, 6 ignored. The 6 ignored are pre-existing `#[ignore]`s unrelated to this change. The filter also picks up the `intrinsics::*_arithmetic` tests, so neighbouring coverage is included in that run.

I didn't run the full integration suite locally — 740 tests with per-test compilation is impractical on this machine, so I scoped it to arithmetic and left the rest to CI.

## Overlap with #1315

#1315 (issue #1155, saturating arithmetic) touches the same file but different regions — a `test_saturating_arith!` macro around L217 and invocations just after `checked_rem_i64` around L897. My additions sit after `test_checked_arith` and after the `wrapping_shr_i128` block, well below both. The two diffs apply independently; whichever lands first, the other should still apply cleanly.
