### PR TITLE
fix(hir): report an unregistered dialect as its own diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Compiler and `midenc`
 
+- Naming an operation in a dialect that is not registered now reports an unknown dialect,
+  which is a separate diagnostic from an unrecognised operation inside a dialect that does
+  exist. The dialect half of the name comes from the source, so it can name anything; it
+  previously reached a direct map index and aborted.
+
 - The filesystem package cache is now per-build. When the calling process already exported
   `MIDENC_PACKAGE_CACHE`, the compiler adopts that directory as its package cache and leaves
   it in place — the caller owns its location and lifetime, which is how packages stay

--- a/hir/src/ir/context.rs
+++ b/hir/src/ir/context.rs
@@ -120,6 +120,19 @@ impl Context {
         self.registered_dialects.borrow()[&dialect].clone()
     }
 
+    /// Like [`Context::get_registered_dialect`], but returns `None` when the dialect is not
+    /// registered, rather than panicking.
+    ///
+    /// Callers that name a dialect from source text must use this: the name is only known at
+    /// runtime, so it cannot be assumed to correspond to a registered dialect.
+    pub fn find_registered_dialect(
+        &self,
+        dialect: impl Into<interner::Symbol>,
+    ) -> Option<Rc<dyn Dialect>> {
+        let dialect = dialect.into();
+        self.registered_dialects.borrow().get(&dialect).cloned()
+    }
+
     pub fn get_registered_name<T>(&self) -> OperationName
     where
         T: OpRegistration,

--- a/hir/src/ir/parse/error.rs
+++ b/hir/src/ir/parse/error.rs
@@ -191,6 +191,13 @@ pub enum ParserError {
         span: SourceSpan,
         reason: String,
     },
+    #[error("unknown dialect '{dialect}'")]
+    #[diagnostic(help("only dialects registered in this context can be named here"))]
+    UnknownDialect {
+        #[label("this dialect is not registered")]
+        span: SourceSpan,
+        dialect: interner::Symbol,
+    },
     #[error("invalid operation")]
     #[diagnostic()]
     NonTerminatorWithSuccessors {

--- a/hir/src/ir/parse/operation.rs
+++ b/hir/src/ir/parse/operation.rs
@@ -873,11 +873,15 @@ where
             });
         };
 
-        // Lazy load dialects in the context as needed.
-        let dialect = self
-            .parser
-            .context()
-            .get_registered_dialect(interner::Symbol::intern(dialect_name));
+        // The dialect name comes from the source, so it may name nothing at all. This is a
+        // different failure from an unregistered operation inside a dialect that does exist.
+        let dialect_symbol = interner::Symbol::intern(dialect_name);
+        let Some(dialect) = self.parser.context().find_registered_dialect(dialect_symbol) else {
+            return Err(ParserError::UnknownDialect {
+                span,
+                dialect: dialect_symbol,
+            });
+        };
         let opcode = interner::Symbol::intern(opcode);
         let Some(op_name) =
             dialect.registered_ops().iter().find(|name| name.name() == opcode).cloned()
@@ -1177,7 +1181,13 @@ where
             (self.state_mut().default_dialect_stack.last().unwrap().as_str(), name)
         });
 
-        let dialect = self.context().get_registered_dialect(interner::Symbol::intern(dialect));
+        let dialect_symbol = interner::Symbol::intern(dialect);
+        let Some(dialect) = self.context().find_registered_dialect(dialect_symbol) else {
+            return Err(ParserError::UnknownDialect {
+                span: name_span,
+                dialect: dialect_symbol,
+            });
+        };
         dialect
             .registered_ops()
             .iter()

--- a/hir/src/ir/parse/tests.rs
+++ b/hir/src/ir/parse/tests.rs
@@ -455,3 +455,36 @@ impl ParserTest {
         parse::parse_any(config, Uri::new(name), source)
     }
 }
+
+/// An unregistered dialect is a different failure from an unregistered operation inside a dialect
+/// that exists, and the diagnostic has to say which one it is.
+#[test]
+fn an_unregistered_dialect_is_named_in_the_diagnostic() {
+    let test = ParserTest::default();
+    let Err(err) =
+        test.parse_any("unknown_dialect.hir", "builtin.module public @t { nosuchdialect.op; };")
+    else {
+        panic!("an unregistered dialect must not parse");
+    };
+    let rendered = alloc::string::ToString::to_string(&err);
+    assert!(
+        rendered.contains("unknown dialect") && rendered.contains("nosuchdialect"),
+        "the diagnostic must name the unregistered dialect, got: {rendered}"
+    );
+}
+
+/// The control: an unknown operation inside a dialect that is registered still reports as an
+/// invalid operation, not as an unknown dialect.
+#[test]
+fn an_unknown_operation_in_a_known_dialect_still_reports_separately() {
+    let test = ParserTest::default();
+    let Err(err) = test.parse_any("unknown_op.hir", "builtin.module public @t { builtin.nope; };")
+    else {
+        panic!("an unregistered operation must not parse");
+    };
+    let rendered = alloc::string::ToString::to_string(&err);
+    assert!(
+        !rendered.contains("unknown dialect"),
+        "a known dialect must not be reported as unknown, got: {rendered}"
+    );
+}


### PR DESCRIPTION
The dialect half of an operation name comes from the source, so it can name anything.
`parse_generic_operation` passed it to `Context::get_registered_dialect`, which indexes the
dialect map directly, so an unknown name ended the process — while a name with no `.` at all
already returned `InvalidOperationName` a few lines above.

`find_registered_dialect` returns `Option` for the two parse sites that take the name at runtime;
`get_registered_dialect` stays as it is for callers naming a dialect at compile time, where it
cannot fail.

Per your note, an unregistered dialect now reports as `unknown dialect '<name>'` rather than as an
invalid operation, so it reads differently from an unrecognised operation inside a dialect that
does exist. A test covers each of those two cases.

Reachable from textual HIR: `FileType::Hir` reaches `parse_file_any` in the compile pipeline, and
`hir-opt` calls `parse_any` directly.

Fixes #1347.
