### PR TITLE
fix: correct Felt::new docs example

### DIFF
--- a/docs/external/src/guides/develop_miden_in_rust.md
+++ b/docs/external/src/guides/develop_miden_in_rust.md
@@ -32,7 +32,7 @@ let a = felt!(42);
 Otherwise, use the `Felt::new` constructor:
 
 ```rust
-let a = Felt::new(some_integer_var).unwrap().unwrap();
+let a = Felt::new(some_integer_var).unwrap();
 ```
 
 The constructor returns an error if the value is not a valid field element, e.g. if it is not in the


### PR DESCRIPTION
### What changed

- Updated the Rust guide's `Felt::new` example to use a single `.unwrap()`.

### Why

`Felt::new` returns a single `Result<Felt, _>`. The guide previously showed `.unwrap().unwrap()`, which is not copy-pastable and does not match the constructor shape used elsewhere in the repository.

Fixes #1344

### Validation

- `rg -n "Felt::new\\([^\\n]+\\)\\.unwrap\\(\\)\\.unwrap\\(\\)" docs/external/src/guides/develop_miden_in_rust.md`
- `git diff --check`
- `npm ci`
- `npm run build:dev` in `docs/external`