### PR TITLE
fix(codegen): compute int32 reserved-bit masks without overflow

### DIFF
--- a/codegen/masm/src/emit/int32.rs
+++ b/codegen/masm/src/emit/int32.rs
@@ -239,11 +239,7 @@ impl OpEmitter<'_> {
         self.is_signed_int32(span);
         // Pop the is_signed flag, and replace it with a selected mask
         // for the upper reserved bits of the N-bit range
-        let reserved = 32 - n;
-        // Add one bit to the reserved bits to represent the sign bit,
-        // and subtract it from the shift to account for the loss
-        let mask = (2u32.pow(reserved + 1) - 1) << (n - 1);
-        self.select_int32(mask, 0, span);
+        self.select_int32(signed_reserved_mask(n), 0, span);
         self.emit_all(
             [
                 // Copy the input to the top of the stack for the masking op
@@ -271,11 +267,7 @@ impl OpEmitter<'_> {
         self.is_signed_int32(span);
         // Pop the is_signed flag, and replace it with a selected mask
         // for the upper reserved bits of the N-bit range
-        let reserved = 32 - n;
-        // Add one bit to the reserved bits to represent the sign bit,
-        // and subtract it from the shift to account for the loss
-        let mask = (2u32.pow(reserved + 1) - 1) << (n - 1);
-        self.select_int32(mask, 0, span);
+        self.select_int32(signed_reserved_mask(n), 0, span);
         self.emit_all(
             [
                 // Copy the input to the top of the stack for the masking op
@@ -297,8 +289,7 @@ impl OpEmitter<'_> {
     pub fn int32_to_uint(&mut self, n: u32, span: SourceSpan) {
         assert_valid_integer_size!(n, 1, 32);
         // Mask the value and ensure that the unused bits above the N-bit range are 0
-        let reserved = 32 - n;
-        let mask = (2u32.pow(reserved) - 1) << n;
+        let mask = unsigned_reserved_mask(n);
         // Copy the input
         self.emit(masm::Instruction::Dup1, span);
         // Apply the mask
@@ -320,8 +311,7 @@ impl OpEmitter<'_> {
     pub fn try_int32_to_uint(&mut self, n: u32, span: SourceSpan) {
         assert_valid_integer_size!(n, 1, 32);
         // Mask the value and ensure that the unused bits above the N-bit range are 0
-        let reserved = 32 - n;
-        let mask = (2u32.pow(reserved) - 1) << n;
+        let mask = unsigned_reserved_mask(n);
         // Copy the input
         self.emit(masm::Instruction::Dup1, span);
         // Apply the mask
@@ -1096,5 +1086,66 @@ impl OpEmitter<'_> {
     pub fn max_imm_i32(&mut self, imm: i32, span: SourceSpan) {
         self.emit_push(imm as u32, span);
         self.raw_exec("::intrinsics::i32::max", span);
+    }
+}
+
+/// Returns the mask covering the bits a signed `n`-bit value may not use, i.e. the `32 - n`
+/// reserved high bits plus the sign bit at position `n - 1`.
+///
+/// `n` must be in `1..=32`.
+fn signed_reserved_mask(n: u32) -> u32 {
+    debug_assert!((1..=32).contains(&n), "invalid signed integer size: {n}");
+    u32::MAX << (n - 1)
+}
+
+/// Returns the mask covering the `32 - n` reserved high bits an unsigned `n`-bit value may not
+/// use.
+///
+/// `n` must be in `1..=32`.
+fn unsigned_reserved_mask(n: u32) -> u32 {
+    debug_assert!((1..=32).contains(&n), "invalid unsigned integer size: {n}");
+    !(u32::MAX >> (32 - n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{signed_reserved_mask, unsigned_reserved_mask};
+
+    /// The masks the emitter used to compute inline, evaluated in `u64` so the intended
+    /// arithmetic is expressible for every `n` without overflowing.
+    fn reference_masks(n: u32) -> (u32, u32) {
+        let reserved = u64::from(32 - n);
+        let signed = ((2u64.pow(reserved as u32 + 1) - 1) << (n - 1)) as u32;
+        let unsigned = ((2u64.pow(reserved as u32) - 1) << n) as u32;
+        (signed, unsigned)
+    }
+
+    #[test]
+    fn reserved_masks_match_reference_over_the_whole_range() {
+        for n in 1..=32 {
+            let (signed, unsigned) = reference_masks(n);
+            assert_eq!(signed_reserved_mask(n), signed, "signed reserved mask diverges at n={n}");
+            assert_eq!(
+                unsigned_reserved_mask(n),
+                unsigned,
+                "unsigned reserved mask diverges at n={n}"
+            );
+        }
+    }
+
+    #[test]
+    fn signed_reserved_mask_covers_sign_bit_and_reserved_bits() {
+        // n=1 and n=32 are the edges where the previous inline arithmetic overflowed.
+        assert_eq!(signed_reserved_mask(1), 0xffff_ffff);
+        assert_eq!(signed_reserved_mask(8), 0xffff_ff80);
+        assert_eq!(signed_reserved_mask(32), 0x8000_0000);
+    }
+
+    #[test]
+    fn unsigned_reserved_mask_covers_reserved_bits_only() {
+        assert_eq!(unsigned_reserved_mask(1), 0xffff_fffe);
+        assert_eq!(unsigned_reserved_mask(8), 0xffff_ff00);
+        // A full-width value reserves nothing, so no bit may be rejected.
+        assert_eq!(unsigned_reserved_mask(32), 0x0000_0000);
     }
 }


### PR DESCRIPTION
## Problem

The MASM emitter computes reserved-bit masks with inline arithmetic that overflows `u32` at the ends of the supported width range. Both formulas are affected, at opposite edges:

```rust
// int32_to_int / try_int32_to_int  — overflows at n = 1 (reserved = 31, 2^32)
let mask = (2u32.pow(reserved + 1) - 1) << (n - 1);

// int32_to_uint / try_int32_to_uint — overflows at n = 32 (shift left by 32)
let mask = (2u32.pow(reserved) - 1) << n;
```

Both `n = 1` and `n = 32` pass the `assert_valid_integer_size!(n, 1, 32)` guard directly above, so these are reachable inputs. In a debug build the emitter panics; in a release build the arithmetic wraps silently and the wrong mask is emitted into generated code.

Reproduced standalone with `panic::catch_unwind`:

```text
old formula signed n=1:     PANIC (attempt to multiply with overflow)
old formula unsigned n=32:  PANIC (attempt to shift left with overflow)
```

## Fix

Extract the two masks into named helpers that compute the result directly, so no intermediate value can exceed `u32`:

```rust
fn signed_reserved_mask(n: u32) -> u32   { u32::MAX << (n - 1) }
fn unsigned_reserved_mask(n: u32) -> u32 { !(u32::MAX >> (32 - n)) }
```

This is a correction rather than a suppression: the shift-based forms are exactly the intended masks, not overflow that has been made to wrap quietly. Four call sites now share the two helpers instead of repeating the arithmetic inline.

## Tests

The primary test asserts an invariant rather than pinning current output: for every `n` in `1..=32`, each helper must equal the emitter's original intended arithmetic, evaluated in `u64` so the intended value is expressible at every width. Two further tests pin the edge and representative masks (`n = 1`, `8`, `32`) for both signedness cases.

Verified by extracting the helpers and the test bodies verbatim and running them under `rustc --edition 2024` with overflow checks on:

```text
PASS reserved_masks_match_reference_over_the_whole_range
PASS signed_reserved_mask_covers_sign_bit_and_reserved_bits
PASS unsigned_reserved_mask_covers_reserved_bits_only
```

`cargo test -p midenc-codegen-masm` could not run in full on this machine: the `miden-core-lib` build script fails on Windows before compilation with `invalid root module path 'mod.masm'` (os error 2), which is unrelated to this change. CI on Linux exercises the tests normally.

`cargo fmt -p midenc-codegen-masm --check` is clean on the changed file.

## Scope

- One file, no new dependencies, `Cargo.lock` unchanged.
- Supersedes #1334, which targeted `main` (126 commits behind `next`, so the whole branch gap rendered as its diff) and fixed only the two signed call sites, leaving `n = 32` broken in the unsigned pair.