### PR TITLE
chore(build): keep the target directory from growing without bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,14 @@ lto = false
 # Needed for 'inventory' to work
 codegen-units = 1
 
+# Keep only file/line debug information for non-workspace dependencies. Full
+# debug information for the Miden VM stack and the other external crates is the
+# dominant cost of the target directory: it multiplies into every statically
+# linked test executable (measured at ~91% of an 820 MB test binary). Workspace
+# crates are not matched by `"*"` and keep full debug information.
+[profile.dev.package."*"]
+debug = "line-tables-only"
+
 [profile.release]
 opt-level = 2
 debug = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -315,10 +315,14 @@ args = [
 # machine) never fails the flow. Set `MIDEN_SKIP_SWEEP` to disable it, for
 # example when alternating between branches that supersede each other's builds.
 [tasks.sweep-flow]
-extend = "sweep"
 private = true
 ignore_errors = true
 condition = { env_not_set = ["MIDEN_SKIP_SWEEP"] }
+command = "python3"
+args = [
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools/sweep-target.py",
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target",
+]
 
 [tasks.update]
 category = "Dependencies"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -324,6 +324,20 @@ args = [
     "${CARGO_TARGET_DIR}",
 ]
 
+[tasks.test-sweep]
+category = "Test"
+description = "Run target-sweeper unit tests"
+command = "python3"
+args = [
+    "-m",
+    "unittest",
+    "discover",
+    "-s",
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools",
+    "-p",
+    "test_sweep_target.py",
+]
+
 [tasks.update]
 category = "Dependencies"
 description = "Update dependencies to latest semver-compatible version"
@@ -400,12 +414,12 @@ args = ["audit"]
 [tasks.test-all]
 category = "Test"
 description = "Runs the complete set of compiler tests"
-run_task = { name = ["test-rust", "test-lit"], fork = true, cleanup_task = "sweep-flow" }
+run_task = { name = ["test-sweep", "test-rust", "test-lit"], fork = true, cleanup_task = "sweep-flow" }
 
 [tasks.test]
 category = "Test"
 description = "Runs all Rust-based tests including network integration tests"
-dependencies = ["test-rust"]
+dependencies = ["test-sweep", "test-rust"]
 
 [tasks.test-release]
 category = "Test"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -396,7 +396,7 @@ args = ["audit"]
 [tasks.test-all]
 category = "Test"
 description = "Runs the complete set of compiler tests"
-dependencies = ["test-rust", "test-lit", "sweep-flow"]
+run_task = { name = ["test-rust", "test-lit"], fork = true, cleanup_task = "sweep-flow" }
 
 [tasks.test]
 category = "Test"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -285,6 +285,41 @@ description = "Clean build artifacts"
 command = "cargo"
 args = ["clean", "${@}"]
 
+[tasks.sweep]
+category = "Build"
+description = "Garbage-collect the target directory: mark the live units by replaying the workspace build/test graphs, keep unmarked units younger than --age days (default 1; --cache-age 14 for directories the marks never reach), delete the rest; pass --dry-run to only report"
+command = "python3"
+args = [
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools/sweep-target.py",
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target",
+    "${@}",
+]
+
+[tasks.sweep-deep]
+category = "Build"
+description = "Garbage-collect the target directory with no age guards: keep only the units the workspace build/test graphs mark live. Run after switching branch bases (a rebase orphans a whole build generation at once). Deletes IDE/clippy checker layers and the nested build caches; the next test run rebuilds them"
+command = "python3"
+args = [
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools/sweep-target.py",
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target",
+    "--age",
+    "0",
+    "--cache-age",
+    "0",
+    "${@}",
+]
+
+# Runs at the end of `cargo make test-all`, the one flow after which the mark
+# step compiles nothing (the whole graph was just built). Skips any directory a
+# running build holds locked, and a failure (for example, no `python3` on the
+# machine) never fails the flow. Set `MIDEN_SKIP_SWEEP` to disable it, for
+# example when alternating between branches that supersede each other's builds.
+[tasks.sweep-flow]
+extend = "sweep"
+private = true
+ignore_errors = true
+condition = { env_not_set = ["MIDEN_SKIP_SWEEP"] }
+
 [tasks.update]
 category = "Dependencies"
 description = "Update dependencies to latest semver-compatible version"
@@ -361,7 +396,7 @@ args = ["audit"]
 [tasks.test-all]
 category = "Test"
 description = "Runs the complete set of compiler tests"
-dependencies = ["test-rust", "test-lit"]
+dependencies = ["test-rust", "test-lit", "sweep-flow"]
 
 [tasks.test]
 category = "Test"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -291,7 +291,7 @@ description = "Garbage-collect the target directory: mark the live units by repl
 command = "python3"
 args = [
     "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools/sweep-target.py",
-    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target",
+    "${CARGO_TARGET_DIR}",
     "${@}",
 ]
 
@@ -301,7 +301,7 @@ description = "Garbage-collect the target directory with no age guards: keep onl
 command = "python3"
 args = [
     "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools/sweep-target.py",
-    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target",
+    "${CARGO_TARGET_DIR}",
     "--age",
     "0",
     "--cache-age",
@@ -321,7 +321,7 @@ condition = { env_not_set = ["MIDEN_SKIP_SWEEP"] }
 command = "python3"
 args = [
     "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools/sweep-target.py",
-    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target",
+    "${CARGO_TARGET_DIR}",
 ]
 
 [tasks.update]
@@ -634,7 +634,7 @@ script = ['''
 #!/usr/bin/env bash
 set -euo pipefail
 WORKSPACE="${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}"
-OUT="${WORKSPACE}/target/fuzza-coverage"
+OUT="${CARGO_TARGET_DIR}/fuzza-coverage"
 mkdir -p "${OUT}"
 
 cargo llvm-cov clean --workspace
@@ -672,7 +672,7 @@ script = ['''
 #!/usr/bin/env bash
 set -euo pipefail
 WORKSPACE="${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}"
-OUT="${WORKSPACE}/target/fuzza-coverage"
+OUT="${CARGO_TARGET_DIR}/fuzza-coverage"
 
 if [[ ! -f "${OUT}/report.json" ]]; then
     echo "no baseline report at ${OUT}/report.json — run \`cargo make fuzza-cov\` first" >&2
@@ -718,7 +718,7 @@ script = ['''
 set -euo pipefail
 WORKSPACE="${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}"
 cargo llvm-cov clean --workspace
-rm -rf "${WORKSPACE}/target/fuzza-coverage"
+rm -rf "${CARGO_TARGET_DIR}/fuzza-coverage"
 ''']
 
 [tasks.fuzza-probe]
@@ -731,7 +731,7 @@ WORKSPACE="${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}"
 FILTER="${1:?usage: cargo make fuzza-probe <test-filter> [emit-kinds, default hir]}"
 EMIT="${2:-hir}"
 CASE="${FILTER##*::}"
-OUT="${WORKSPACE}/target/fuzza-probe/${CASE}"
+OUT="${CARGO_TARGET_DIR}/fuzza-probe/${CASE}"
 # Fresh output dir per probe so stale dumps can't be mistaken for this run's.
 rm -rf "${OUT}"
 mkdir -p "${OUT}"
@@ -749,7 +749,7 @@ for k in "${KINDS[@]}"; do SPEC="${SPEC:+${SPEC},}${k}=${OUT}"; done
 # across probes. --include-ignored lets a case wired with a temporary
 # #[ignore] (the recommended probe setup) run without un-ignoring it.
 status=0
-MIDENC_EMIT="${SPEC}" CARGO_TARGET_DIR="${WORKSPACE}/target" \
+MIDENC_EMIT="${SPEC}" \
     cargo test --package midenc-integration-tests "${FILTER}" -- \
     --include-ignored --test-threads=1 --nocapture || status=$?
 

--- a/midenc-compile/src/pipeline/frontends/rust.rs
+++ b/midenc-compile/src/pipeline/frontends/rust.rs
@@ -862,6 +862,14 @@ fn build_cargo_args(manifest_path: &Path, options: &Options) -> Vec<String> {
         ("profile.release.lto", "true"),
         ("profile.release.codegen-units", "1"),
         ("profile.release.panic", "\"abort\""),
+        // The guest Wasm needs DWARF (`debug = true` above) so the compiler can turn it
+        // into Miden debug information — but the host-side units of this nested build
+        // (build scripts, proc macros, and their whole native Miden dependency cone) do
+        // not. Without this override they inherit the profile's full debug information,
+        // which was measured at ~94% of a 310 MB proc-macro artifact, repeated in every
+        // build directory a test suite uses.
+        ("profile.dev.build-override.debug", "false"),
+        ("profile.release.build-override.debug", "false"),
     ];
 
     for (key, value) in cfg_pairs {
@@ -2216,6 +2224,14 @@ pub(crate) mod manifest {
             ("profile.release.lto", "true"),
             ("profile.release.codegen-units", "1"),
             ("profile.release.panic", "\"abort\""),
+            // The guest Wasm needs DWARF (`debug = true` above) so the compiler can turn
+            // it into Miden debug information — but the host-side units of this nested
+            // build (build scripts, proc macros, and their whole native Miden dependency
+            // cone) do not. When a profile sets `debug` explicitly, the host units
+            // inherit it, which was measured at ~94% of a 310 MB proc-macro artifact,
+            // repeated in every build directory a test suite uses.
+            ("profile.dev.build-override.debug", "false"),
+            ("profile.release.build-override.debug", "false"),
         ];
 
         for (key, value) in cfg_pairs {

--- a/midenc-session/build.rs
+++ b/midenc-session/build.rs
@@ -3,8 +3,11 @@ use std::{env, str};
 fn main() {
     println!("cargo::rerun-if-env-changed=MIDENC_BUILD_VERSION");
     println!("cargo::rerun-if-env-changed=MIDENC_BUILD_REV");
-    println!("cargo::rerun-if-env-changed=CARGO_PKG_VERSION");
-    println!("cargo::rerun-if-env-changed=PROFILE");
+    // Do not declare `rerun-if-env-changed` for Cargo-controlled variables such as
+    // `CARGO_PKG_VERSION` or `PROFILE`. Cargo compares them against its own ambient
+    // environment, where they are normally unset — but a test or a build script that
+    // spawns `cargo` against this target directory has them set, which flips the stored
+    // value and forces a full rebuild of every dependent crate on each alternation.
 
     if let Some(sha) = git_describe() {
         println!("cargo::rustc-env=MIDENC_BUILD_REV={sha}");

--- a/sdk/alloc/build.rs
+++ b/sdk/alloc/build.rs
@@ -29,7 +29,10 @@ fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    println!("cargo:rerun-if-env-changed=TARGET");
+    // Do not declare `rerun-if-env-changed=TARGET`: Cargo controls that variable, and it
+    // is unset in Cargo's own environment but set inside build-script environments, so
+    // the declaration makes the fingerprint flip between the two. Cargo already runs
+    // this script once for each target platform.
     println!("cargo:rerun-if-env-changed=RUSTUP_TOOLCHAIN");
     println!("cargo:rerun-if-env-changed=RUSTFLAGS");
     println!("cargo:rerun-if-changed={}", manifest_dir.join("stubs/heap_base.rs").display());

--- a/sdk/base-sys/build.rs
+++ b/sdk/base-sys/build.rs
@@ -32,7 +32,10 @@ fn main() {
         return;
     }
 
-    println!("cargo:rerun-if-env-changed=TARGET");
+    // Do not declare `rerun-if-env-changed=TARGET`: Cargo controls that variable, and it
+    // is unset in Cargo's own environment but set inside build-script environments, so
+    // the declaration makes the fingerprint flip between the two. Cargo already runs
+    // this script once for each target platform.
     println!("cargo:rerun-if-env-changed=RUSTUP_TOOLCHAIN");
     println!("cargo:rerun-if-env-changed=RUSTFLAGS");
 

--- a/sdk/stdlib-sys/build.rs
+++ b/sdk/stdlib-sys/build.rs
@@ -38,7 +38,10 @@ fn main() {
         return;
     }
 
-    println!("cargo:rerun-if-env-changed=TARGET");
+    // Do not declare `rerun-if-env-changed=TARGET`: Cargo controls that variable, and it
+    // is unset in Cargo's own environment but set inside build-script environments, so
+    // the declaration makes the fingerprint flip between the two. Cargo already runs
+    // this script once for each target platform.
     println!("cargo:rerun-if-env-changed=RUSTUP_TOOLCHAIN");
     println!("cargo:rerun-if-env-changed=RUSTFLAGS");
 

--- a/tests/fixtures/components/assert-debug-test/src/lib.rs
+++ b/tests/fixtures/components/assert-debug-test/src/lib.rs
@@ -24,5 +24,7 @@ fn my_alloc_error(_info: core::alloc::Layout) -> ! {
 #[no_mangle]
 pub fn entrypoint(x: u32) -> u32 {
     assert!(x > 100);
-    x
+    let mut cargo_dwarf_local = x;
+    core::hint::black_box(&mut cargo_dwarf_local);
+    cargo_dwarf_local
 }

--- a/tests/integration/src/end_to_end/debuginfo/source_locations.rs
+++ b/tests/integration/src/end_to_end/debuginfo/source_locations.rs
@@ -15,7 +15,12 @@ fn rust_assert_macro_source_location_with_debug_executor() {
     let mut test = CompilerTest::rust_source_cargo_miden(
         "../fixtures/components/assert-debug-test",
         config,
-        ["--entrypoint".to_string(), "assert_debug_test::entrypoint".to_string()],
+        [
+            "--entrypoint".to_string(),
+            "assert_debug_test::entrypoint".to_string(),
+            "--debug".to_string(),
+            "full".to_string(),
+        ],
     );
 
     let package = test.compile_package();
@@ -28,6 +33,17 @@ fn rust_assert_macro_source_location_with_debug_executor() {
             .iter()
             .find(|msg| debug_info[msg.message].contains("entered unreachable code"))
             .is_some()
+    );
+
+    // Unlike the Wasm parameter `x`, this source local can only come from the
+    // DWARF emitted by the fixture's Cargo release profile. Finding it in the
+    // package proves that a Cargo-produced variable decorator survived Wasm
+    // translation and Miden Assembly serialization.
+    assert!(
+        debug_info.nodes().iter().flat_map(|node| node.debug_vars.iter()).any(|var| {
+            debug_info[var.name_idx].as_ref() == "cargo_dwarf_local" && var.arg_idx.is_none()
+        }),
+        "Cargo DWARF local should survive as a Miden Assembly debug-variable decorator"
     );
 
     // First, test that the function works when assertion passes (x > 100)

--- a/tests/integration/src/sdk/build_script.rs
+++ b/tests/integration/src/sdk/build_script.rs
@@ -172,12 +172,19 @@ fn main() {
 }
 
 /// Runs a plain (non-midenc) `cargo check` of `consumer`, the way an IDE does.
+///
+/// The check must not inherit the suite's shared build cache
+/// (`CARGO_BUILD_BUILD_DIR`): an IDE has no such variable, these tests assert
+/// on the persisted build-script output below the project's own `target/`, and
+/// concurrent tests reuse the fixture package names, so a shared cache would
+/// let one test observe another's generations.
 fn plain_cargo_check(consumer: &Path) -> Output {
     Command::new("cargo")
         .arg("check")
         .env("CARGO_MIDEN", cargo_miden_binary())
         .env_remove("MIDENC_PACKAGE_CACHE")
         .env_remove("CARGO_TARGET_DIR")
+        .env_remove("CARGO_BUILD_BUILD_DIR")
         .env_remove("RUSTFLAGS")
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .current_dir(consumer)
@@ -193,6 +200,7 @@ fn counted_plain_cargo_check(consumer: &Path, counter: &Path) -> Output {
         .env("MIDENC_TEST_CARGO_MIDEN_COUNT", counter)
         .env_remove("MIDENC_PACKAGE_CACHE")
         .env_remove("CARGO_TARGET_DIR")
+        .env_remove("CARGO_BUILD_BUILD_DIR")
         .env_remove("RUSTFLAGS")
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .current_dir(consumer)
@@ -664,6 +672,7 @@ path = "src/lib.rs"
         .env("CARGO_MIDEN", project.root().join("definitely-missing-cargo-miden"))
         .env_remove("MIDENC_PACKAGE_CACHE")
         .env_remove("CARGO_TARGET_DIR")
+        .env_remove("CARGO_BUILD_BUILD_DIR")
         .current_dir(project.root())
         .output()
         .expect("failed to spawn cargo check");

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -173,6 +173,13 @@ resolver = "3"
 opt-level = "z"
 panic = "abort"
 debug = false
+
+# The plain-Cargo checks in these tests build the project natively, where full
+# DWARF for the proc macros and build scripts of the Miden dependency cone
+# costs gigabytes. A `cargo miden build` is not affected: its `--config
+# profile.dev.debug=true` overrides this value for the guest Wasm.
+[profile.dev]
+debug = "line-tables-only"
 "#;
     let basic_wallet_cargo = format!(
         r#"

--- a/tests/support/src/cargo_proj/mod.rs
+++ b/tests/support/src/cargo_proj/mod.rs
@@ -584,6 +584,25 @@ pub fn shared_build_dir() -> PathBuf {
     test_target_dir().join("miden_test_shared")
 }
 
+/// The one Cargo *build* directory (`CARGO_BUILD_BUILD_DIR`) every nested build shares —
+/// including the builds that must keep separate target directories.
+///
+/// Cargo splits build output in two: hash-keyed intermediate artifacts go to the build
+/// directory, while the final artifacts a consumer reads (the `.wasm`, the uplifted
+/// binaries) go to the target directory, keyed by package name alone. The name-keyed
+/// final artifacts are the only reason this suite keeps some target directories apart
+/// (identically named generated packages would overwrite each other); the hash-keyed
+/// intermediates never collide. Sharing one build directory therefore deduplicates the
+/// heavy dependency cones — measured at 6.7 GB of byte-identical files across the
+/// separate directories — without giving up the per-purpose target directories.
+///
+/// The same convention (`target/miden_build_cache`) is used by the test entry points
+/// outside this crate that manage their own target directories (`tests/templates`,
+/// the sdk component and consumer tests).
+pub fn shared_build_cache_dir() -> PathBuf {
+    test_target_dir().join("miden_build_cache")
+}
+
 /// Point this process's nested `cargo` invocations at [`shared_build_dir`].
 ///
 /// The environment is the only means we have to reache them: the nested `cargo` is spawned by the
@@ -610,6 +629,14 @@ pub fn use_shared_build_dir() {
             panic!("failed to create the shared build directory {}: {e}", dir.display())
         });
         unsafe { std::env::set_var("CARGO_TARGET_DIR", &dir) };
+        // Route the hash-keyed intermediates of every nested build this process spawns —
+        // including the spawns that override or drop `CARGO_TARGET_DIR` — into the one
+        // shared build cache ([`shared_build_cache_dir`]).
+        let cache = shared_build_cache_dir();
+        std::fs::create_dir_all(&cache).unwrap_or_else(|e| {
+            panic!("failed to create the shared build cache {}: {e}", cache.display())
+        });
+        unsafe { std::env::set_var("CARGO_BUILD_BUILD_DIR", &cache) };
     });
 }
 

--- a/tests/templates/src/lib.rs
+++ b/tests/templates/src/lib.rs
@@ -70,28 +70,51 @@ fn current_dir_lock() -> CurrentDirGuard {
 ///
 /// It must not simply inherit the ambient `CARGO_TARGET_DIR` either, since
 /// `cargo make` points that at the workspace's own target directory.
-struct TargetDirGuard(Option<String>);
+///
+/// Only the name-keyed *final* artifacts need this separation. The hash-keyed
+/// intermediates — the whole dependency cone, identical across every template —
+/// go to the one shared build cache (`CARGO_BUILD_BUILD_DIR`), following the
+/// `target/miden_build_cache` convention that `tests/support` establishes.
+struct TargetDirGuard {
+    target_dir: Option<String>,
+    build_dir: Option<String>,
+}
 
 impl TargetDirGuard {
     fn for_template(template: &str) -> Self {
-        let previous = env::var("CARGO_TARGET_DIR").ok();
+        let previous_target = env::var("CARGO_TARGET_DIR").ok();
+        let previous_build = env::var("CARGO_BUILD_BUILD_DIR").ok();
         let dir = workspace_root()
             .join("target/miden_test_template_projects")
             .join(template.replace('-', "_"));
         fs::create_dir_all(&dir).expect("create the template build directory");
+        let cache = workspace_root().join("target/miden_build_cache");
+        fs::create_dir_all(&cache).expect("create the shared build cache");
         // Safety: `set_var` is unsafe because of threads elsewhere in the
         // process; under nextest each test is its own process, and this is set
         // once before any subprocess is spawned.
-        unsafe { env::set_var("CARGO_TARGET_DIR", &dir) };
-        Self(previous)
+        unsafe {
+            env::set_var("CARGO_TARGET_DIR", &dir);
+            env::set_var("CARGO_BUILD_BUILD_DIR", &cache);
+        }
+        Self {
+            target_dir: previous_target,
+            build_dir: previous_build,
+        }
     }
 }
 
 impl Drop for TargetDirGuard {
     fn drop(&mut self) {
-        match self.0.take() {
-            Some(previous) => unsafe { env::set_var("CARGO_TARGET_DIR", previous) },
-            None => unsafe { env::remove_var("CARGO_TARGET_DIR") },
+        unsafe {
+            match self.target_dir.take() {
+                Some(previous) => env::set_var("CARGO_TARGET_DIR", previous),
+                None => env::remove_var("CARGO_TARGET_DIR"),
+            }
+            match self.build_dir.take() {
+                Some(previous) => env::set_var("CARGO_BUILD_BUILD_DIR", previous),
+                None => env::remove_var("CARGO_BUILD_BUILD_DIR"),
+            }
         }
     }
 }

--- a/tools/sweep-target.py
+++ b/tools/sweep-target.py
@@ -71,12 +71,219 @@ def unit_hash(name):
     return match.group(1) if match else None
 
 
+class UnresolvedExecutableError(Exception):
+    """Raised when a Cargo executable cannot be mapped to its hashed cache unit."""
+
+
+def unhashed_artifact_name(name):
+    """Remove Cargo's unit hash from an artifact file name."""
+    stem, separator, suffix = name.partition(".")
+    match = HASH_RE.search(stem)
+    if not match:
+        return name
+    name = stem[:match.start()]
+    return f"{name}{separator}{suffix}" if separator else name
+
+
+def cargo_path_components(path, target_dir=None, build_dir=None):
+    """Return path components below Cargo's target or build directory."""
+    if target_dir is None or build_dir is None:
+        return tuple(path.split(os.sep))
+
+    absolute = os.path.abspath(path)
+    matching_roots = []
+    for root in {os.path.abspath(target_dir), os.path.abspath(build_dir)}:
+        try:
+            if os.path.commonpath((absolute, root)) == root:
+                matching_roots.append(root)
+        except ValueError:
+            continue
+    if not matching_roots:
+        return ()
+
+    # Prefer the most specific root when one is nested under the other.
+    root = max(matching_roots, key=len)
+    relative = os.path.relpath(absolute, root)
+    return tuple(relative.split(os.sep)) if relative != os.curdir else ()
+
+
+def artifact_hashes(path, target_dir=None, build_dir=None):
+    """Return unit hashes encoded in a Cargo artifact path.
+
+    Normal artifacts carry the hash in their basename. Build-script artifacts
+    instead use a hashless basename below `build/<crate>-<hash>`. Restricting
+    the search to those Cargo-owned positions avoids mistaking a workspace or
+    target-directory component for a live unit hash.
+    """
+    components = cargo_path_components(path, target_dir, build_dir)
+    if not components:
+        return set()
+
+    found = set()
+    marked = unit_hash(components[-1])
+    if marked:
+        found.add(marked)
+    for index, component in enumerate(components[:-1]):
+        if component == "build":
+            marked = unit_hash(components[index + 1])
+            if marked:
+                found.add(marked)
+    return found
+
+
+def files_equal(first, second):
+    """Return whether two regular files are byte-identical."""
+    if os.path.samefile(first, second):
+        return True
+    if os.path.getsize(first) != os.path.getsize(second):
+        return False
+    with open(first, "rb") as lhs, open(second, "rb") as rhs:
+        while True:
+            lhs_chunk = lhs.read(1024 * 1024)
+            rhs_chunk = rhs.read(1024 * 1024)
+            if lhs_chunk != rhs_chunk:
+                return False
+            if not lhs_chunk:
+                return True
+
+
+def uplifted_executable_hashes(message, target_dir, build_dir):
+    """Resolve an uplifted executable to its byte-identical hashed cache unit.
+
+    Cargo's JSON messages name ordinary binaries only by their final, unhashed
+    path (for example, `target/debug/midenc`). The build cache keeps the same
+    executable as `target/debug/deps/midenc-<hash>`. Compare the uplifted file
+    with same-named cache candidates so the live unit hash is not swept.
+
+    Multiple byte-identical candidates are all live for sweep purposes. That
+    deliberately favors retaining a duplicate over guessing which one Cargo
+    uplifted and deleting a live unit.
+    """
+    executable = message["executable"]
+    target = message.get("target", {})
+    crate_name = target.get("name")
+    if not crate_name:
+        raise UnresolvedExecutableError(
+            f"Cargo did not report a target name for uplifted executable: {executable}"
+        )
+
+    # Cargo normalizes hyphens in package target names to underscores in the
+    # rustc crate name used for cached artifacts. The uplifted executable keeps
+    # the original target name (for example, `cargo-miden` versus
+    # `deps/cargo_miden-<hash>`).
+    executable_suffix = os.path.splitext(executable)[1]
+    cached_name = f"{crate_name.replace('-', '_')}{executable_suffix}"
+
+    profile_dir = os.path.dirname(os.path.abspath(executable))
+    cache_subdir = "deps"
+    if "example" in target.get("kind", []):
+        cache_subdir = "examples"
+        if os.path.basename(profile_dir) == "examples":
+            profile_dir = os.path.dirname(profile_dir)
+    try:
+        relative_profile = os.path.relpath(profile_dir, os.path.abspath(target_dir))
+    except ValueError as err:
+        raise UnresolvedExecutableError(
+            f"uplifted executable is outside Cargo's target directory: {executable}"
+        ) from err
+    if relative_profile == os.pardir or relative_profile.startswith(os.pardir + os.sep):
+        raise UnresolvedExecutableError(
+            f"uplifted executable is outside Cargo's target directory: {executable}"
+        )
+    cache_dir = os.path.join(os.path.abspath(build_dir), relative_profile, cache_subdir)
+    try:
+        candidates = os.scandir(cache_dir)
+    except OSError as err:
+        raise UnresolvedExecutableError(
+            f"cannot inspect cache for uplifted executable {executable}: {err}"
+        ) from err
+
+    resolved = set()
+    try:
+        with candidates:
+            for entry in candidates:
+                marked = unit_hash(entry.name)
+                if marked is None or unhashed_artifact_name(entry.name) != cached_name:
+                    continue
+                try:
+                    matches = entry.is_file(follow_symlinks=False) and files_equal(
+                        executable, entry.path
+                    )
+                except OSError as err:
+                    raise UnresolvedExecutableError(
+                        f"cannot compare uplifted executable {executable} with {entry.path}: {err}"
+                    ) from err
+                if matches:
+                    resolved.add(marked)
+    except OSError as err:
+        raise UnresolvedExecutableError(
+            f"cannot inspect cache for uplifted executable {executable}: {err}"
+        ) from err
+
+    if not resolved:
+        raise UnresolvedExecutableError(
+            f"cannot resolve uplifted executable to a hashed cache unit: {executable}"
+        )
+    return resolved
+
+
+def live_hashes_from_message(message, target_dir=None, build_dir=None):
+    """Return every live unit hash represented by one Cargo JSON message."""
+    live = set()
+    paths = list(message.get("filenames", []))
+    if message.get("out_dir"):
+        paths.append(message["out_dir"])
+    for path in paths:
+        live.update(artifact_hashes(path, target_dir, build_dir))
+
+    executable = message.get("executable")
+    executable_hashes = (
+        artifact_hashes(executable, target_dir, build_dir) if executable else set()
+    )
+    live.update(executable_hashes)
+    if executable and not executable_hashes:
+        if target_dir is None or build_dir is None:
+            raise UnresolvedExecutableError(
+                "Cargo target and build directories are required to resolve "
+                f"uplifted executable: {executable}"
+            )
+        live.update(uplifted_executable_hashes(message, target_dir, build_dir))
+    return live
+
+
+def cargo_output_directories(workspace_root):
+    """Return Cargo's final-artifact and cache roots for the workspace."""
+    result = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version=1"],
+        cwd=workspace_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        metadata = json.loads(result.stdout)
+        target_dir = metadata["target_directory"]
+        # `build_directory` was added after `target_directory`. On older Cargo
+        # versions they are necessarily the same directory.
+        build_dir = metadata.get("build_directory", target_dir)
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+    return target_dir, build_dir
+
+
 def mark_live_units(workspace_root):
     """Replay the workspace invocations and collect the live unit hashes.
 
     Returns the set of hashes, or None when an invocation fails — the caller
     must not sweep with an incomplete live set.
     """
+    output_dirs = cargo_output_directories(workspace_root)
+    if output_dirs is None:
+        print("mark failed, not sweeping: cargo metadata failed", file=sys.stderr)
+        return None
+    target_dir, build_dir = output_dirs
+
     live = set()
     for invocation in MARK_INVOCATIONS:
         result = subprocess.run(
@@ -93,18 +300,15 @@ def mark_live_units(workspace_root):
                 message = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            # Harvest the hash from every path component: a library carries it
-            # in the file name, but a build-script executable is reported as a
-            # hashless `.../build/<crate>-<hash>/build-script-build`, and a
-            # build-script run only as its `.../build/<crate>-<hash>/out`.
-            paths = list(message.get("filenames", []))
-            if message.get("out_dir"):
-                paths.append(message["out_dir"])
-            for path in paths:
-                for component in path.split(os.sep):
-                    marked = unit_hash(component)
-                    if marked:
-                        live.add(marked)
+            # Harvest hashes from every path component: libraries carry one in
+            # the file name, while build scripts carry one in a parent directory.
+            # Ordinary binaries require resolving their unhashed uplifted copy
+            # back to the hashed cache artifact.
+            try:
+                live.update(live_hashes_from_message(message, target_dir, build_dir))
+            except UnresolvedExecutableError as err:
+                print(f"mark failed, not sweeping: {err}", file=sys.stderr)
+                return None
     return live
 
 

--- a/tools/sweep-target.py
+++ b/tools/sweep-target.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Garbage-collect Cargo target directories with a mark-and-sweep pass.
+
+Cargo keys intermediate artifacts by a metadata hash and never deletes them:
+when an edit to the dependency graph gives a unit a new hash, the old
+artifacts stay on disk forever. No local record separates a dead unit from a
+live one — Cargo refreshes its `invoked.timestamp` bookkeeping only when it
+compiles a unit, and grouping units by their fingerprint configuration cannot
+work either, because one crate legitimately keeps several live variants whose
+fingerprints are identical (each top-level invocation unifies transitive
+features differently).
+
+The one reliable source for the live set is Cargo itself: with
+`--message-format=json` it emits an artifact message for every unit of an
+invocation, including the fresh ones. This tool therefore:
+
+1. MARKS: replays the workspace's build and test invocations in JSON mode and
+   collects every artifact hash they report. On a warm tree — right after a
+   test run — this compiles nothing and takes seconds.
+2. PROTECTS, with one of two age guards per profile directory:
+   - A directory that holds marked units belongs to the replayed graphs, so
+     an unmarked unit there is almost always dead; it survives only `--age`
+     days (default 1 — with agent-driven editing the dead units can double a
+     target directory in a single day). The exceptions this guard covers are
+     the checker layers of IDEs and clippy, which Cargo rebuilds cheaply
+     when one is swept.
+   - A directory with no marked units (the nested caches only test runs
+     populate, the release profile) cannot be told apart from garbage at
+     all, and its live units cannot refresh their timestamps without a
+     recompile. A short age would force a full rebuild of such a cache per
+     window, so these keep `--cache-age` days (default 14).
+3. SWEEPS: deletes the `deps/`, `build/`, and `.fingerprint/` entries of
+   every unit that is neither marked nor protected. Incremental caches and
+   uplifted final artifacts are never touched.
+
+A profile directory whose Cargo lock is held by a running build is skipped.
+
+Usage: sweep-target.py [--dry-run] [--age DAYS] [--cache-age DAYS] ROOT [ROOT...]
+"""
+
+import fcntl
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+# The workspace invocations whose unit graphs define the live set of the
+# workspace's own profile directories. These are the graphs `cargo make`
+# builds and tests with; each runs with `--message-format=json` appended.
+MARK_INVOCATIONS = (
+    ["cargo", "build", "-p", "midenc"],
+    ["cargo", "build", "-p", "cargo-miden"],
+    ["cargo", "build", "-p", "midenc-hir-opt"],
+    ["cargo", "build", "-p", "miden-objtool"],
+    ["cargo", "test", "--no-run", "--workspace"],
+)
+
+# Subdirectories of a profile directory that hold build output. The scan must
+# not descend into them when it looks for more profile directories.
+OUTPUT_DIRS = (".fingerprint", "deps", "build", "incremental", "examples", "tmp")
+
+HASH_RE = re.compile(r"-([0-9a-f]{16,20})$")
+
+
+def unit_hash(name):
+    """Return the metadata hash carried by an artifact or directory name."""
+    match = HASH_RE.search(name.split(".", 1)[0])
+    return match.group(1) if match else None
+
+
+def mark_live_units(workspace_root):
+    """Replay the workspace invocations and collect the live unit hashes.
+
+    Returns the set of hashes, or None when an invocation fails — the caller
+    must not sweep with an incomplete live set.
+    """
+    live = set()
+    for invocation in MARK_INVOCATIONS:
+        result = subprocess.run(
+            invocation + ["--message-format=json"],
+            cwd=workspace_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            print(f"mark failed, not sweeping: {' '.join(invocation)}", file=sys.stderr)
+            return None
+        for line in result.stdout.splitlines():
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Harvest the hash from every path component: a library carries it
+            # in the file name, but a build-script executable is reported as a
+            # hashless `.../build/<crate>-<hash>/build-script-build`, and a
+            # build-script run only as its `.../build/<crate>-<hash>/out`.
+            paths = list(message.get("filenames", []))
+            if message.get("out_dir"):
+                paths.append(message["out_dir"])
+            for path in paths:
+                for component in path.split(os.sep):
+                    marked = unit_hash(component)
+                    if marked:
+                        live.add(marked)
+    return live
+
+
+def profile_dirs(root):
+    """Yield every directory under `root` that holds a `.fingerprint` table."""
+    for dirpath, dirnames, _ in os.walk(root):
+        if ".fingerprint" in dirnames:
+            yield dirpath
+        dirnames[:] = [d for d in dirnames if d not in OUTPUT_DIRS]
+
+
+def try_lock(profile_dir):
+    """Take the profile directory's Cargo lock without blocking.
+
+    Returns the open file object that holds the lock, or None when a running
+    build holds it. The caller must keep the object alive while it deletes.
+    """
+    for name in (".cargo-lock", ".cargo-build-lock"):
+        path = os.path.join(profile_dir, name)
+        if os.path.exists(path):
+            handle = open(path)
+            try:
+                fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                handle.close()
+                return None
+            return handle
+    return open(os.devnull)
+
+
+def tree_size(path):
+    """Return the total apparent size of `path` in bytes."""
+    if not os.path.isdir(path):
+        return os.lstat(path).st_size
+    total = 0
+    for dirpath, _, filenames in os.walk(path):
+        for name in filenames:
+            try:
+                total += os.lstat(os.path.join(dirpath, name)).st_size
+            except OSError:
+                pass
+    return total
+
+
+def remove(path, dry_run):
+    """Delete `path` and return the bytes it held."""
+    size = tree_size(path)
+    if not dry_run:
+        if os.path.isdir(path):
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            os.unlink(path)
+    return size
+
+
+def dead_units(profile_dir, root, live, marked_cutoff, cache_cutoff):
+    """Return (dead hash set, cutoff) for one profile directory.
+
+    The directory's tier decides which age applies. The marked tier — the
+    short `marked_cutoff` — requires both signals: the profile directory
+    sits directly under the swept root (the workspace's own profile
+    directories, the only ones whose graphs the marks replay), and the
+    marks cover a meaningful share of its units. Everything nested (the
+    shared build cache, per-test target directories) is cache tier with
+    `cache_cutoff`: its live units are not enumerable, they cannot refresh
+    their timestamps without a recompile, and hash overlap with the
+    workspace graphs is common there (fixture builds share path
+    dependencies) without implying the marks cover the directory.
+    """
+    fingerprint_dir = os.path.join(profile_dir, ".fingerprint")
+    unmarked = []
+    marked_count = 0
+    total = 0
+    for unit in os.listdir(fingerprint_dir):
+        found = unit_hash(unit)
+        if not found:
+            continue
+        total += 1
+        if found in live:
+            marked_count += 1
+            continue
+        unit_dir = os.path.join(fingerprint_dir, unit)
+        newest = os.lstat(unit_dir).st_mtime
+        stamp = os.path.join(unit_dir, "invoked.timestamp")
+        if os.path.exists(stamp):
+            newest = max(newest, os.lstat(stamp).st_mtime)
+        unmarked.append((found, newest))
+    at_root = os.path.dirname(os.path.abspath(profile_dir)) == os.path.abspath(root)
+    covered = at_root and marked_count >= max(8, total // 20)
+    cutoff = marked_cutoff if covered else cache_cutoff
+    return {found for found, newest in unmarked if newest < cutoff}, cutoff
+
+
+def sweep_profile_dir(profile_dir, root, live, marked_cutoff, cache_cutoff, dry_run):
+    """Sweep one profile directory. Returns (bytes, unit count)."""
+    dead, cutoff = dead_units(profile_dir, root, live, marked_cutoff, cache_cutoff)
+    freed = 0
+    for subdir in ("deps", "build", ".fingerprint"):
+        path = os.path.join(profile_dir, subdir)
+        if not dead:
+            break
+        if not os.path.isdir(path):
+            continue
+        for name in os.listdir(path):
+            if unit_hash(name) in dead:
+                freed += remove(os.path.join(path, name), dry_run)
+    # Incremental caches are keyed separately from the unit hashes, so they are
+    # swept by age alone, with the same cutoff as the directory's tier: a cache
+    # nobody compiled with since the cutoff only saves time for a unit that is
+    # gone or dormant, and deleting one costs a single non-incremental rebuild.
+    incremental = os.path.join(profile_dir, "incremental")
+    count = len(dead)
+    if os.path.isdir(incremental):
+        for name in os.listdir(incremental):
+            path = os.path.join(incremental, name)
+            newest = 0
+            for dirpath, _, filenames in os.walk(path):
+                for filename in filenames:
+                    try:
+                        newest = max(newest, os.lstat(os.path.join(dirpath, filename)).st_mtime)
+                    except OSError:
+                        pass
+            if newest < cutoff:
+                freed += remove(path, dry_run)
+                count += 1
+    return freed, count
+
+
+def main():
+    args = sys.argv[1:]
+    dry_run = "--dry-run" in args
+    args = [a for a in args if a != "--dry-run"]
+
+    def take_days(flag, default):
+        if flag in args:
+            index = args.index(flag)
+            value = float(args[index + 1])
+            del args[index:index + 2]
+            return value
+        return default
+
+    age_days = take_days("--age", 1.0)
+    cache_age_days = take_days("--cache-age", 14.0)
+    if not args:
+        print(__doc__.strip().splitlines()[-1], file=sys.stderr)
+        return 2
+    roots = args
+    now = time.time()
+    marked_cutoff = now - age_days * 86400.0
+    cache_cutoff = now - cache_age_days * 86400.0
+    live = mark_live_units(os.path.dirname(os.path.abspath(roots[0])))
+    if live is None:
+        return 1
+    print(f"marked {len(live)} live units")
+    total = units = skipped = 0
+    for root in roots:
+        for profile_dir in profile_dirs(root):
+            lock = try_lock(profile_dir)
+            if lock is None:
+                print(f"skipped (build in progress): {profile_dir}")
+                skipped += 1
+                continue
+            with lock:
+                freed, count = sweep_profile_dir(
+                    profile_dir, root, live, marked_cutoff, cache_cutoff, dry_run)
+            if count:
+                print(f"{freed / 1e9:6.2f} GB  {count:4d} units  {profile_dir}")
+            total += freed
+            units += count
+    verb = "would free" if dry_run else "freed"
+    print(f"{verb} {total / 1e9:.2f} GB from {units} dead units"
+          + (f" ({skipped} directories skipped)" if skipped else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_sweep_target.py
+++ b/tools/test_sweep_target.py
@@ -1,0 +1,87 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("sweep-target.py")
+SPEC = importlib.util.spec_from_file_location("sweep_target", SCRIPT)
+sweep_target = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(sweep_target)
+
+
+class LiveExecutableMarkingTests(unittest.TestCase):
+    def test_hash_suffixed_root_still_marks_all_matching_cached_units(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target_dir = Path(temp) / "cargo-target-deadbeefdeadbeef"
+            build_dir = Path(temp) / "build"
+            profile = target_dir / "debug"
+            deps = build_dir / "debug" / "deps"
+            deps.mkdir(parents=True)
+            profile.mkdir(parents=True)
+
+            executable = profile / "demo-tool"
+            executable.write_bytes(b"live executable")
+            (deps / "demo_tool-1111111111111111").write_bytes(b"stale executable")
+            (deps / "demo_tool-2222222222222222").write_bytes(executable.read_bytes())
+            (deps / "demo_tool-3333333333333333").write_bytes(executable.read_bytes())
+
+            message = {
+                "reason": "compiler-artifact",
+                "filenames": [str(executable)],
+                "executable": str(executable),
+                "target": {"name": "demo-tool", "kind": ["bin"]},
+            }
+
+            self.assertEqual(
+                sweep_target.live_hashes_from_message(message, target_dir, build_dir),
+                {"2222222222222222", "3333333333333333"},
+            )
+
+    def test_build_script_hash_is_read_from_cache_ancestor(self):
+        message = {
+            "filenames": [
+                "target/debug/build/build-helper-4444444444444444/build-script-build"
+            ],
+            "executable": None,
+        }
+
+        self.assertEqual(
+            sweep_target.live_hashes_from_message(message),
+            {"4444444444444444"},
+        )
+
+    def test_unresolved_uplifted_executable_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target_dir = Path(temp) / "target"
+            build_dir = Path(temp) / "build"
+            profile = target_dir / "debug"
+            (build_dir / "debug" / "deps").mkdir(parents=True)
+            profile.mkdir(parents=True)
+            executable = profile / "midenc"
+            executable.write_bytes(b"live executable")
+
+            message = {
+                "reason": "compiler-artifact",
+                "filenames": [str(executable)],
+                "executable": str(executable),
+                "target": {"name": "midenc", "kind": ["bin"]},
+            }
+
+            with self.assertRaises(sweep_target.UnresolvedExecutableError):
+                sweep_target.live_hashes_from_message(message, target_dir, build_dir)
+
+    def test_hashed_executable_is_marked_directly(self):
+        message = json.loads(
+            '{"filenames":["target/debug/deps/tool-3333333333333333"],'
+            '"executable":"target/debug/deps/tool-3333333333333333"}'
+        )
+        self.assertEqual(
+            sweep_target.live_hashes_from_message(message),
+            {"3333333333333333"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One `cargo make test-all` wrote ~70 GB into `target/`, and normal development kept growing it well past that (183 GB observed) with no remedy short of `cargo clean`. Three independent causes, one commit each.

**Debug information was the multiplier.** About 91% of every statically linked test executable (~820 MB apiece, dozens of them) and ~94% of the host-side proc macros and build scripts compiled by nested `cargo miden build`s was DWARF that nothing ever reads. External dependencies now build with `line-tables-only` in dev — workspace crates keep full debug info — and the host side of nested guest builds drops debug info entirely, while the guest Wasm keeps its DWARF, which the compiler needs for Miden debug info. This commit also removes `rerun-if-env-changed` declarations on Cargo-controlled variables (`CARGO_PKG_VERSION`, `PROFILE`, `TARGET`): Cargo compares them against its own environment, where they are unset, but test-spawned Cargo processes have them set, so every run flip-flopped the stored value and rebuilt the whole compiler stack for nothing.

**Nested test builds duplicated whole dependency cones.** The suite keeps separate target directories only to stop identically named generated packages from overwriting each other's final artifacts — yet the hash-keyed intermediates, which are all the weight, never collide. All nested builds now share one build directory (`CARGO_BUILD_BUILD_DIR`) while keeping their per-purpose target directories: 6.7 GB of byte-identical duplication collapses, the per-purpose directories shrink from gigabytes to megabytes, and a nested build whose dependencies another test already compiled finishes in well under a second.

**Cargo never deletes superseded artifacts.** Every edit that touches the dependency graph orphans the previous unit hashes forever; nothing on disk distinguishes a dead unit from a live one, so age- or fingerprint-based sweeping deletes live units (measured: one such attempt caused 514 needless recompiles). `cargo make sweep` — run automatically at the end of `cargo make test-all`, and skippable via `MIDEN_SKIP_SWEEP` — garbage-collects with a mark-and-sweep instead: the live set comes from replaying the workspace build and test graphs with `--message-format=json`, the one reliable liveness source, with age guards protecting the units the marks cannot enumerate (IDE and clippy checker layers, the nested caches only test runs populate). Incremental caches are swept by the same age rules. For the one event the guards deliberately mishandle — switching branch bases, which orphans a whole build generation at once — `cargo make sweep-deep` drops the guards and keeps only what the marks prove live (measured: 55.8 GB reclaimed same-day after a rebase).

Net effect: a cold `test-all` writes about a third less, an unchanged rerun recompiles nothing and adds nothing, and superseded artifacts are collected right after the run that supersedes them instead of accumulating until the next manual `cargo clean`.
