### PR TITLE
test: un-ignore overflowing_rem_i8/i16/i32

### DIFF
--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -640,7 +640,6 @@ fn overflowing_rem_u128() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1173"]
 fn overflowing_rem_i8() {
     test_overflowing_arith(
         i8::overflowing_rem,
@@ -650,7 +649,6 @@ fn overflowing_rem_i8() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1173"]
 fn overflowing_rem_i16() {
     test_overflowing_arith(
         i16::overflowing_rem,
@@ -660,7 +658,6 @@ fn overflowing_rem_i16() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1173"]
 fn overflowing_rem_i32() {
     test_overflowing_arith(
         i32::overflowing_rem,


### PR DESCRIPTION
Re-enables `overflowing_rem_i8`/`i16`/`i32` per @bitwalker's comment on #1173.

All three no longer reproduce against current `next` (the prerequisite #1174 is closed). Verified locally on my own machine, not CI:

```
PROPTEST_CASES=5000 cargo test -p midenc-integration-tests --lib -- --exact end_to_end::arithmetic::overflowing_rem_i8 --ignored --nocapture
PROPTEST_CASES=5000 cargo test -p midenc-integration-tests --lib -- --exact end_to_end::arithmetic::overflowing_rem_i16 --ignored --nocapture
PROPTEST_CASES=5000 cargo test -p midenc-integration-tests --lib -- --exact end_to_end::arithmetic::overflowing_rem_i32 --ignored --nocapture
```
All three: `5000 cases, 0 failures`.

Closes #1173.