### PR TITLE
fix(hir): report malformed symbol tables instead of aborting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exist. The dialect half of the name comes from the source, so it can name anything; it
   previously reached a direct map index and aborted.
 
+- Parsing a module whose body is empty, or which defines the same symbol twice, now
+  succeeds or reports a redefinition rather than aborting. Building the symbol table
+  assumed a region with an entry block and uniquely named symbols, which is not something
+  parsed text can be relied on to provide.
+
 - The filesystem package cache is now per-build. When the calling process already exported
   `MIDENC_PACKAGE_CACHE`, the compiler adopts that directory as its package cache and leaves
   it in place — the caller owns its location and lifetime, which is how packages stay

--- a/hir/src/ir/parse/asm_parser.rs
+++ b/hir/src/ir/parse/asm_parser.rs
@@ -96,7 +96,7 @@ impl AsmParserState {
         at: SourceSpan,
         end: SourceSpan,
         result_groups: &[(usize, SourceSpan)],
-    ) {
+    ) -> Result<(), super::ParserError> {
         let PartialOpDef {
             symbol_uses,
             is_symbol_table,
@@ -119,7 +119,8 @@ impl AsmParserState {
             // Populate symbol table first
             {
                 let mut op = op.borrow_mut();
-                let symbol_table = SymbolMap::build(&op);
+                let symbol_table = SymbolMap::try_build(&op)
+                    .map_err(|name| super::ParserError::SymbolAlreadyDefined { span: at, name })?;
                 if let Some(op_symbol_table) = op.as_trait_mut::<dyn SymbolTable>() {
                     **op_symbol_table.symbol_manager_mut().symbols_mut() = symbol_table;
                 }
@@ -132,6 +133,7 @@ impl AsmParserState {
                 .or_default()
                 .extend(symbol_uses.drain().flat_map(|(_, uses)| uses));
         }
+        Ok(())
     }
 
     /// Start a definition for a region nested under the current operation.

--- a/hir/src/ir/parse/error.rs
+++ b/hir/src/ir/parse/error.rs
@@ -260,6 +260,13 @@ pub enum ParserError {
         span: SourceSpan,
         name: BlockId,
     },
+    #[error("redefinition of symbol {name}")]
+    #[diagnostic()]
+    SymbolAlreadyDefined {
+        #[label]
+        span: SourceSpan,
+        name: interner::Symbol,
+    },
     #[error("too many arguments specified in argument list")]
     #[diagnostic()]
     TooManyBlockArguments {

--- a/hir/src/ir/parse/operation.rs
+++ b/hir/src/ir/parse/operation.rs
@@ -777,7 +777,7 @@ where
                 }
             }
         } else if let Some(asm_state) = self.state_mut().asm_state.as_deref_mut() {
-            asm_state.finalize_operation_definition(op, name_span, end, &[]);
+            asm_state.finalize_operation_definition(op, name_span, end, &[])?;
         }
 
         Ok(op)

--- a/hir/src/ir/parse/tests.rs
+++ b/hir/src/ir/parse/tests.rs
@@ -488,3 +488,29 @@ fn an_unknown_operation_in_a_known_dialect_still_reports_separately() {
         "a known dialect must not be reported as unknown, got: {rendered}"
     );
 }
+
+/// A module with an empty body defines no symbols; building its symbol table must not unwrap the
+/// missing entry block.
+#[test]
+fn an_empty_module_body_parses() {
+    let test = ParserTest::default();
+    test.parse_any("empty.hir", "builtin.module public @t {};")
+        .expect("an empty module body should parse");
+}
+
+/// Two symbols with one name is something the author wrote, so it must be reported rather than
+/// tripping the uniqueness assertion inside the symbol table.
+#[test]
+fn a_duplicate_symbol_is_reported() {
+    let test = ParserTest::default();
+    let source = "\
+builtin.module public @t {
+    builtin.function internal extern(\"C\") @f(%a: i32) -> i32 {
+        builtin.ret %a : (i32);
+    };
+    builtin.function internal extern(\"C\") @f(%b: i32) -> i32 {
+        builtin.ret %b : (i32);
+    };
+};";
+    assert!(test.parse_any("dup.hir", source).is_err(), "a duplicate symbol must not parse");
+}

--- a/hir/src/ir/symbols/table.rs
+++ b/hir/src/ir/symbols/table.rs
@@ -132,22 +132,39 @@ impl SymbolMap {
     /// It is assumed that the given operation is a [SymbolTable] op, but this is not checked, and
     /// does not affect the correctness - however, it has limited utility for non-symbol table ops.
     pub fn build(op: &Operation) -> Self {
+        Self::try_build(op).expect("expected region to contain uniquely named symbol operations")
+    }
+
+    /// Like [`SymbolMap::build`], but reports the offending name instead of panicking when the
+    /// same symbol is defined twice.
+    ///
+    /// Callers handling parsed text must use this: a duplicate there is something the author
+    /// wrote, not a broken invariant. An operation with no region, or whose region has no blocks,
+    /// defines no symbols and yields an empty map.
+    pub fn try_build(op: &Operation) -> Result<Self, SymbolName> {
         let mut symbols = FxHashMap::default();
 
-        let region = op.regions().front().get().unwrap();
-        for op in region.entry().body() {
-            if let Some(symbol_ref) = op.as_symbol_ref() {
-                let name = symbol_ref.borrow().name();
-                symbols
-                    .try_insert(name, symbol_ref)
-                    .expect("expected region to contain uniquely named symbol operations");
+        let Some(region) = op.regions().front().get() else {
+            return Ok(Self {
+                symbols,
+                uniquing_count: 0,
+            });
+        };
+        if !region.is_empty() {
+            for op in region.entry().body() {
+                if let Some(symbol_ref) = op.as_symbol_ref() {
+                    let name = symbol_ref.borrow().name();
+                    if symbols.try_insert(name, symbol_ref).is_err() {
+                        return Err(name);
+                    }
+                }
             }
         }
 
-        Self {
+        Ok(Self {
             symbols,
             uniquing_count: 0,
-        }
+        })
     }
 
     /// Get the symbol named `name`, or `None` if undefined.


### PR DESCRIPTION
`SymbolMap::build` assumes the operation has a region, that the region has an entry block, and
that no two symbols in it share a name. `finalize_operation_definition` calls it while parsing, so
those assumptions were being made about text the user wrote rather than about IR a builder
produced.

Two of them were reachable. `builtin.module public @t {};` reached `Region::entry`, which unwraps
`None` even though `Region::is_empty` sits next to it. A module defining `@f` twice reached the
`try_insert(..).expect(..)`, where a duplicate is something the author wrote rather than a broken
invariant.

`try_build` returns the offending name; `build` stays as a wrapper, so the two callers that work
on builder-produced IR are unchanged. The parser turns a duplicate into `redefinition of symbol`,
next to the existing `redefinition of block`. `finalize_operation_definition` now returns a
`Result` so the parse site can propagate it.

Touches `parse/error.rs`, `parse/operation.rs` and `parse/tests.rs`, which #1358 also touches — I
will rebase whichever of the two lands second.

Fixes #1348.
