### PR TITLE
feat(codegen): implement checked_mod for i64

### DIFF
--- a/codegen/masm/intrinsics/i64.masm
+++ b/codegen/masm/intrinsics/i64.masm
@@ -253,6 +253,50 @@ pub proc checked_div # [b_lo, b_hi, a_lo, a_hi]
     end
 end
 
+# Computes `a % b`, asserting that both inputs are valid i64 values (u32 limbs).
+#
+# Execution traps if `b == 0` or if the result overflows (i64::MIN % -1), matching Rust's
+# panicking `%` semantics for signed integers -- the same case `checked_div` traps on.
+pub proc checked_mod # [b_lo, b_hi, a_lo, a_hi]
+    u32assertw
+
+    # check for i64::MIN % -1, the only overflow case for signed i64 remainder
+    dup.1 push.NEG1_HI eq
+    dup.1 push.NEG1_LO eq
+    and                           # [b == -1, b_lo, b_hi, a_lo, a_hi]
+    dup.4 push.MIN_HI eq
+    dup.4 push.MIN_LO eq
+    and                           # [a == MIN, b == -1, b_lo, b_hi, a_lo, a_hi]
+    and                           # [overflows, b_lo, b_hi, a_lo, a_hi]
+    assertz                       # [b_lo, b_hi, a_lo, a_hi]
+
+    # sign(b) -- computed only to keep the abs(a)/abs(b) choreography identical to
+    # checked_div; unused for the sign of the result.
+    dup.1 push.SIGN_BIT u32and push.SIGN_BIT eq
+    # sign(a)
+    dup.4 push.SIGN_BIT u32and push.SIGN_BIT eq
+    # negate_result = sign(a) -- unlike division, `%`'s result sign always follows the
+    # dividend, never the divisor.
+    dup.0
+    # reorder: [sign_a, sign_b, b, a, negate_result]
+    movdn.6
+
+    # abs(a)
+    movup.4 movup.5 swap
+    exec.cneg_u64  # [abs_a_lo, abs_a_hi, sign_b, b_lo, b_hi, negate_result]
+
+    # abs(b)
+    movup.3 movup.4 swap
+    movup.4 movdn.2
+    exec.cneg_u64  # [abs_b_lo, abs_b_hi, abs_a_lo, abs_a_hi, negate_result]
+
+    # remainder = |a| % |b|
+    exec.::miden::core::math::u64::mod  # [r_lo, r_hi, negate_result]
+
+    # apply the dividend's sign to the result
+    exec.cneg_u64
+end
+
 # Given two i64 values in two's complement representation, compare them,
 # returning -1 if `a` < `b`, 0 if equal, and 1 if `a` > `b`.
 pub proc icmp # [b_lo, b_hi, a_lo, a_hi]

--- a/codegen/masm/src/emit/binary.rs
+++ b/codegen/masm/src/emit/binary.rs
@@ -654,6 +654,7 @@ impl OpEmitter<'_> {
         assert_eq!(ty, rhs.ty(), "expected mod operands to be the same type");
         match &ty {
             Type::U64 => self.checked_mod_u64(span),
+            Type::I64 => self.checked_mod_i64(span),
             Type::I32 => self.checked_mod_i32(span),
             Type::U32 => self.checked_mod_u32(span),
             ty @ (Type::U16 | Type::U8) => {

--- a/codegen/masm/src/emit/int64.rs
+++ b/codegen/masm/src/emit/int64.rs
@@ -732,6 +732,17 @@ impl OpEmitter<'_> {
         self.raw_exec("::miden::core::math::u64::mod", span);
     }
 
+    /// Pops two i64 values off the stack, `b` and `a`, and pushes the result of `a % b` on the
+    /// stack.
+    ///
+    /// Both the operands and result are validated to ensure they are valid i64 values. This
+    /// operation is checked, so if the operands or result are not valid i64, execution traps.
+    /// It also traps for `i64::MIN % -1` since the underlying division overflows.
+    #[inline]
+    pub fn checked_mod_i64(&mut self, span: SourceSpan) {
+        self.raw_exec("::intrinsics::i64::checked_mod", span);
+    }
+
     /// Pops two u64 values off the stack, `b` and `a`, and pushes the result of `a % b` on the
     /// stack.
     ///

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -285,8 +285,7 @@ test_wide_bin_op!(div, /, u128, u128, 0..=u128::MAX, 1..=u128::MAX);
 test_wide_bin_op!(div, /, i128, i128, i128::MIN..=i128::MAX, 1..=i128::MAX);
 
 test_int_op!(rem, %, u64, 0..=u64::MAX, 1..=u64::MAX);
-// https://github.com/0xMiden/compiler/issues/1285
-// test_int_op!(rem, %, i64, i64::MIN..=i64::MAX, 1..=i64::MAX);
+test_int_op!(rem, %, i64, i64::MIN..=i64::MAX, 1..=i64::MAX);
 test_int_op!(rem, %, u32, 0..=u32::MAX, 1..=u32::MAX);
 test_int_op!(rem, %, i32, i32::MIN..=i32::MAX, 1..=i32::MAX);
 test_int_op!(rem, %, u16, 0..=u16::MAX, 1..=u16::MAX);

--- a/tests/integration/src/end_to_end/differential/tests/signed.rs
+++ b/tests/integration/src/end_to_end/differential/tests/signed.rs
@@ -110,11 +110,9 @@ fn i64_sdiv() {
 }
 
 /// Reproducer for a compile-time gap: signed 64-bit `%` with a dynamic
-/// divisor — `arith.Mod` on I64 reaches `checked_mod`, whose dispatch has no
-/// I64 arm (and no wasm.I64RemS op or i64 mod intrinsic exists to back one).
+/// divisor — `arith.Mod` on I64 reaches `checked_mod`, whose dispatch now has an I64 arm
+/// backed by `::intrinsics::i64::checked_mod`.
 #[test]
-#[ignore = "compile-time compiler panic: 'not implemented: checked_mod for i64 is not supported' \
-            (codegen/masm/src/emit/binary.rs:665); i64 % with a dynamic divisor cannot compile"]
 fn i64_srem() {
     run_case("i64_srem", include_str!("../cases/case_i64_srem.rs"));
 }


### PR DESCRIPTION
Implements `checked_mod` for i64. Fixes #1285.

- New `checked_mod` proc in `codegen/masm/intrinsics/i64.masm`, mirroring `checked_div`'s abs/sign choreography: validate operands, trap on `i64::MIN % -1` (matching Rust's panicking `%` semantics - the same case `checked_div` already traps on for `/`), otherwise compute the magnitude via `::miden::core::math::u64::mod` on the absolute values and apply the **dividend's** sign (not the divisor's) to the result.
- New `checked_mod_i64` in `codegen/masm/src/emit/int64.rs` (parallel to the existing `checked_div_i64`).
- The missing `I64` arm in `checked_mod`'s dispatch in `codegen/masm/src/emit/binary.rs`.
- Un-ignores `i64_srem` (the differential-fuzzing regression test that documented this as a known compiler panic) and `test_int_op!(rem, %, i64, ...)` in `arithmetic.rs`.

Deliberately scoped to just this: `checked_rem_i64` (#1000, already assigned to @mooori) and `checked_mul_i64` (#1144) are separate, unrelated Option-returning `checked_*` gaps, untouched here.

Verified locally, not just CI:

```
cargo test -p midenc-integration-tests --lib -- --exact end_to_end::differential::tests::signed::i64_srem --nocapture
cargo test -p midenc-integration-tests --lib -- --exact end_to_end::arithmetic::rem_i64 --nocapture
cargo test -p midenc-integration-tests --lib -- end_to_end::arithmetic i64 --nocapture
```
First two: `1 passed`. Third (full i64 arithmetic regression sweep): `274 passed; 0 failed; 6 ignored` (the 6 ignored are unrelated, gated on other open issues).