### PR TITLE
tests: share one build directory across the suite's nested cargo builds

### DIFF
--- a/tests/integration-network/src/mockchain/asset_amount.rs
+++ b/tests/integration-network/src/mockchain/asset_amount.rs
@@ -170,11 +170,8 @@ fn compile_note_package(note_name: &str, source: &str, wallet_root: &Path) -> Ar
 fn asset_amount_api_matches_kernel_balances() {
     // Compile the contracts first (before creating any runtime)
     let (wallet_project, wallet_package) = build_wallet_project();
-    let note_package = compile_note_package(
-        "asset-amount-note",
-        ASSET_AMOUNT_NOTE_SOURCE,
-        wallet_project.root().as_path(),
-    );
+    let note_package =
+        compile_note_package("asset-amount-note", ASSET_AMOUNT_NOTE_SOURCE, wallet_project.root());
 
     let wallet_component =
         AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();

--- a/tests/integration-network/src/mockchain/fpi/blind_import.rs
+++ b/tests/integration-network/src/mockchain/fpi/blind_import.rs
@@ -72,10 +72,7 @@ fn different_account_import_sets_have_distinct_metadata_worlds() {
     );
     let first_root = first_account.root();
     let second_root = second_account.root();
-    let dependencies = [
-        (FIRST_ACCOUNT_PACKAGE, first_root.as_path()),
-        (SECOND_ACCOUNT_PACKAGE, second_root.as_path()),
-    ];
+    let dependencies = [(FIRST_ACCOUNT_PACKAGE, first_root), (SECOND_ACCOUNT_PACKAGE, second_root)];
     let note_project = project(NOTE_NAME)
         .file(
             "miden-project.toml",
@@ -136,7 +133,7 @@ fn build_note_project(
                 note_name,
                 note_package,
                 ACCOUNT_PACKAGE,
-                &account_root,
+                account_root,
             )),
         )
         .file(
@@ -144,7 +141,7 @@ fn build_note_project(
             &use_regression_version(note_cargo_toml_for_dependency(
                 note_name,
                 ACCOUNT_PACKAGE,
-                &account_root,
+                account_root,
             )),
         )
         .file("src/lib.rs", source)

--- a/tests/integration-network/src/mockchain/fpi/common.rs
+++ b/tests/integration-network/src/mockchain/fpi/common.rs
@@ -39,11 +39,8 @@ pub(super) fn build_fpi_test_packages(
     let counter_package = compile_rust_package(account_project.root(), true);
 
     let note_project = project(&names.note_name)
-        .file(
-            "miden-project.toml",
-            &note_miden_project_toml(&names, account_project.root().as_path()),
-        )
-        .file("Cargo.toml", &note_cargo_toml(&names, account_project.root().as_path()))
+        .file("miden-project.toml", &note_miden_project_toml(&names, account_project.root()))
+        .file("Cargo.toml", &note_cargo_toml(&names, account_project.root()))
         .file("src/lib.rs", caller_source)
         .build();
     let caller_note_package = compile_rust_package(note_project.root(), true);
@@ -113,8 +110,8 @@ pub(super) fn build_multi_package_fpi_test_packages(
     let first_account_root = first_account_project.root();
     let second_account_root = second_account_project.root();
     let dependencies = [
-        (names.first_account_package.as_str(), first_account_root.as_path()),
-        (names.second_account_package.as_str(), second_account_root.as_path()),
+        (names.first_account_package.as_str(), first_account_root),
+        (names.second_account_package.as_str(), second_account_root),
     ];
     let note_project = project(&names.note_name)
         .file(
@@ -173,7 +170,7 @@ pub(super) fn build_account_to_account_fpi_test_packages(
                 &names.caller_account_name,
                 &names.caller_account_package,
                 &names.callee_account_package,
-                callee_project.root().as_path(),
+                callee_project.root(),
             ),
         )
         .file(
@@ -182,7 +179,7 @@ pub(super) fn build_account_to_account_fpi_test_packages(
                 &names.caller_account_name,
                 &names.caller_account_package,
                 &names.callee_account_package,
-                callee_project.root().as_path(),
+                callee_project.root(),
             ),
         )
         .file("src/lib.rs", caller_source)
@@ -196,7 +193,7 @@ pub(super) fn build_account_to_account_fpi_test_packages(
                 &names.note_name,
                 &names.note_package,
                 &names.caller_account_package,
-                caller_project.root().as_path(),
+                caller_project.root(),
             ),
         )
         .file(
@@ -204,7 +201,7 @@ pub(super) fn build_account_to_account_fpi_test_packages(
             &note_cargo_toml_for_dependency(
                 &names.note_name,
                 &names.caller_account_package,
-                caller_project.root().as_path(),
+                caller_project.root(),
             ),
         )
         .file("src/lib.rs", note_source)

--- a/tests/integration-network/src/mockchain/sibling/common.rs
+++ b/tests/integration-network/src/mockchain/sibling/common.rs
@@ -37,11 +37,10 @@ pub(super) fn build_sibling_test_packages(
     let counter_package = compile_rust_package(counter_project.root(), true);
 
     let counter_root = counter_project.root();
-    let dependencies = [(names.counter_account_package.as_str(), counter_root.as_path())];
+    let dependencies = [(names.counter_account_package.as_str(), counter_root)];
     let (caller_project, caller_package) =
         build_sibling_caller_project(&names, &dependencies, caller_source);
-    let note_package =
-        build_sibling_note_package(&names, caller_project.root().as_path(), note_source);
+    let note_package = build_sibling_note_package(&names, caller_project.root(), note_source);
 
     (counter_package, caller_package, note_package, counter_storage_slot)
 }
@@ -91,13 +90,12 @@ pub(super) fn build_multi_sibling_test_packages(
     let first_root = first_project.root();
     let second_root = second_project.root();
     let dependencies = [
-        (names.counter_account_package.as_str(), first_root.as_path()),
-        (second_account_package.as_str(), second_root.as_path()),
+        (names.counter_account_package.as_str(), first_root),
+        (second_account_package.as_str(), second_root),
     ];
     let (caller_project, caller_package) =
         build_sibling_caller_project(&names, &dependencies, caller_source);
-    let note_package =
-        build_sibling_note_package(&names, caller_project.root().as_path(), note_source);
+    let note_package = build_sibling_note_package(&names, caller_project.root(), note_source);
 
     (
         first_package,

--- a/tests/integration-network/src/mockchain/swapp.rs
+++ b/tests/integration-network/src/mockchain/swapp.rs
@@ -6,7 +6,10 @@
 //! with the requested asset routed back to the creator through a P2ID note and the unfilled
 //! portion re-offered through a remainder SWAPP note.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, OnceLock},
+};
 
 use miden_client::{
     account::component::{BasicWallet, InitStorageData},
@@ -53,9 +56,18 @@ struct SwappPackages {
 ///
 /// The basic wallet is compiled first so that its package artifacts are available to the note
 /// project which depends on it.
+#[track_caller]
 fn compile_swapp_packages() -> SwappPackages {
-    let wallet = compile_rust_package("../../examples/basic-wallet", true);
-    let swapp = compile_rust_package("../fixtures/components/swapp-note", true);
+    static WALLET: OnceLock<Arc<Package>> = OnceLock::new();
+    static SWAPP: OnceLock<Arc<Package>> = OnceLock::new();
+
+    let wallet = WALLET
+        .get_or_init(|| compile_rust_package("../../examples/basic-wallet", true))
+        .clone();
+    let swapp = SWAPP
+        .get_or_init(|| compile_rust_package("../fixtures/components/swapp-note", true))
+        .clone();
+
     SwappPackages { wallet, swapp }
 }
 

--- a/tests/integration/src/end_to_end/differential/harness.rs
+++ b/tests/integration/src/end_to_end/differential/harness.rs
@@ -119,7 +119,7 @@ fn run_case_inner(name: &str, source: &str, inputs: Inputs<'_>) {
         .file("Cargo.toml", &manifest)
         .file("src/lib.rs", &full_source)
         .build();
-    let dylib_path = build_host_cdylib(&native_proj.root(), &pkg_name);
+    let dylib_path = build_host_cdylib(native_proj.root(), &pkg_name);
 
     let lib = unsafe { libloading::Library::new(&dylib_path) }
         .unwrap_or_else(|e| panic!("failed to load {}: {e}", dylib_path.display()));

--- a/tests/integration/src/end_to_end/differential/harness.rs
+++ b/tests/integration/src/end_to_end/differential/harness.rs
@@ -250,13 +250,16 @@ fn build_host_cdylib(project_root: &std::path::Path, pkg_name: &str) -> PathBuf 
     // link the default platform libs (libSystem/libc) so the resulting dylib is
     // loadable via `libloading`.
     //
-    // Clear `CARGO_TARGET_DIR` so the case project uses its own `target/` rather
-    // than the parent's redirected one.
+    // `CARGO_TARGET_DIR` is inherited rather than cleared, so this build joins the
+    // one build directory the rest of the suite shares (`cargo_proj::shared_build_dir`)
+    // instead of giving each of the 90+ cases a private `target/`. Nothing here
+    // depends on where the artifact lands: the path is read back out of cargo's JSON
+    // output, and these units differ from every other unit in the directory by their
+    // `RUSTFLAGS`, which Cargo already folds into the metadata hash.
     let mut child = Command::new("cargo")
         .current_dir(project_root)
         .args(["build", "--release", "--lib", "--message-format=json-render-diagnostics"])
         .env("RUSTFLAGS", "-C default-linker-libraries=yes")
-        .env_remove("CARGO_TARGET_DIR")
         .stdout(Stdio::piped())
         .spawn()
         .expect("failed to spawn cargo for native build");

--- a/tests/integration/src/sdk/canonabi.rs
+++ b/tests/integration/src/sdk/canonabi.rs
@@ -249,13 +249,13 @@ fn run_canonabi_case(
     let names = CanonAbiProjectNames::new(case);
     let account_project = build_account_project(&names, account_source);
     let account_root = account_project.root();
-    let mut account_test = build_generated_test(&account_root);
+    let mut account_test = build_generated_test(account_root);
     let account_package = account_test.compile_package();
     assert!(account_package.is_library());
     let generated_wit = read_generated_wit(&account_project);
     assert_generated_wit(&generated_wit);
 
-    let note_project = build_note_project(&names, &account_root, note_body);
+    let note_project = build_note_project(&names, account_root, note_body);
     let mut note_test = build_generated_test(note_project.root());
     let note_package = note_test.compile_package();
     assert!(note_package.is_library());

--- a/tests/support/src/cargo_proj/mod.rs
+++ b/tests/support/src/cargo_proj/mod.rs
@@ -172,13 +172,18 @@ pub struct ProjectBuilder {
 
 impl ProjectBuilder {
     /// Root of the project, ex: `/path/to/cargo/target/cit/t0/foo`
-    pub fn root(&self) -> PathBuf {
+    pub fn root(&self) -> &Path {
         self.root.root()
     }
 
     /// Project's debug dir, ex: `/path/to/cargo/target/cit/t0/foo/target/debug`
     pub fn target_debug_dir(&self) -> PathBuf {
         self.root.target_debug_dir()
+    }
+
+    /// Project's debug dir, ex: `/path/to/cargo/target/cit/t0/foo/target/release`
+    pub fn target_release_dir(&self) -> PathBuf {
+        self.root.target_release_dir()
     }
 
     /// Creates a new [`ProjectBuilder`] rooted at `root`.
@@ -249,7 +254,6 @@ impl ProjectBuilder {
 
         // Create the directory if missing
         self.root.root().mkdir_p();
-
         let manifest_path = self.root.root().join("Cargo.toml");
         if !self.no_manifest && self.files.iter().all(|fb| fb.path != manifest_path) {
             self._file(Path::new("Cargo.toml"), &basic_manifest("foo", "0.0.1"), false)
@@ -357,7 +361,7 @@ impl ProjectBuilder {
             }
         }
 
-        prune_dir(&root, &expected_files, &expected_symlinks);
+        prune_dir(root, &expected_files, &expected_symlinks);
     }
 
     fn skip_rust_compilation(&self, artifact_name: &str) -> bool {
@@ -416,8 +420,8 @@ fn workspace_lockfile_path() -> PathBuf {
 
 impl Project {
     /// Root of the project, ex: `/path/to/cargo/target/cit/t0/foo`
-    pub fn root(&self) -> PathBuf {
-        self.root.clone()
+    pub fn root(&self) -> &Path {
+        &self.root
     }
 
     /// Project's target dir, ex: `/path/to/cargo/target/cit/t0/foo/target`
@@ -428,6 +432,11 @@ impl Project {
     /// Project's debug dir, ex: `/path/to/cargo/target/cit/t0/foo/target/debug`
     pub fn target_debug_dir(&self) -> PathBuf {
         self.build_dir().join("debug")
+    }
+
+    /// Project's release dir, ex: `/path/to/cargo/target/cit/t0/foo/target/release`
+    pub fn target_release_dir(&self) -> PathBuf {
+        self.build_dir().join("release")
     }
 
     /// Path to an example built as a library.
@@ -448,9 +457,7 @@ impl Project {
     /// Path to a release binary.
     /// ex: `/path/to/cargo/target/cit/t0/foo/target/release/foo`
     pub fn release_bin(&self, b: &str) -> PathBuf {
-        self.build_dir()
-            .join("release")
-            .join(format!("{}{}", b, env::consts::EXE_SUFFIX))
+        self.target_release_dir().join(format!("{}{}", b, env::consts::EXE_SUFFIX))
     }
 
     /// Path to a debug binary for a specific target triple.
@@ -645,6 +652,7 @@ pub fn project(proj_folder_name: &str) -> ProjectBuilder {
     let cargo_projects_root =
         cargo_projects_root().join(callsite_dir(loc.file(), loc.line(), loc.column()));
     let cargo_proj_path = cargo_projects_root.join(proj_folder_name);
+
     ProjectBuilder::new(cargo_proj_path)
 }
 

--- a/tests/support/src/cargo_proj/mod.rs
+++ b/tests/support/src/cargo_proj/mod.rs
@@ -506,6 +506,106 @@ impl Project {
     }
 }
 
+/// The Cargo target directory this test process builds under.
+///
+/// Derived from an absolute `CARGO_TARGET_DIR` when the process was started with one, otherwise
+/// inferred from the test executable's location. Read **once**, before [`use_shared_build_dir`]
+/// overwrites the variable, so both directories below are anchored to the same place whether the
+/// suite is invoked as `cargo test` (no ambient variable) or through `cargo make` (which sets one,
+/// `Makefile.toml`).
+fn test_target_dir() -> PathBuf {
+    static TARGET_DIR: OnceLock<PathBuf> = OnceLock::new();
+    TARGET_DIR
+        .get_or_init(|| {
+            // Prefer an explicit override when provided (useful in CI).
+            if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
+                let dir = PathBuf::from(dir);
+                if dir.is_absolute() {
+                    return dir;
+                }
+            }
+
+            let exe = std::env::current_exe()
+                .unwrap_or_else(|e| panic!("failed to determine test target directory: {e}"));
+
+            // `cargo test` places the test binary at `<target_dir>/<profile>/deps/<bin>`.
+            for ancestor in exe.ancestors() {
+                if ancestor
+                    .file_name()
+                    .is_some_and(|file_name| file_name.eq_ignore_ascii_case("target"))
+                    && ancestor.is_dir()
+                {
+                    return ancestor.to_path_buf();
+                }
+            }
+
+            panic!("failed to determine test target directory from current_exe: {}", exe.display());
+        })
+        .clone()
+}
+
+/// The one build directory every nested `cargo` invocation in this suite shares.
+///
+/// # Why one directory
+///
+/// Each generated project is its own workspace, so with no `CARGO_TARGET_DIR` Cargo gives each one
+/// a private `target/` and shares nothing. Every one of them builds `core`, `alloc`,
+/// `compiler_builtins` and `panic_abort` from source (`-Z build-std`) plus the whole native Miden
+/// stack as build dependencies, at `lto = true, codegen-units = 1` — around 900 MB and half a
+/// minute of compilation to produce a few hundred bytes of Wasm. Across the suite that is the same
+/// work tens of times over: at the time this was written, this was measured at 48,131 crate units
+/// of which 1,627 are distinct.
+///
+/// Cargo already keys artifacts by a metadata hash that separates flag variants, so one directory
+/// holds all of them side by side. It takes an exclusive lock on the build directory, so concurrent
+/// nested builds serialize; that cost was measured before this was adopted rather than assumed. On
+/// a 19-test slice driving 57 nested builds on ten cores: **1034 s and 33.6 GB unshared, versus
+/// 66.9 s and 1.05 GB shared** — 15.5x on time and 31.8x on disk — with 56 build-directory lock
+/// waits which, in total, cannot have exceeded the 67 s the whole run took.
+///
+/// The directory is a sibling of the generated projects rather than the workspace target directory
+/// itself, so that nested-build output stays separable from the workspace's own and can be measured
+/// (and deleted) on its own.
+///
+/// # Why it is worth keeping
+///
+/// At a few GB the cache survives between runs, without this, the total size of a warm cache was
+/// exceeding 100GB, which made it necessary to frequently delete it to avoid consuming a lot of
+/// disk space unnecessarily - this made test runs cold, exacerbating test run times due to the
+/// need to rebuild the cache frequently.
+pub fn shared_build_dir() -> PathBuf {
+    test_target_dir().join("miden_test_shared")
+}
+
+/// Point this process's nested `cargo` invocations at [`shared_build_dir`].
+///
+/// The environment is the only means we have to reache them: the nested `cargo` is spawned by the
+/// compiler itself (`midenc-compile`'s `run_cargo`), which inherits this process's environment,
+/// and it selects the project with `--manifest-path` rather than by working directory — so a
+/// `.cargo/config.toml` written beside the project would never be read.
+///
+/// Idempotent, and safe to call from any entry point that is about to cause a nested build. It must
+/// be called by **every** such entry point, not just [`project`]: tests that compile a checked-in
+/// fixture project never generate one, and before this they wrote a private `target/` into the
+/// source tree (`tests/fixtures/components/*/target`, measured at ~1.7 GB apiece).
+///
+/// # Safety
+///
+/// `set_var` is unsafe because a concurrent `getenv` on another thread is a data race. This runs at
+/// most once per process, from the first entry point reached, and before that entry point spawns
+/// anything. The same reasoning is what permits the equivalent call in `tests/templates`, and the
+/// suite's own runner (`cargo make test` → `nextest`) gives each test its own process.
+pub fn use_shared_build_dir() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let dir = shared_build_dir();
+        std::fs::create_dir_all(&dir).unwrap_or_else(|e| {
+            panic!("failed to create the shared build directory {}: {e}", dir.display())
+        });
+        unsafe { std::env::set_var("CARGO_TARGET_DIR", &dir) };
+    });
+}
+
 /// Creates a [`ProjectBuilder`] for a generated Cargo project.
 ///
 /// The project is located under the Cargo target directory to maximize reuse of build artifacts
@@ -518,36 +618,13 @@ pub fn project(proj_folder_name: &str) -> ProjectBuilder {
     /// Compute the directory under which generated Cargo projects should live.
     ///
     /// We keep these projects in the Cargo target directory so that Cargo build artifacts
-    /// (under each project's `target/`) can be reused across test runs.
+    /// (which now live in [`shared_build_dir`]) can be reused across test runs.
     fn cargo_projects_root() -> PathBuf {
-        static ROOT: OnceLock<PathBuf> = OnceLock::new();
-        ROOT.get_or_init(|| {
-            // Prefer an explicit override when provided (useful in CI).
-            if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
-                let dir = PathBuf::from(dir);
-                if dir.is_absolute() {
-                    return dir.join("miden_test_cargo_projects");
-                }
-            }
-
-            let exe = std::env::current_exe()
-                .unwrap_or_else(|e| panic!("failed to determine test target directory: {e}"));
-
-            // `cargo test` places the test binary at `<target_dir>/<profile>/deps/<bin>`.
-            if let Some(target_dir) = exe.parent().and_then(|p| p.parent()).and_then(|p| p.parent())
-            {
-                return target_dir.join("miden_test_cargo_projects");
-            }
-
-            for ancestor in exe.ancestors() {
-                if ancestor.file_name() == Some(std::ffi::OsStr::new("target")) {
-                    return ancestor.join("miden_test_cargo_projects");
-                }
-            }
-
-            panic!("failed to determine test target directory from current_exe: {}", exe.display());
-        })
-        .clone()
+        let root = test_target_dir().join("miden_test_cargo_projects");
+        // Anything built out of a generated project is a nested build, so redirect them before the
+        // caller gets a chance to start one.
+        use_shared_build_dir();
+        root
     }
 
     /// Convert a call site into a stable directory name component.

--- a/tests/support/src/compiler_test.rs
+++ b/tests/support/src/compiler_test.rs
@@ -320,6 +320,12 @@ impl CompilerTestBuilder {
         // Build test
         match source {
             CompilerTestInputType::CargoMiden(config) => {
+                // Every route into a nested `cargo` has to redirect it, not just the generated-
+                // project one: a test naming a checked-in fixture project never calls
+                // `cargo_proj::project`, and without this it builds a private `target/` into the
+                // source tree instead of sharing one.
+                crate::cargo_proj::use_shared_build_dir();
+
                 let mut argv = vec![];
                 if config.release {
                     argv.push("--release".to_string());


### PR DESCRIPTION
@greenhat FYI, this addresses the issue with the build cache for the test suite consuming ~100GB and taking ages to rebuild cold.