### PR TITLE
ci(release): build the template bundle only when the candidate includes templates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
       contents: read
     outputs:
       subject: ${{ steps.subject.outputs.sha }}
+      templates: ${{ steps.intent.outputs.templates }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -88,10 +89,17 @@ jobs:
         run: release-tool lint
 
       - name: Generate the intent
+        id: intent
         run: |
           release-tool plan \
             --subject "${GITHUB_SHA}" --output "${RUNNER_TEMP}/intent.json"
           cat "${RUNNER_TEMP}/intent.json"
+          # The template bundle is an asset of the `templates` unit alone.
+          # Built for a candidate that omits the unit, it reaches `stage` as an
+          # asset routed nowhere, which is refused rather than dropped (R13).
+          # So the bundle steps run only when the intent stages `templates`.
+          templates=$(jq -r 'any(.stages[]; .unit == "templates")' "${RUNNER_TEMP}/intent.json")
+          echo "templates=${templates}" >> "${GITHUB_OUTPUT}"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -142,10 +150,14 @@ jobs:
             --cache-dir "${RUNNER_TEMP}/index-cache"
 
       - name: Build the template bundle
+        if: needs.plan.outputs.templates == 'true'
         run: |
           release-tool bundle \
             --output "${RUNNER_TEMP}/templates.tar.gz"
 
+      # The bundle is absent when the candidate omits `templates`. That is fine
+      # here: `if-no-files-found` fires only when no path matches at all, and
+      # `plan.json` always does.
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-plan
@@ -280,6 +292,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts
 
       - name: Collect the template bundle
+        if: needs.plan.outputs.templates == 'true'
         run: cp "${RUNNER_TEMP}/templates.tar.gz" "${RUNNER_TEMP}/artifacts/"
 
       # Uploads every asset and reads each one back, while the release is still

--- a/.release/release.toml
+++ b/.release/release.toml
@@ -11,3 +11,5 @@ units = ["compiler"]
 version = "0.10.1"
 tag = "v0.10.1"
 prerelease = false
+
+# comment to satisfy the requirement that the last commit should touch this file

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -273,7 +273,7 @@ Fully automated. Nothing to do but watch.
 | --- | --- |
 | `plan` | Validates the subject against `main`, lints the candidate, generates the intent. |
 | `verify` | Calls `release-verify.yml` at the full tier. |
-| `seal and stage` | Seals the intent into a plan; builds the template bundle. |
+| `seal and stage` | Seals the intent into a plan; builds the template bundle when the candidate includes `templates`. |
 | `build <binary> (<target>)` | A 3 × 2 matrix — `midenc`, `cargo-miden`, `miden-objtool` × Linux, macOS — building, smoke-testing, and archiving each executable. |
 | `attest artifacts` | Records build provenance for the six executables. |
 | `stage drafts` | Creates the draft releases, routes every artifact to a unit by its `assets` globs, uploads, and reads each one back. |
@@ -442,9 +442,10 @@ Follow Phase A and Phase B exactly as written in §4, let Phase C run, and at D1
 **do not approve**. That is the only difference from a production release. Clean
 up with [§8.1](#81-discarding-drafts).
 
-*Expect:* draft releases carrying the executables, the template bundle,
-`SHA256SUMS`, and the sealed plan; build attestations for the six executables;
-**no tags**, and **nothing on crates.io**.
+*Expect:* draft releases carrying the executables, the template bundle (when
+the candidate includes `templates`), `SHA256SUMS`, and the sealed plan; build
+attestations for the six executables; **no tags**, and **nothing on
+crates.io**.
 
 This is the only way to exercise the real GitHub path — draft creation, asset
 upload and readback, real runners, real artifacts. It still does not prove that


### PR DESCRIPTION
Close #1383

The release workflow built and staged templates.tar.gz unconditionally, but the bundle is an asset of the templates unit alone. The first compiler-only candidate (v0.10.1) failed in the stage-drafts job: release-tool stage refuses an asset routed to a unit the plan does not include rather than silently dropping it.

The plan job now derives a templates flag from the intent it generates, and the bundle build and collect steps run only when that flag is set. The bundle stays in the shared release-plan artifact, which tolerates its absence because the plan file always matches. The release-process document reflects the conditional bundle.

The comment appended to .release/release.toml carries no meaning; it exists so that this change is the last one on main to touch the declaration, which the plan job requires of the commit it releases.