### PR TITLE
fix(eval): use checked_mul for Overflow::Checked arith.mul

### DIFF
--- a/eval/src/eval.rs
+++ b/eval/src/eval.rs
@@ -1092,7 +1092,7 @@ impl Eval for arith::Mul {
         let result = match *self.get_overflow() {
             Overflow::Unchecked => binop!(self, evaluator, mul),
             Overflow::Checked => {
-                let result = binop_checked!(self, evaluator, checked_sub, mul);
+                let result = binop_checked!(self, evaluator, checked_mul, mul);
                 let Some(result) = result else {
                     return Err(evaluator.report(
                         "evaluation failed",

--- a/eval/src/tests.rs
+++ b/eval/src/tests.rs
@@ -217,6 +217,51 @@ fn inv_zero_reports_error() -> Result<(), Report> {
 }
 
 #[test]
+fn checked_mul_evaluates_product() -> Result<(), Report> {
+    let mut test = EvalTest::named("checked_mul_evaluates_product");
+    test.with_function(&[Type::U32, Type::U32], &[Type::U32]);
+
+    {
+        let mut builder = test.function_builder();
+        let lhs = builder.current_block().borrow().arguments()[0] as ValueRef;
+        let rhs = builder.current_block().borrow().arguments()[1] as ValueRef;
+        // ArithOpBuilder::mul uses Overflow::Checked
+        let product = builder.mul(lhs, rhs, SourceSpan::default())?;
+        builder.ret(Some(product), SourceSpan::default())?;
+    }
+
+    let callable = test.function().borrow();
+    let results = test.evaluator.eval_callable(&*callable, [6u32.into(), 3u32.into()])?;
+    assert_eq!(results.len(), 1);
+    // Regression: Checked mul previously called checked_sub and returned 3.
+    assert_eq!(results[0], Value::Immediate(18u32.into()));
+
+    Ok(())
+}
+
+#[test]
+fn checked_mul_reports_overflow() -> Result<(), Report> {
+    let mut test = EvalTest::named("checked_mul_reports_overflow");
+    test.with_function(&[Type::U32, Type::U32], &[Type::U32]);
+
+    {
+        let mut builder = test.function_builder();
+        let lhs = builder.current_block().borrow().arguments()[0] as ValueRef;
+        let rhs = builder.current_block().borrow().arguments()[1] as ValueRef;
+        let product = builder.mul(lhs, rhs, SourceSpan::default())?;
+        builder.ret(Some(product), SourceSpan::default())?;
+    }
+
+    let callable = test.function().borrow();
+    let _err = test
+        .evaluator
+        .eval_callable(&*callable, [u32::MAX.into(), 2u32.into()])
+        .expect_err("overflowing checked mul should produce an evaluation error");
+
+    Ok(())
+}
+
+#[test]
 fn println_collects_printed_lines() -> Result<(), Report> {
     let mut test = EvalTest::named("println_collects_printed_lines");
     test.with_function(&[], &[]);


### PR DESCRIPTION
## Summary

- Fixes an evaluator semantic bug where `arith.mul` with `Overflow::Checked` called `checked_sub` instead of `checked_mul`
- Adds unit tests for the happy path (`6 * 3 == 18`) and overflow

Fixes #1336

## Test plan

- [x] `cargo test -p midenc-hir-eval --lib checked_mul -- --nocapture`